### PR TITLE
fix custom composer vendor-dir loading

### DIFF
--- a/src/Annotator/AbstractAnnotator.php
+++ b/src/Annotator/AbstractAnnotator.php
@@ -24,7 +24,8 @@ use SebastianBergmann\Diff\Differ;
 $composerVendorDir = getcwd() . DS . 'vendor';
 $codesnifferDir = 'squizlabs' . DS . 'php_codesniffer';
 if (!is_dir($composerVendorDir . $codesnifferDir)) {
-	$composerVendorDir = substr(__DIR__, 0, strpos(__DIR__, DS . 'cakephp-ide-helper'));
+	$ideHelperDir = substr(__DIR__, 0, strpos(__DIR__, DS . 'cakephp-ide-helper'));
+	$composerVendorDir = dirname($ideHelperDir);
 }
 $manualAutoload = $composerVendorDir . DS . $codesnifferDir . DS . 'autoload.php';
 if (!class_exists(Config::class) && file_exists($manualAutoload)) {

--- a/src/Annotator/AbstractAnnotator.php
+++ b/src/Annotator/AbstractAnnotator.php
@@ -21,10 +21,13 @@ use ReflectionClass;
 use RuntimeException;
 use SebastianBergmann\Diff\Differ;
 
-$currentDir = __DIR__;
-$vendorDir = substr($currentDir, 0, strpos($currentDir, DS . 'cakephp-ide-helper'));
-$composerVendorDir = dirname($vendorDir);
-$manualAutoload = $composerVendorDir . DS . 'squizlabs' . DS . 'php_codesniffer' . DS . 'autoload.php';
+
+$composerVendorDir = getcwd() . DS . 'vendor' . DS;
+if (!is_dir($composerVendorDir)) {
+	$vendorDir = substr(__DIR__, 0, strpos(__DIR__, DS . 'cakephp-ide-helper'));
+	$composerVendorDir = dirname($vendorDir) . DS;
+}
+$manualAutoload = $composerVendorDir . 'squizlabs' . DS . 'php_codesniffer' . DS . 'autoload.php';
 if (!class_exists(Config::class) && file_exists($manualAutoload)) {
 	require $manualAutoload;
 }

--- a/src/Annotator/AbstractAnnotator.php
+++ b/src/Annotator/AbstractAnnotator.php
@@ -22,9 +22,9 @@ use RuntimeException;
 use SebastianBergmann\Diff\Differ;
 
 $currentDir = __DIR__;
-$vendorDir = substr($currentDir, 0, strpos($currentDir, '/cakephp-ide-helper'));
+$vendorDir = substr($currentDir, 0, strpos($currentDir, DS . 'cakephp-ide-helper'));
 $composerVendorDir = dirname($vendorDir);
-$manualAutoload = $composerVendorDir . '/squizlabs/php_codesniffer/autoload.php';
+$manualAutoload = $composerVendorDir . DS . 'squizlabs' . DS . 'php_codesniffer' . DS . 'autoload.php';
 if (!class_exists(Config::class) && file_exists($manualAutoload)) {
 	require $manualAutoload;
 }

--- a/src/Annotator/AbstractAnnotator.php
+++ b/src/Annotator/AbstractAnnotator.php
@@ -21,7 +21,6 @@ use ReflectionClass;
 use RuntimeException;
 use SebastianBergmann\Diff\Differ;
 
-
 $composerVendorDir = getcwd() . DS . 'vendor' . DS;
 if (!is_dir($composerVendorDir)) {
 	$vendorDir = substr(__DIR__, 0, strpos(__DIR__, DS . 'cakephp-ide-helper'));

--- a/src/Annotator/AbstractAnnotator.php
+++ b/src/Annotator/AbstractAnnotator.php
@@ -21,7 +21,10 @@ use ReflectionClass;
 use RuntimeException;
 use SebastianBergmann\Diff\Differ;
 
-$manualAutoload = getcwd() . '/vendor/squizlabs/php_codesniffer/autoload.php';
+$currentDir = __DIR__;
+$vendorDir = substr($currentDir, 0, strpos($currentDir, '/cakephp-ide-helper'));
+$composerVendorDir = dirname($vendorDir);
+$manualAutoload = $composerVendorDir . '/squizlabs/php_codesniffer/autoload.php';
 if (!class_exists(Config::class) && file_exists($manualAutoload)) {
 	require $manualAutoload;
 }

--- a/src/Annotator/AbstractAnnotator.php
+++ b/src/Annotator/AbstractAnnotator.php
@@ -26,7 +26,7 @@ $codesnifferDir = 'squizlabs' . DS . 'php_codesniffer';
 if (!is_dir($composerVendorDir . $codesnifferDir)) {
 	$composerVendorDir = substr(__DIR__, 0, strpos(__DIR__, DS . 'cakephp-ide-helper'));
 }
-$manualAutoload =  $composerVendorDir . DS . $codesnifferDir . DS . 'autoload.php';
+$manualAutoload = $composerVendorDir . DS . $codesnifferDir . DS . 'autoload.php';
 if (!class_exists(Config::class) && file_exists($manualAutoload)) {
 	require $manualAutoload;
 }

--- a/src/Annotator/AbstractAnnotator.php
+++ b/src/Annotator/AbstractAnnotator.php
@@ -23,7 +23,7 @@ use SebastianBergmann\Diff\Differ;
 
 $composerVendorDir = getcwd() . DS . 'vendor';
 $codesnifferDir = 'squizlabs' . DS . 'php_codesniffer';
-if (!is_dir($composerVendorDir . $codesnifferDir)) {
+if (!is_dir($composerVendorDir . DS . $codesnifferDir)) {
 	$ideHelperDir = substr(__DIR__, 0, strpos(__DIR__, DS . 'cakephp-ide-helper'));
 	$composerVendorDir = dirname($ideHelperDir);
 }

--- a/src/Annotator/AbstractAnnotator.php
+++ b/src/Annotator/AbstractAnnotator.php
@@ -21,12 +21,12 @@ use ReflectionClass;
 use RuntimeException;
 use SebastianBergmann\Diff\Differ;
 
-$composerVendorDir = getcwd() . DS . 'vendor' . DS;
-if (!is_dir($composerVendorDir)) {
-	$vendorDir = substr(__DIR__, 0, strpos(__DIR__, DS . 'cakephp-ide-helper'));
-	$composerVendorDir = dirname($vendorDir) . DS;
+$composerVendorDir = getcwd() . DS . 'vendor';
+$codesnifferDir = 'squizlabs' . DS . 'php_codesniffer';
+if (!is_dir($composerVendorDir . $codesnifferDir)) {
+	$composerVendorDir = substr(__DIR__, 0, strpos(__DIR__, DS . 'cakephp-ide-helper'));
 }
-$manualAutoload = $composerVendorDir . 'squizlabs' . DS . 'php_codesniffer' . DS . 'autoload.php';
+$manualAutoload =  $composerVendorDir . DS . $codesnifferDir . DS . 'autoload.php';
 if (!class_exists(Config::class) && file_exists($manualAutoload)) {
 	require $manualAutoload;
 }


### PR DESCRIPTION
## Purpose
With composer config "vendor-dir", AbstractAnnotator fail to manual autoload for php_codesniffer.
To fix this,  find composer package directory path in ancestor instead of 'getcwd() . '/vendor/' . 

## What happened
in composer.json

```json
{
    "config": {
        "vendor-dir": "vendor/php-composer"
    }
}
```

run `bin/cake  IdeHelper.annotations all` to throw exception.
```
bash-4.2# bin/cake  IdeHelper.annotations all
[Models]
Warning Error: Class '\PHP_CodeSniffer_File' not found in [/var/www/html/vendor/composer/dereuromark/cakephp-ide-helper/src/Annotator/AbstractAnnotator.php, line 29]

2017-12-14 11:34:47 Warning: Warning (2): Class '\PHP_CodeSniffer_File' not found in [/var/www/html/vendor/composer/dereuromark/cakephp-ide-helper/src/Annotator/AbstractAnnotator.php, line 29]
Trace:
Cake\Error\BaseErrorHandler::handleError() - CORE/src/Error/BaseErrorHandler.php, line 153
class_alias - [internal], line ??
include - ROOT/vendor/composer/dereuromark/cakephp-ide-helper/src/Annotator/AbstractAnnotator.php, line 29
Composer\Autoload\includeFile - ROOT/vendor/composer/composer/ClassLoader.php, line 444
Composer\Autoload\ClassLoader::loadClass() - ROOT/vendor/composer/composer/ClassLoader.php, line 322
```

### What I did
As `vendor-dir`path, set two level upper from plugin directory.