### PR TITLE
Allow dynamically loaded behaviors to be annotated.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ before_script:
 script:
   - if [[ $DEFAULT == 1 ]]; then vendor/bin/phpunit; fi
   - if [[ $PHPCS == 1 ]]; then vendor/bin/phpcs -p --extensions=php --standard=vendor/fig-r/psr2r-sniffer/PSR2R/ruleset.xml --ignore=/vendor/,/tmp/,/logs/ --extensions=php . ; fi
-  - if [[ $PHPSTAN == 1 ]]; then composer require --dev phpstan/phpstan:"^0.8" && vendor/bin/phpstan analyse -c tests/phpstan.neon -l 3 src; fi
+  - if [[ $PHPSTAN == 1 ]]; then composer require --dev phpstan/phpstan:"^0.9" && vendor/bin/phpstan analyse -c tests/phpstan.neon -l 3 src; fi
 
   - if [[ $CODECOVERAGE == 1 ]]; then vendor/bin/phpunit --coverage-clover=clover.xml || true; fi
   - if [[ $CODECOVERAGE == 1 ]]; then wget -O codecov.sh https://codecov.io/bash; fi

--- a/src/Annotation/MethodAnnotation.php
+++ b/src/Annotation/MethodAnnotation.php
@@ -64,7 +64,7 @@ class MethodAnnotation extends AbstractAnnotation {
 	 * @return bool
 	 */
 	public function matches(AbstractAnnotation $annotation) {
-		if ($annotation::TAG !== static::TAG) {
+		if (!$annotation instanceof self) {
 			return false;
 		}
 		$methodName = substr($annotation->getMethod(), 0, strpos($annotation->getMethod(), '('));
@@ -76,7 +76,7 @@ class MethodAnnotation extends AbstractAnnotation {
 	}
 
 	/**
-	 * @param \IdeHelper\Annotation\AbstractAnnotation|\IdeHelper\Annotation\MethodAnnotation $annotation
+	 * @param \IdeHelper\Annotation\MethodAnnotation $annotation
 	 * @return void
 	 */
 	public function replaceWith(AbstractAnnotation $annotation) {

--- a/src/Annotation/MixinAnnotation.php
+++ b/src/Annotation/MixinAnnotation.php
@@ -48,7 +48,7 @@ class MixinAnnotation extends AbstractAnnotation {
 	 * @return bool
 	 */
 	public function matches(AbstractAnnotation $annotation) {
-		if ($annotation::TAG !== static::TAG) {
+		if (!$annotation instanceof self) {
 			return false;
 		}
 		if ($annotation->getType() !== $this->type) {

--- a/src/Annotation/PropertyAnnotation.php
+++ b/src/Annotation/PropertyAnnotation.php
@@ -65,7 +65,7 @@ class PropertyAnnotation extends AbstractAnnotation {
 	 * @return bool
 	 */
 	public function matches(AbstractAnnotation $annotation) {
-		if ($annotation::TAG !== static::TAG) {
+		if (!$annotation instanceof self) {
 			return false;
 		}
 		if ($annotation->getProperty() !== $this->property) {
@@ -76,7 +76,7 @@ class PropertyAnnotation extends AbstractAnnotation {
 	}
 
 	/**
-	 * @param \IdeHelper\Annotation\AbstractAnnotation|\IdeHelper\Annotation\PropertyAnnotation $annotation
+	 * @param \IdeHelper\Annotation\PropertyAnnotation $annotation
 	 * @return void
 	 */
 	public function replaceWith(AbstractAnnotation $annotation) {

--- a/src/Annotation/VariableAnnotation.php
+++ b/src/Annotation/VariableAnnotation.php
@@ -61,7 +61,7 @@ class VariableAnnotation extends AbstractAnnotation {
 	 * @return bool
 	 */
 	public function matches(AbstractAnnotation $annotation) {
-		if ($annotation::TAG !== static::TAG) {
+		if (!$annotation instanceof self) {
 			return false;
 		}
 		if ($annotation->getVariable() !== $this->variable) {
@@ -72,7 +72,7 @@ class VariableAnnotation extends AbstractAnnotation {
 	}
 
 	/**
-	 * @param \IdeHelper\Annotation\AbstractAnnotation|\IdeHelper\Annotation\VariableAnnotation $annotation
+	 * @param \IdeHelper\Annotation\VariableAnnotation $annotation
 	 * @return void
 	 */
 	public function replaceWith(AbstractAnnotation $annotation) {

--- a/src/Annotator/AbstractAnnotator.php
+++ b/src/Annotator/AbstractAnnotator.php
@@ -247,7 +247,7 @@ abstract class AbstractAnnotator {
 	/**
 	 * @param \PHP_CodeSniffer\Files\File $file
 	 * @param int $docBlockCloseIndex
-	 * @param \IdeHelper\Annotation\AbstractAnnotation[] &$annotations
+	 * @param \IdeHelper\Annotation\AbstractAnnotation[] $annotations
 	 *
 	 * @return string
 	 */
@@ -580,7 +580,7 @@ abstract class AbstractAnnotator {
 	 *   $object->_foo
 	 * (assuming the property was directly publicly accessible)
 	 *
-	 * @param object &$object Instantiated object that we want the property off.
+	 * @param object $object Instantiated object that we want the property off.
 	 * @param string $name Property name to fetch.
 	 *
 	 * @return mixed Property value.

--- a/src/CodeCompletion/Task/BehaviorTask.php
+++ b/src/CodeCompletion/Task/BehaviorTask.php
@@ -50,7 +50,7 @@ TXT;
 			$behaviors = $this->addBehaviors($behaviors, $folder);
 		}
 
-		$plugins = Plugin::loaded();
+		$plugins = (array)Plugin::loaded();
 		foreach ($plugins as $plugin) {
 			$folders = App::path('Model/Behavior', $plugin);
 			foreach ($folders as $folder) {

--- a/src/Generator/Task/TableFinderTask.php
+++ b/src/Generator/Task/TableFinderTask.php
@@ -90,7 +90,7 @@ class TableFinderTask extends ModelTask {
 	 *   $object->_foo
 	 * (assuming the property was directly publicly accessible)
 	 *
-	 * @param object &$object Instantiated object that we want the property off.
+	 * @param object $object Instantiated object that we want the property off.
 	 * @param string $name Property name to fetch.
 	 *
 	 * @return mixed Property value.


### PR DESCRIPTION
> preg_match_all('/\$this-\>addBehavior\(\'([a-z.\/]+)\'/i', $content, $matches);

is not really powerful.
This allows also dynamically loaded behaviors to be found :)

Also needed for https://github.com/cakephp/cakephp/pull/11484 etc.