### PR TITLE
Allow belongsToMany join table relations to be clickable.

### DIFF
--- a/src/Annotator/ModelAnnotator.php
+++ b/src/Annotator/ModelAnnotator.php
@@ -210,12 +210,7 @@ class ModelAnnotator extends AbstractAnnotator {
 			}
 
 			/** @var \Cake\ORM\Association\BelongsToMany $association */
-			$through = $association->getThrough();
-			if (!$through) {
-				$tableName = $this->_junctionTableName($association);
-				$through = Inflector::camelize($tableName);
-			}
-
+			$through = $this->throughAlias($association);
 			if (!$through) {
 				continue;
 			}
@@ -226,6 +221,22 @@ class ModelAnnotator extends AbstractAnnotator {
 		}
 
 		return $associations;
+	}
+
+	/**
+	 * @param \Cake\ORM\Association\BelongsToMany $association
+	 * @return string
+	 */
+	protected function throughAlias(BelongsToMany $association) {
+		$through = $association->getThrough();
+		if ($through) {
+			return $through;
+		}
+
+		$tableName = $this->_junctionTableName($association);
+		$through = Inflector::camelize($tableName);
+
+		return $through;
 	}
 
 	/**


### PR DESCRIPTION
For BelongsToMany relationships this will add typehinting/clickability for the pivot table and its Table class:

```php
// FeaturesTable
        $this->belongsToMany('DependingFeatures', [
            'foreignKey' => 'feature_id',
            'className' => 'Features',
            'targetForeignKey' => 'depending_feature_id',
            'joinTable' => 'features_features',
            'propertyName' => 'depending_features',
        ]);
        $this->belongsToMany('Modules', [
            'foreignKey' => 'feature_id',
            'targetForeignKey' => 'module_id',
            'through' => 'FeaturesModules',
            'joinTable' => 'features_modules',
            'propertyName' => 'modules',
        ]);
```

now adds
```php
 * @property \App\Model\Table\FeaturesFeaturesTable|\Cake\ORM\Association\BelongsToMany $FeaturesFeatures
 * @property \App\Model\Table\FeaturesModulesTable|\Cake\ORM\Association\BelongsToMany $FeaturesModules
 */
class FeaturesTable extends Table
```
or at least basic Cake\ORM\Table class for chaining and querying on the pivot table as in

```php
$this->Features->FeaturesModules->find()->contain(['Modules', 'Features']);
// or
$this->Features->FeaturesFeatures->find()->contain(['DependingFeatures', 'Features']);
```

Note one time through and one time auto-calc alias.