### PR TITLE
Always generate element name with /

### DIFF
--- a/src/Generator/Task/ElementTask.php
+++ b/src/Generator/Task/ElementTask.php
@@ -69,6 +69,7 @@ class ElementTask extends ModelTask {
 			foreach ($Regex as $file) {
 				$name = str_replace($path, '', $file[0]);
 				$name = substr($name, 0, -4);
+				$name = str_replace(DS, '/', $name);
 				if ($plugin) {
 					$name = $plugin . '.' . $name;
 				}


### PR DESCRIPTION
On Windows, generated element names has \ separator.
```
'Flash\default' => \Cake\View\View::class,
'Flash\error' => \Cake\View\View::class,
'Flash\success' => \Cake\View\View::class,
```

Separator should always be /
```
'Flash/default' => \Cake\View\View::class,
'Flash/error' => \Cake\View\View::class,
'Flash/success' => \Cake\View\View::class,
```

#77 