### PR TITLE
Add ModelAwareTrait task

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,9 +50,9 @@
 	},
 	"scripts": {
 		"test": "php phpunit.phar",
-		"test-setup": "[ ! -f phpunit.phar ] && wget https://phar.phpunit.de/phpunit-5.7.20.phar && mv phpunit-5.7.20.phar phpunit.phar || true",
+		"test-setup": "[ ! -f phpunit.phar ] && wget https://phar.phpunit.de/phpunit-6.5.8.phar && mv phpunit-6.5.8.phar phpunit.phar || true",
 		"test-coverage" : "php phpunit.phar --log-junit tmp/coverage/unitreport.xml --coverage-html tmp/coverage --coverage-clover tmp/coverage/coverage.xml",
-		"phpstan": "phpstan analyse -c tests/phpstan.neon -l 3 src",
+		"phpstan": "phpstan analyse -c tests/phpstan.neon -l 3 src/",
 		"phpstan-setup": "cp composer.json composer.backup && composer require --dev phpstan/phpstan && mv composer.backup composer.json",
 		"cs-check": "phpcs -p --standard=vendor/fig-r/psr2r-sniffer/PSR2R/ruleset.xml --extensions=php src tests config",
 		"cs-fix": "phpcbf -v --standard=vendor/fig-r/psr2r-sniffer/PSR2R/ruleset.xml --extensions=php src tests config"

--- a/docs/Annotations.md
+++ b/docs/Annotations.md
@@ -230,6 +230,67 @@ would get the following annotations:
  */
 ```
 
+## Classes and ClassAnnotationTasks
+
+In order to run certain "fixers" over all classes, class annotations and their tasks are available.
+Out of the box the following tasks are run:
+
+### ModelAware
+
+Any `use ModelAwareTrait` usage together with `$this->loadModel(...)` calls will add the required annotation on top of the class.
+
+### Custom Tasks
+
+Just create your own Task class:
+```php
+namespace App\Annotator\ClassAnnotatorTask;
+
+use IdeHelper\Annotator\ClassAnnotatorTask\AbstractClassAnnotatorTask;
+use IdeHelper\Annotator\ClassAnnotatorTask\ClassAnnotatorTaskInterface;
+
+class MyClassAnnotatorTask extends AbstractClassAnnotatorTask implements ClassAnnotatorTaskInterface {
+
+	/**
+	 * @return bool
+	 */
+	public function shouldRun() {
+		...
+	}
+	
+	/**
+	 * @param string $path
+	 * @return bool
+	 */
+	public function annotate($path) {
+		...
+	}
+
+}
+```
+
+Then add it to the config:
+```php
+'IdeHelper' => [
+	'classAnnotatorTasks' => [
+		'MyClassAnnotatorTask' => \App\Annotator\ClassAnnotatorTask\MyClassAnnotatorTask::class,
+	],
+],
+```
+The key `'MyClassAnnotatorTask'` can be any string.
+
+#### Replacing native tasks
+Using associative arrays you can even exchange any native task with your own implementation:
+```php
+'IdeHelper' => [
+	'classAnnotatorTasks' => [
+		\IdeHelper\Annotator\ClassAnnotatorTask\ModelAwareTask::class => \App\Annotator\ClassAnnotatorTask\MyEnhancedModelAwareTask::class,
+	],
+],
+```
+The native class name is the key then, your replacement the value.
+Setting the value to `null` completely disables a native task.
+
+
 ## Templates
 This will ensure annotations for view templates and elements:
 ```

--- a/src/Annotation/AbstractAnnotation.php
+++ b/src/Annotation/AbstractAnnotation.php
@@ -57,6 +57,7 @@ abstract class AbstractAnnotation implements AnnotationInterface, ReplacableAnno
 
 	/**
 	 * @return int|null
+	 * @throws \RuntimeException
 	 */
 	public function getIndex() {
 		if ($this->index === null) {

--- a/src/Annotation/AnnotationFactory.php
+++ b/src/Annotation/AnnotationFactory.php
@@ -57,6 +57,7 @@ class AnnotationFactory {
 	 * @param string|null $content
 	 * @param int|null $index
 	 * @return \IdeHelper\Annotation\AbstractAnnotation
+	 * @throws \RuntimeException
 	 */
 	public static function createOrFail($tag, $type, $content = null, $index = null) {
 		$annotation = static::create($tag, $type, $content, $index);

--- a/src/Annotator/AbstractAnnotator.php
+++ b/src/Annotator/AbstractAnnotator.php
@@ -235,6 +235,8 @@ abstract class AbstractAnnotator {
 	 * @param int $docBlockCloseIndex
 	 * @param \IdeHelper\Annotation\AbstractAnnotation[] $annotations
 	 *
+	 * @throws \RuntimeException
+	 *
 	 * @return string
 	 */
 	protected function _appendToExistingDocBlock(File $file, $docBlockCloseIndex, array &$annotations) {

--- a/src/Annotator/ClassAnnotator.php
+++ b/src/Annotator/ClassAnnotator.php
@@ -1,0 +1,44 @@
+<?php
+namespace IdeHelper\Annotator;
+
+class ClassAnnotator extends AbstractAnnotator {
+
+	/**
+	 * @param string $path Path to file.
+	 * @return void
+	 */
+	public function annotate($path) {
+		$content = file_get_contents($path);
+
+		$this->_invokeTasks($path, $content);
+	}
+
+	/**
+	 * @param string $path
+	 * @param string $content
+	 *
+	 * @return void
+	 */
+	protected function _invokeTasks($path, $content) {
+		$tasks = $this->getTasks($content);
+
+		foreach ($tasks as $task) {
+			if (!$task->shouldRun($path, $content)) {
+				continue;
+			}
+
+			$task->annotate($path);
+		}
+	}
+
+	/**
+	 * @param string $content
+	 * @return \IdeHelper\Annotator\ClassAnnotatorTask\ClassAnnotatorTaskInterface[]
+	 */
+	protected function getTasks($content) {
+		$taskCollection = new ClassAnnotatorTaskCollection();
+
+		return $taskCollection->tasks($this->_io, $this->_config, $content);
+	}
+
+}

--- a/src/Annotator/ClassAnnotatorTask/ClassAnnotatorTaskInterface.php
+++ b/src/Annotator/ClassAnnotatorTask/ClassAnnotatorTaskInterface.php
@@ -1,0 +1,19 @@
+<?php
+namespace IdeHelper\Annotator\ClassAnnotatorTask;
+
+interface ClassAnnotatorTaskInterface {
+
+	/**
+	 * @param string $path
+	 * @param string $content
+	 * @return bool
+	 */
+	public function shouldRun($path, $content);
+
+	/**
+	 * @param string $path Path to file.
+	 * @return void
+	 */
+	public function annotate($path);
+
+}

--- a/src/Annotator/ClassAnnotatorTask/ModelAwareClassAnnotatorTask.php
+++ b/src/Annotator/ClassAnnotatorTask/ModelAwareClassAnnotatorTask.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace IdeHelper\Annotator\ClassAnnotatorTask;
+
+class ModelAwareClassAnnotatorTask extends AbstractClassAnnotatorTask implements ClassAnnotatorTaskInterface {
+	/**
+	 * @param string $path
+	 * @param string $content
+	 * @return bool
+	 */
+	public function shouldRun($path, $content) {
+		if (!preg_match('#\buse ModelAwareTrait\b#', $content)) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * @param string $path
+	 * @return bool
+	 */
+	public function annotate($path) {
+		$models = $this->_getUsedModels($this->content);
+
+		$annotations = $this->_getModelAnnotations($models, $this->content);
+
+		return $this->_annotate($path, $this->content, $annotations);
+	}
+
+	/**
+	 * @param string $content
+	 *
+	 * @return array
+	 */
+	protected function _getUsedModels($content) {
+		preg_match_all('/\$this-\>loadModel\(\'([a-z.]+)\'/i', $content, $matches);
+		if (empty($matches[1])) {
+			return [];
+		}
+
+		$models = $matches[1];
+
+		return array_unique($models);
+	}
+
+}

--- a/src/Annotator/ClassAnnotatorTaskCollection.php
+++ b/src/Annotator/ClassAnnotatorTaskCollection.php
@@ -1,0 +1,57 @@
+<?php
+namespace IdeHelper\Annotator;
+
+use Cake\Core\Configure;
+use IdeHelper\Annotator\ClassAnnotatorTask\ModelAwareClassAnnotatorTask;
+use IdeHelper\Console\Io;
+
+class ClassAnnotatorTaskCollection {
+
+	/**
+	 * @var array
+	 */
+	protected $defaultTasks = [
+		ModelAwareClassAnnotatorTask::class => ModelAwareClassAnnotatorTask::class,
+	];
+
+	/**
+	 * @var array
+	 */
+	protected $tasks;
+
+	/**
+	 * @param array $tasks
+	 */
+	public function __construct(array $tasks = []) {
+		$defaultTasks = (array)Configure::read('IdeHelper.classAnnotatorTasks') + $this->defaultTasks;
+		$tasks += $defaultTasks;
+
+		foreach ($tasks as $task) {
+			if (!$task) {
+				continue;
+			}
+
+			$this->tasks = $tasks;
+		}
+	}
+
+	/**
+	 * @param \IdeHelper\Console\Io $io
+	 * @param array $config
+	 * @param string $content
+	 * @return \IdeHelper\Annotator\ClassAnnotatorTask\ClassAnnotatorTaskInterface[]
+	 */
+	public function tasks(Io $io, array $config, $content) {
+		$tasks = $this->tasks;
+
+		$collection = [];
+		foreach ($tasks as $task) {
+			/** @var \IdeHelper\Annotator\ClassAnnotatorTask\ClassAnnotatorTaskInterface $object */
+			$object = new $task($io, $config, $content);
+			$collection[] = $object;
+		}
+
+		return $collection;
+	}
+
+}

--- a/src/Annotator/EntityAnnotator.php
+++ b/src/Annotator/EntityAnnotator.php
@@ -28,6 +28,7 @@ class EntityAnnotator extends AbstractAnnotator {
 	/**
 	 * @param string $path Path to file.
 	 * @return bool
+	 * @throws \RuntimeException
 	 */
 	public function annotate($path) {
 		$name = pathinfo($path, PATHINFO_FILENAME);

--- a/src/Annotator/ModelAnnotator.php
+++ b/src/Annotator/ModelAnnotator.php
@@ -78,6 +78,7 @@ class ModelAnnotator extends AbstractAnnotator {
 	 * @param array $behaviors
 	 *
 	 * @return bool
+	 * @throws \RuntimeException
 	 */
 	protected function _table($path, $entityName, array $associations, array $behaviors) {
 		$content = file_get_contents($path);

--- a/src/Annotator/TemplateAnnotator.php
+++ b/src/Annotator/TemplateAnnotator.php
@@ -108,6 +108,8 @@ class TemplateAnnotator extends AbstractAnnotator {
 	 * @param int|null $phpOpenTagIndex
 	 * @param int|null $docBlockCloseIndex
 	 *
+	 * @throws \RuntimeException
+	 *
 	 * @return string
 	 */
 	protected function _addNewTemplateDocBlock(File $file, array $annotations, $phpOpenTagIndex, $docBlockCloseIndex) {

--- a/src/CodeCompletion/TaskCollection.php
+++ b/src/CodeCompletion/TaskCollection.php
@@ -41,6 +41,7 @@ class TaskCollection {
 	 *
 	 * @param string|\IdeHelper\CodeCompletion\Task\TaskInterface $task The task to map.
 	 * @return $this
+	 * @throws \InvalidArgumentException
 	 */
 	public function add($task) {
 		if (is_string($task)) {

--- a/src/Generator/TaskCollection.php
+++ b/src/Generator/TaskCollection.php
@@ -55,6 +55,7 @@ class TaskCollection {
 	 *
 	 * @param string|\IdeHelper\Generator\Task\TaskInterface $task The task to map.
 	 * @return $this
+	 * @throws \InvalidArgumentException
 	 */
 	public function add($task) {
 		if (is_string($task)) {

--- a/src/Shell/PhpstormShell.php
+++ b/src/Shell/PhpstormShell.php
@@ -79,6 +79,7 @@ class PhpstormShell extends Shell {
 
 	/**
 	 * @return string
+	 * @throws \RuntimeException
 	 */
 	protected function getMetaFilePath() {
 		if (is_file(ROOT . DS . '.phpstorm.meta.php')) {

--- a/tests/TestCase/Annotator/ClassAnnotatorTest.php
+++ b/tests/TestCase/Annotator/ClassAnnotatorTest.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace IdeHelper\Test\TestCase\Annotator;
+
+use App\Model\Table\FooTable;
+use Cake\Console\ConsoleIo;
+use Cake\Database\Schema\TableSchema;
+use Cake\ORM\TableRegistry;
+use IdeHelper\Annotator\AbstractAnnotator;
+use IdeHelper\Annotator\ClassAnnotator;
+use IdeHelper\Console\Io;
+use Tools\TestSuite\ConsoleOutput;
+use Tools\TestSuite\TestCase;
+
+class ClassAnnotatorTest extends TestCase {
+
+	use DiffHelperTrait;
+
+	/**
+	 * @var array
+	 */
+	public $fixtures = [
+		'plugin.ide_helper.foo',
+		'plugin.ide_helper.wheels',
+	];
+
+	/**
+	 * @var \Tools\TestSuite\ConsoleOutput
+	 */
+	protected $out;
+
+	/**
+	 * @var \Tools\TestSuite\ConsoleOutput
+	 */
+	protected $err;
+
+	/**
+	 * @var \IdeHelper\Console\Io
+	 */
+	protected $io;
+
+	/**
+	 * @return void
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->out = new ConsoleOutput();
+		$this->err = new ConsoleOutput();
+		$consoleIo = new ConsoleIo($this->out, $this->err);
+		$this->io = new Io($consoleIo);
+
+		$x = TableRegistry::get('IdeHelper.Foo', ['className' => FooTable::class]);
+		$columns = [
+			'id' => [
+				'type' => 'integer',
+				'length' => 11,
+				'unsigned' => false,
+				'null' => false,
+				'default' => null,
+				'comment' => '',
+				'autoIncrement' => true,
+				'baseType' => null,
+				'precision' => null
+			],
+			'name' => [
+				'type' => 'string',
+				'length' => 100,
+				'null' => false,
+				'default' => null,
+				'comment' => '',
+				'baseType' => null,
+				'precision' => null,
+				'fixed' => null
+			],
+			'content' => [
+				'type' => 'string',
+				'length' => 100,
+				'null' => false,
+				'default' => null,
+				'comment' => '',
+				'baseType' => null,
+				'precision' => null,
+				'fixed' => null
+			],
+			'created' => [
+				'type' => 'datetime',
+				'length' => null,
+				'null' => true,
+				'default' => null,
+				'comment' => '',
+				'baseType' => null,
+				'precision' => null
+			],
+		];
+		$schema = new TableSchema('Foo', $columns);
+		$x->setSchema($schema);
+		TableRegistry::set('Foo', $x);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testAnnotate() {
+		$annotator = $this->_getAnnotatorMock([]);
+
+		$path = APP . 'Custom/CustomClass.php';
+		$execPath = TMP . 'CustomClass.php';
+		copy($path, $execPath);
+
+		$annotator->annotate($execPath);
+
+		$content = file_get_contents($execPath);
+
+		$testPath = TEST_FILES . 'Custom/CustomClass.php';
+		$expectedContent = file_get_contents($testPath);
+		$this->assertTextEquals($expectedContent, $content);
+
+		$output = (string)$this->out->output();
+
+		$this->assertTextContains('  -> 1 annotation added.', $output);
+	}
+
+	/**
+	 * @param array $params
+	 * @return \IdeHelper\Annotator\ClassAnnotator|\PHPUnit_Framework_MockObject_MockObject
+	 */
+	protected function _getAnnotatorMock(array $params) {
+		$params += [
+			//AbstractAnnotator::CONFIG_REMOVE => true,
+			AbstractAnnotator::CONFIG_VERBOSE => true,
+		];
+		return new ClassAnnotator($this->io, $params);
+	}
+
+}

--- a/tests/TestCase/Annotator/ClassAnnotatorTest.php
+++ b/tests/TestCase/Annotator/ClassAnnotatorTest.php
@@ -2,10 +2,7 @@
 
 namespace IdeHelper\Test\TestCase\Annotator;
 
-use App\Model\Table\FooTable;
 use Cake\Console\ConsoleIo;
-use Cake\Database\Schema\TableSchema;
-use Cake\ORM\TableRegistry;
 use IdeHelper\Annotator\AbstractAnnotator;
 use IdeHelper\Annotator\ClassAnnotator;
 use IdeHelper\Console\Io;
@@ -13,16 +10,6 @@ use Tools\TestSuite\ConsoleOutput;
 use Tools\TestSuite\TestCase;
 
 class ClassAnnotatorTest extends TestCase {
-
-	use DiffHelperTrait;
-
-	/**
-	 * @var array
-	 */
-	public $fixtures = [
-		'plugin.ide_helper.foo',
-		'plugin.ide_helper.wheels',
-	];
 
 	/**
 	 * @var \Tools\TestSuite\ConsoleOutput
@@ -49,53 +36,6 @@ class ClassAnnotatorTest extends TestCase {
 		$this->err = new ConsoleOutput();
 		$consoleIo = new ConsoleIo($this->out, $this->err);
 		$this->io = new Io($consoleIo);
-
-		$x = TableRegistry::get('IdeHelper.Foo', ['className' => FooTable::class]);
-		$columns = [
-			'id' => [
-				'type' => 'integer',
-				'length' => 11,
-				'unsigned' => false,
-				'null' => false,
-				'default' => null,
-				'comment' => '',
-				'autoIncrement' => true,
-				'baseType' => null,
-				'precision' => null
-			],
-			'name' => [
-				'type' => 'string',
-				'length' => 100,
-				'null' => false,
-				'default' => null,
-				'comment' => '',
-				'baseType' => null,
-				'precision' => null,
-				'fixed' => null
-			],
-			'content' => [
-				'type' => 'string',
-				'length' => 100,
-				'null' => false,
-				'default' => null,
-				'comment' => '',
-				'baseType' => null,
-				'precision' => null,
-				'fixed' => null
-			],
-			'created' => [
-				'type' => 'datetime',
-				'length' => null,
-				'null' => true,
-				'default' => null,
-				'comment' => '',
-				'baseType' => null,
-				'precision' => null
-			],
-		];
-		$schema = new TableSchema('Foo', $columns);
-		$x->setSchema($schema);
-		TableRegistry::set('Foo', $x);
 	}
 
 	/**

--- a/tests/TestCase/Annotator/EntityAnnotatorTest.php
+++ b/tests/TestCase/Annotator/EntityAnnotatorTest.php
@@ -35,7 +35,7 @@ class EntityAnnotatorTest extends TestCase {
 	protected $err;
 
 	/**
-	 * @var \Cake\Console\ConsoleIo
+	 * @var \IdeHelper\Console\Io
 	 */
 	protected $io;
 

--- a/tests/test_app/src/Custom/CustomClass.php
+++ b/tests/test_app/src/Custom/CustomClass.php
@@ -1,0 +1,20 @@
+<?php
+namespace App\Custom;
+
+use Cake\Datasource\ModelAwareTrait;
+
+/**
+ * @property \App\Model\Table\BarBarsTable $BarBars
+ */
+class CustomClass {
+
+	use ModelAwareTrait;
+
+	/**
+	 * @return void
+	 */
+	public function initialize() {
+		$this->loadModel('Foo');
+	}
+
+}

--- a/tests/test_app/src/Custom/Nested/NestedClass.php
+++ b/tests/test_app/src/Custom/Nested/NestedClass.php
@@ -1,0 +1,17 @@
+<?php
+namespace App\Custom\Nested;
+
+use Cake\Datasource\ModelAwareTrait;
+
+class NestedClass {
+
+	use ModelAwareTrait;
+
+	/**
+	 * @return void
+	 */
+	public function initialize() {
+		$this->loadModel('Foo');
+	}
+
+}

--- a/tests/test_files/Custom/CustomClass.php
+++ b/tests/test_files/Custom/CustomClass.php
@@ -1,0 +1,21 @@
+<?php
+namespace App\Custom;
+
+use Cake\Datasource\ModelAwareTrait;
+
+/**
+ * @property \App\Model\Table\BarBarsTable $BarBars
+ * @property \App\Model\Table\FooTable $Foo
+ */
+class CustomClass {
+
+	use ModelAwareTrait;
+
+	/**
+	 * @return void
+	 */
+	public function initialize() {
+		$this->loadModel('Foo');
+	}
+
+}

--- a/tests/test_files/Custom/Nested/NestedClass.php
+++ b/tests/test_files/Custom/Nested/NestedClass.php
@@ -1,0 +1,20 @@
+<?php
+namespace App\Custom\Nested;
+
+use Cake\Datasource\ModelAwareTrait;
+
+/**
+ * @property \App\Model\Table\FooTable $Foo
+ */
+class NestedClass {
+
+	use ModelAwareTrait;
+
+	/**
+	 * @return void
+	 */
+	public function initialize() {
+		$this->loadModel('Foo');
+	}
+
+}


### PR DESCRIPTION
Allows annotation fixes on all classes (instead of certain groups), as well as allow any custom task to be injected here.

This is especially useful now that all TableRegistry::get() calls are deprecated and should be transformed into the trait's loadModel() method calls.

Before:
```php
namespace App\Custom;

use Cake\Datasource\ModelAwareTrait;

class CustomClass {

	use ModelAwareTrait;

	/**
	 * @return void
	 */
	public function initialize() {
		$this->loadModel('Foo');
		$this->Foo->someMethod();
	}

}
```

After
```php
namespace App\Custom;

use Cake\Datasource\ModelAwareTrait;

/**
 * @property \App\Model\Table\FooTable $Foo
 */
class CustomClass {

	use ModelAwareTrait;

	/**
	 * @return void
	 */
	public function initialize() {
		$this->loadModel('Foo');
		$this->Foo->someMethod();
	}

}

```