### PR TITLE
Allow Type autocomplete.

### DIFF
--- a/docs/Generator.md
+++ b/docs/Generator.md
@@ -15,7 +15,9 @@ Make sure it is indexed (maybe a restart of PhpStorm could be required).
 Note: We are using a directory here to allow custom and manually created meta files along with this generated file.
 Any file inside this directory will be parsed and used. Prefixing with a `.` dot is recommended for PHPCS to skip this file automatically.
 
-### Models
+### Available tasks
+
+#### Models
 ```php
 /** @var \App\Model\Table\UsersTable $users */
 $users = TableRegistry::get('Users');
@@ -28,7 +30,7 @@ It will automatically detect this static factory call in the map and hint `$user
 
 This task also annotates the dynamic model factory calls (e.g. `$this->getTableLocator()->get('Users')`) or `loadModel()` usage.
 
-### TableAssociations
+#### TableAssociations
 The following is now auto-completed, for example:
 ```php
 $this->belongsTo('Authors');
@@ -37,7 +39,7 @@ $this->hasMany('Articles');
 $this->belongsToMany('Tags.Tags');
 ```
 
-### TableFinders
+#### TableFinders
 The `'threaded'` string is now auto-completed, for example:
 ```php
 $this->Posts->find('threaded')
@@ -46,23 +48,31 @@ $this->Posts->find('threaded')
 Note: Using Configure key `'IdeHelper.preemptive'` set to `true` you can be a bit more verbose and include all possible custom finders, including those from behaviors.
 
 
-### Behaviors
+#### Behaviors
 The following is now auto-completed, for example:
 ```php
 $this->addBehavior('Tools.Slugged')
 ```
 
-### Components
+#### Components
 The following is now auto-completed, for example:
 ```php
 $this->loadComponent('Security')
 ```
 
-### Helpers
+#### Helpers
 The following is now auto-completed, for example:
 ```php
 $this->loadHelper('Tools.Tree')
 ```
+
+#### Types
+In your bootstrap (app, or plugin), you might add additional database Type classes, or you reconfigure existing ones:
+```php
+Type::build('date')->useLocaleParser()->setLocaleFormat('d.m.Y');;
+Type::build('datetime')->useLocaleParser()->setLocaleFormat('d.m.Y H:i');
+```
+The IDE will now recognize the returned type of class and allow auto-complete here, too.
 
 ### Adding your own tasks
 Just create your own Task class:

--- a/src/Generator/Task/DatabaseTypeTask.php
+++ b/src/Generator/Task/DatabaseTypeTask.php
@@ -1,0 +1,47 @@
+<?php
+namespace IdeHelper\Generator\Task;
+
+use Cake\Database\Type;
+use Exception;
+
+class DatabaseTypeTask implements TaskInterface {
+
+	const CLASS_TYPE = Type::class;
+
+	/**
+	 * @return array
+	 */
+	public function collect() {
+		$result = [];
+
+		$types = $this->getTypes();
+		$map = [];
+		foreach ($types as $type => $className) {
+			$map[$type] = '\\' . $className . '::class';
+		}
+
+		$result['\\' . static::CLASS_TYPE . '::build(0)'] = $map;
+
+		return $result;
+	}
+
+	/**
+	 * @return array
+	 */
+	protected function getTypes() {
+		$types = [];
+
+		try {
+			$allTypes = Type::buildAll();
+		} catch (Exception $exception) {
+			return $types;
+		}
+
+		foreach ($allTypes as $key => $type) {
+			$types[$key] = get_class($type);
+		}
+
+		return $types;
+	}
+
+}

--- a/src/Generator/TaskCollection.php
+++ b/src/Generator/TaskCollection.php
@@ -4,6 +4,7 @@ namespace IdeHelper\Generator;
 use Cake\Core\Configure;
 use IdeHelper\Generator\Task\BehaviorTask;
 use IdeHelper\Generator\Task\ComponentTask;
+use IdeHelper\Generator\Task\DatabaseTypeTask;
 use IdeHelper\Generator\Task\HelperTask;
 use IdeHelper\Generator\Task\ModelTask;
 use IdeHelper\Generator\Task\TableAssociationTask;
@@ -23,6 +24,7 @@ class TaskCollection {
 		HelperTask::class => HelperTask::class,
 		TableAssociationTask::class => TableAssociationTask::class,
 		TableFinderTask::class => TableFinderTask::class,
+		DatabaseTypeTask::class => DatabaseTypeTask::class,
 	];
 
 	/**

--- a/tests/TestCase/Generator/Task/DatabaseTypeTaskTest.php
+++ b/tests/TestCase/Generator/Task/DatabaseTypeTaskTest.php
@@ -27,7 +27,7 @@ class DatabaseTypeTaskTest extends TestCase {
 	 * @return void
 	 */
 	public function testCollect() {
-		Type::map('uuid', UuidType::class);
+		Type::set('uuid', new UuidType());
 
 		$result = $this->task->collect();
 

--- a/tests/TestCase/Generator/Task/DatabaseTypeTaskTest.php
+++ b/tests/TestCase/Generator/Task/DatabaseTypeTaskTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace IdeHelper\Test\TestCase\Generator\Task;
+
+use App\Database\Type\UuidType;
+use Cake\Database\Type;
+use IdeHelper\Generator\Task\DatabaseTypeTask;
+use Tools\TestSuite\TestCase;
+
+class DatabaseTypeTaskTest extends TestCase {
+
+	/**
+	 * @var \IdeHelper\Generator\Task\DatabaseTypeTask
+	 */
+	protected $task;
+
+	/**
+	 * @return void
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->task = new DatabaseTypeTask();
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testCollect() {
+		Type::map('uuid', UuidType::class);
+
+		$result = $this->task->collect();
+
+		$this->assertCount(1, $result);
+
+		$expected = '\Cake\Database\Type\BinaryType::class';
+		$this->assertSame($expected, $result['\Cake\Database\Type::build(0)']['binary']);
+
+		$expected = '\App\Database\Type\UuidType::class';
+		$this->assertSame($expected, $result['\Cake\Database\Type::build(0)']['uuid']);
+	}
+
+}

--- a/tests/test_app/src/Database/Type/UuidType.php
+++ b/tests/test_app/src/Database/Type/UuidType.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         3.0.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace App\Database\Type;
+
+use Cake\Database\Type\UuidType as CoreUuidType;
+
+/**
+ * Provides behavior for the UUID type
+ */
+class UuidType extends CoreUuidType {
+}

--- a/tests/test_files/meta/phpstorm/.meta.php
+++ b/tests/test_files/meta/phpstorm/.meta.php
@@ -180,4 +180,26 @@ namespace PHPSTORM_META {
 		])
 	);
 
+	override(
+		\Cake\Database\Type::build(0),
+		map([
+			'tinyinteger' => \Cake\Database\Type\IntegerType::class,
+			'smallinteger' => \Cake\Database\Type\IntegerType::class,
+			'integer' => \Cake\Database\Type\IntegerType::class,
+			'biginteger' => \Cake\Database\Type\IntegerType::class,
+			'binary' => \Cake\Database\Type\BinaryType::class,
+			'boolean' => \Cake\Database\Type\BoolType::class,
+			'date' => \Cake\Database\Type\DateType::class,
+			'datetime' => \Cake\Database\Type\DateTimeType::class,
+			'decimal' => \Cake\Database\Type\DecimalType::class,
+			'float' => \Cake\Database\Type\FloatType::class,
+			'json' => \Cake\Database\Type\JsonType::class,
+			'string' => \Cake\Database\Type\StringType::class,
+			'text' => \Cake\Database\Type\StringType::class,
+			'time' => \Cake\Database\Type\TimeType::class,
+			'timestamp' => \Cake\Database\Type\DateTimeType::class,
+			'uuid' => \Cake\Database\Type\UuidType::class,
+		])
+	);
+
 }


### PR DESCRIPTION
For e.g.
```php
Type::build('time')->useLocaleParser()->setLocaleFormat('H:i');
Type::build('date')->useLocaleParser()->setLocaleFormat('d.m.Y');;
Type::build('datetime')->useLocaleParser()->setLocaleFormat('d.m.Y H:i');
```
before:
![before](https://user-images.githubusercontent.com/39854/33172779-c4c47bea-d051-11e7-83ac-5dca0a682f6c.png)
after:
![after](https://user-images.githubusercontent.com/39854/33172785-c69e062a-d051-11e7-9379-093a377aad8d.png)
