### PR TITLE
Allow configurable prefixes for controller annotations

### DIFF
--- a/config/app.dist.php
+++ b/config/app.dist.php
@@ -1,6 +1,6 @@
 <?php
 return [
-	 // Copy the following over to your project one in /src/config/
+	 // Copy the following over to your project one in ROOT/config/
 	'IdeHelper' => [
 		// Controller prefixes to check for
 		'prefixes' => [

--- a/config/app.dist.php
+++ b/config/app.dist.php
@@ -1,0 +1,14 @@
+<?php
+return [
+	 // Copy the following over to your project one in /src/config/
+	'IdeHelper' => [
+		// Controller prefixes to check for
+		'prefixes' => [
+			'Admin',
+		],
+		// Template paths to skip
+		'skipTemplatePaths' => [
+			'/src/Template/Bake/',
+		]
+	],
+];

--- a/docs/README.md
+++ b/docs/README.md
@@ -331,3 +331,6 @@ class MyAnnotator extends AbstractAnnotator {
 }
 ```
 Then read a folder, iterate over it and invoke your annotator from the shell command with a specific path.
+
+## Configure options
+You have a full list of default and possible Configure options, please see the `app.dist.php` file in `/config/` directory.

--- a/docs/README.md
+++ b/docs/README.md
@@ -52,8 +52,8 @@ class ApplesController extends AppController {
 ```
 
 ### Custom Prefixes
-By default, the annotator supports the `Admin` prefix for your controllers (as subfolder).
-Using Configure key `'IdeHelper.prefixes'` you can configure the prefix whitelist and use your own array of prefixes.
+By default, the annotator supports any prefix for your controllers (as subfolder).
+Using Configure key `'IdeHelper.prefixes'` you can configure a prefix whitelist.
 
 ## Models
 This will ensure the annotations for tables and their entities:
@@ -333,4 +333,5 @@ class MyAnnotator extends AbstractAnnotator {
 Then read a folder, iterate over it and invoke your annotator from the shell command with a specific path.
 
 ## Configure options
-You have a full list of default and possible Configure options, please see the `app.dist.php` file in `/config/` directory.
+You have a full list of possible Configure options, please see the `app.dist.php` file in `/config/` directory.
+The content can be directly copy-pasted into your project config.

--- a/docs/README.md
+++ b/docs/README.md
@@ -53,7 +53,7 @@ class ApplesController extends AppController {
 
 ### Custom Prefixes
 By default, the annotator supports the `Admin` prefix for your controllers (as subfolder).
-Using Configure key `'IdeHelper.prefixes'` you can configure the prefix whitelist and use your own prefix array.
+Using Configure key `'IdeHelper.prefixes'` you can configure the prefix whitelist and use your own array of prefixes.
 
 ## Models
 This will ensure the annotations for tables and their entities:

--- a/docs/README.md
+++ b/docs/README.md
@@ -51,6 +51,10 @@ class ApplesController extends AppController {
 }
 ```
 
+### Custom Prefixes
+By default, the annotator supports the `Admin` prefix for your controllers (as subfolder).
+Using Configure key `'IdeHelper.prefixes'` you can configure the prefix whitelist and use your own prefix array.
+
 ## Models
 This will ensure the annotations for tables and their entities:
 

--- a/src/Shell/AnnotationsShell.php
+++ b/src/Shell/AnnotationsShell.php
@@ -157,8 +157,14 @@ class AnnotationsShell extends Shell {
 			$annotator->annotate($folder . $file);
 		}
 
-		if (!empty($folderContent[0]) && in_array('Admin', $folderContent[0])) {
-			$this->_controllers($folder . 'Admin' . DS);
+		foreach ($folderContent[0] as $subFolder) {
+			$prefixes = (array)Configure::read('IdeHelper.prefixes') ?: ['Admin'];
+
+			if (!in_array($subFolder, $prefixes, true)) {
+				continue;
+			}
+
+			$this->_controllers($folder . $subFolder . DS);
 			return;
 		}
 	}

--- a/src/Shell/AnnotationsShell.php
+++ b/src/Shell/AnnotationsShell.php
@@ -158,14 +158,13 @@ class AnnotationsShell extends Shell {
 		}
 
 		foreach ($folderContent[0] as $subFolder) {
-			$prefixes = (array)Configure::read('IdeHelper.prefixes') ?: ['Admin'];
+			$prefixes = (array)Configure::read('IdeHelper.prefixes') ?: ['Admin', 'FooBar'];
 
 			if (!in_array($subFolder, $prefixes, true)) {
 				continue;
 			}
 
 			$this->_controllers($folder . $subFolder . DS);
-			return;
 		}
 	}
 

--- a/src/Shell/AnnotationsShell.php
+++ b/src/Shell/AnnotationsShell.php
@@ -158,7 +158,7 @@ class AnnotationsShell extends Shell {
 		}
 
 		foreach ($folderContent[0] as $subFolder) {
-			$prefixes = (array)Configure::read('IdeHelper.prefixes') ?: ['Admin', 'FooBar'];
+			$prefixes = (array)Configure::read('IdeHelper.prefixes') ?: ['Admin'];
 
 			if (!in_array($subFolder, $prefixes, true)) {
 				continue;

--- a/src/Shell/AnnotationsShell.php
+++ b/src/Shell/AnnotationsShell.php
@@ -158,9 +158,9 @@ class AnnotationsShell extends Shell {
 		}
 
 		foreach ($folderContent[0] as $subFolder) {
-			$prefixes = (array)Configure::read('IdeHelper.prefixes') ?: ['Admin'];
+			$prefixes = (array)Configure::read('IdeHelper.prefixes') ?: null;
 
-			if (!in_array($subFolder, $prefixes, true)) {
+			if ($prefixes !== null && !in_array($subFolder, $prefixes, true)) {
 				continue;
 			}
 


### PR DESCRIPTION
Resolves https://github.com/dereuromark/cakephp-ide-helper/issues/27

@ADmad Do you think this suffices with some small docs update to communicate the Configure key?

I didnt want to blindly walk through all subfolders, as they can contain non Controller code classes as well.