### PR TITLE
Allow addBehavior() calls to be autocompleted.

### DIFF
--- a/docs/Generator.md
+++ b/docs/Generator.md
@@ -63,6 +63,7 @@ Using associative arrays you can even exchange any native task with your own imp
 ],
 ```
 The native class name is the key then, your replacement the value.
+Setting the value to `null` completely disables a native task.
 
 #### Example
 So let's imagine you have the following methods you want to annotate:

--- a/src/Generator/Task/BehaviorTask.php
+++ b/src/Generator/Task/BehaviorTask.php
@@ -1,0 +1,88 @@
+<?php
+namespace IdeHelper\Generator\Task;
+
+use Cake\Core\App;
+use Cake\Core\Plugin;
+use Cake\Filesystem\Folder;
+use Cake\ORM\Table;
+
+class BehaviorTask implements TaskInterface {
+
+	/**
+	 * @var array
+	 */
+	protected $aliases = [
+		'\Cake\ORM\Table::addBehavior(0)',
+	];
+
+	/**
+	 * @return array
+	 */
+	public function collect() {
+		$map = [];
+
+		$behaviors = $this->collectBehaviors();
+		foreach ($behaviors as $name => $className) {
+			$map[$name] = '\\' . $className . '::class';
+		}
+
+		$result = [];
+		foreach ($this->aliases as $alias) {
+			$result[$alias] = $map;
+		}
+
+		return $result;
+	}
+
+	/**
+	 * @return string[]
+	 */
+	protected function collectBehaviors() {
+		$components = [];
+
+		$folders = array_merge(App::core('ORM/Behavior'), App::path('Model/Behavior'));
+		foreach ($folders as $folder) {
+			$components = $this->addBehaviors($components, $folder);
+		}
+
+		$plugins = Plugin::loaded();
+		foreach ($plugins as $plugin) {
+			$folders = App::path('Model/Behavior', $plugin);
+			foreach ($folders as $folder) {
+				$components = $this->addBehaviors($components, $folder, $plugin);
+			}
+		}
+
+		return $components;
+	}
+
+	/**
+	 * @param array $components
+	 * @param string $folder
+	 * @param string|null $plugin
+	 *
+	 * @return string[]
+	 */
+	protected function addBehaviors(array $components, $folder, $plugin = null) {
+		$folderContent = (new Folder($folder))->read(Folder::SORT_NAME, true);
+
+		// This suffices as the return value is $this (calling Table class) anyway for chaining.
+		$className = Table::class;
+
+		foreach ($folderContent[1] as $file) {
+			preg_match('/^(.+)Behavior\.php$/', $file, $matches);
+			if (!$matches) {
+				continue;
+			}
+			$name = $matches[1];
+			if ($plugin) {
+				$name = $plugin . '.' . $name;
+			}
+
+			$components[$name] = $className;
+		}
+
+		return $components;
+	}
+
+}

--- a/src/Generator/TaskCollection.php
+++ b/src/Generator/TaskCollection.php
@@ -34,6 +34,10 @@ class TaskCollection {
 		$tasks += $defaultTasks;
 
 		foreach ($tasks as $task) {
+			if (!$task) {
+				continue;
+			}
+
 			$this->add($task);
 		}
 	}

--- a/src/Generator/TaskCollection.php
+++ b/src/Generator/TaskCollection.php
@@ -2,6 +2,7 @@
 namespace IdeHelper\Generator;
 
 use Cake\Core\Configure;
+use IdeHelper\Generator\Task\BehaviorTask;
 use IdeHelper\Generator\Task\ComponentTask;
 use IdeHelper\Generator\Task\HelperTask;
 use IdeHelper\Generator\Task\ModelTask;
@@ -15,6 +16,7 @@ class TaskCollection {
 	 */
 	protected $defaultTasks = [
 		ModelTask::class => ModelTask::class,
+		BehaviorTask::class => BehaviorTask::class,
 		ComponentTask::class => ComponentTask::class,
 		HelperTask::class => HelperTask::class,
 	];

--- a/tests/TestCase/Generator/Task/BehaviorTaskTest.php
+++ b/tests/TestCase/Generator/Task/BehaviorTaskTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace IdeHelper\Test\TestCase\Generator\Task;
+
+use IdeHelper\Generator\Task\BehaviorTask;
+use Tools\TestSuite\TestCase;
+
+class BehaviorTaskTest extends TestCase {
+
+	/**
+	 * @var \IdeHelper\Generator\Task\BehaviorTask
+	 */
+	protected $task;
+
+	/**
+	 * @return void
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->task = new BehaviorTask();
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testCollect() {
+		$result = $this->task->collect();
+
+		$this->assertCount(1, $result);
+
+		$expected = '\Cake\ORM\Table::class';
+		$this->assertSame($expected, $result['\Cake\ORM\Table::addBehavior(0)']['Timestamp']);
+
+		$expected = '\Cake\ORM\Table::class';
+		$this->assertSame($expected, $result['\Cake\ORM\Table::addBehavior(0)']['Shim.Nullable']);
+	}
+
+}

--- a/tests/test_files/meta/phpstorm/.meta.php
+++ b/tests/test_files/meta/phpstorm/.meta.php
@@ -59,6 +59,17 @@ namespace PHPSTORM_META {
 	);
 
 	override(
+		\Cake\ORM\Table::addBehavior(0),
+		map([
+			'CounterCache' => \Cake\ORM\Table::class,
+			'Timestamp' => \Cake\ORM\Table::class,
+			'Translate' => \Cake\ORM\Table::class,
+			'Tree' => \Cake\ORM\Table::class,
+			'Shim.Nullable' => \Cake\ORM\Table::class,
+		])
+	);
+
+	override(
 		\Cake\Controller\Controller::loadComponent(0),
 		map([
 			'Auth' => \Cake\Controller\Component\AuthComponent::class,


### PR DESCRIPTION
Besides loadHelper() and loadComponent() now also addBehavior('SomeTableName') is autocompleted and now just a semi-magic string :)

Please double check / confirm someone.

Resolves https://github.com/dereuromark/cakephp-ide-helper/issues/45

![behavior_typehinting](https://user-images.githubusercontent.com/39854/30692758-3f0dd0d8-9ecd-11e7-975e-b627ded50e12.png)
