### PR TITLE
WIP: Resolve #69

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,8 @@
 			"IdeHelper\\Test\\": "tests/",
 			"IdeHelper\\PHPStan\\": "tests/PHPStan/",
 			"Cake\\Test\\": "vendor/cakephp/cakephp/tests/",
-			"App\\": "tests/test_app/src/"
+			"App\\": "tests/test_app/src/",
+			"Example\\Slug\\": "tests/test_app/plugins/Example/Slug/src"
 		}
 	},
 	"scripts": {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -64,6 +64,7 @@ Cake\Cache\Cache::config($cache);
 Cake\Core\Plugin::load('IdeHelper', ['path' => ROOT . DS, 'autoload' => true]);
 Cake\Core\Plugin::load('Shim', ['path' => ROOT . DS . 'vendor/dereuromark/cakephp-shim/', 'autoload' => true]);
 Cake\Core\Plugin::load('Awesome', ['path' => TEST_ROOT . 'plugins/Awesome/', 'autoload' => true]);
+Cake\Core\Plugin::load('Example/Slug', ['path' => TEST_ROOT . 'plugins/Example/Slug', 'autoload' => true]);
 
 DispatcherFactory::add('Routing');
 DispatcherFactory::add('ControllerFactory');

--- a/tests/test_app/plugins/Example/Slug/src/Model/Behavior/SluggableBehavior.php
+++ b/tests/test_app/plugins/Example/Slug/src/Model/Behavior/SluggableBehavior.php
@@ -1,0 +1,9 @@
+<?php
+namespace Example\Slug\Model\Behavior;
+
+use Cake\ORM\Behavior;
+
+class SluggableBehavior extends Behavior
+{
+
+}

--- a/tests/test_app/plugins/Example/Slug/src/Model/Behavior/SluggableBehavior.php
+++ b/tests/test_app/plugins/Example/Slug/src/Model/Behavior/SluggableBehavior.php
@@ -3,7 +3,5 @@ namespace Example\Slug\Model\Behavior;
 
 use Cake\ORM\Behavior;
 
-class SluggableBehavior extends Behavior
-{
-
+class SluggableBehavior extends Behavior {
 }

--- a/tests/test_app/src/Model/Table/FooTable.php
+++ b/tests/test_app/src/Model/Table/FooTable.php
@@ -14,7 +14,7 @@ class FooTable extends Table {
 
 		$this->addBehavior('Tools.Confirmable');
 		$this->addBehavior('Timestamp');
-        $this->addBehavior('Example/Slug.Sluggable');
+		$this->addBehavior('Example/Slug.Sluggable');
 	}
 
 }

--- a/tests/test_app/src/Model/Table/FooTable.php
+++ b/tests/test_app/src/Model/Table/FooTable.php
@@ -14,6 +14,7 @@ class FooTable extends Table {
 
 		$this->addBehavior('Tools.Confirmable');
 		$this->addBehavior('Timestamp');
+        $this->addBehavior('Example/Slug.Sluggable');
 	}
 
 }

--- a/tests/test_files/Model/Table/FooTable.php
+++ b/tests/test_files/Model/Table/FooTable.php
@@ -14,6 +14,7 @@ use Cake\ORM\Table;
  *
  * @mixin \Tools\Model\Behavior\ConfirmableBehavior
  * @mixin \Cake\ORM\Behavior\TimestampBehavior
+ * @mixin \Example\Slug\Model\Behavior\SluggableBehavior
  */
 class FooTable extends Table {
 
@@ -26,6 +27,7 @@ class FooTable extends Table {
 
 		$this->addBehavior('Tools.Confirmable');
 		$this->addBehavior('Timestamp');
+        $this->addBehavior('Example/Slug.Sluggable');
 	}
 
 }

--- a/tests/test_files/Model/Table/FooTable.php
+++ b/tests/test_files/Model/Table/FooTable.php
@@ -27,7 +27,7 @@ class FooTable extends Table {
 
 		$this->addBehavior('Tools.Confirmable');
 		$this->addBehavior('Timestamp');
-        $this->addBehavior('Example/Slug.Sluggable');
+		$this->addBehavior('Example/Slug.Sluggable');
 	}
 
 }


### PR DESCRIPTION
Added a new plugin with a namespaced plugin behaviour, and updated the tests accordingly to create a failure to match the issue.

I've been struggling to create code which will make this pass, due to the `App::className` call returning correctly sometimes and incorrectly other times, without a way to differentiate the calling context.