### PR TITLE
Add plugins.

### DIFF
--- a/src/Generator/Task/PluginTask.php
+++ b/src/Generator/Task/PluginTask.php
@@ -1,0 +1,48 @@
+<?php
+namespace IdeHelper\Generator\Task;
+
+use Cake\Core\Configure;
+use Cake\Http\BaseApplication;
+
+class PluginTask implements TaskInterface {
+
+	const CLASS_APPLICATION = BaseApplication::class;
+
+	/**
+	 * @var array
+	 */
+	protected $aliases = [
+		'\\' . self::CLASS_APPLICATION . '::addPlugin(0)',
+	];
+
+	/**
+	 * @return array
+	 */
+	public function collect() {
+		$map = [];
+
+		$plugins = $this->collectPlugins();
+		foreach ($plugins as $name) {
+			$map[$name] = '\\' . self::CLASS_APPLICATION . '::class';
+		}
+
+		$result = [];
+		foreach ($this->aliases as $alias) {
+			$result[$alias] = $map;
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Read from PluginCollection loaded config.
+	 *
+	 * @return string[]
+	 */
+	protected function collectPlugins() {
+		$plugins = Configure::read('plugins');
+
+		return array_keys($plugins);
+	}
+
+}

--- a/src/Generator/TaskCollection.php
+++ b/src/Generator/TaskCollection.php
@@ -8,6 +8,7 @@ use IdeHelper\Generator\Task\DatabaseTypeTask;
 use IdeHelper\Generator\Task\ElementTask;
 use IdeHelper\Generator\Task\HelperTask;
 use IdeHelper\Generator\Task\ModelTask;
+use IdeHelper\Generator\Task\PluginTask;
 use IdeHelper\Generator\Task\TableAssociationTask;
 use IdeHelper\Generator\Task\TableFinderTask;
 use IdeHelper\Generator\Task\TaskInterface;
@@ -27,6 +28,7 @@ class TaskCollection {
 		TableFinderTask::class => TableFinderTask::class,
 		DatabaseTypeTask::class => DatabaseTypeTask::class,
 		ElementTask::class => ElementTask::class,
+		PluginTask::class => PluginTask::class,
 	];
 
 	/**


### PR DESCRIPTION
Can someone test and verify this please?
For some reason my phpstorm version doesnt seem to like it..

It adds available plugins
```
+       override(\n
+               \Cake\Http\BaseApplication::addPlugin(0),\n
+               map([\n
+                       'WyriHaximus/TwigView' => \Cake\Http\BaseApplication::class,\n
+                       'Bake' => \Cake\Http\BaseApplication::class,\n
+                       'Shim' => \Cake\Http\BaseApplication::class,\n
+                       'Tools' => \Cake\Http\BaseApplication::class,\n
+               ])\n
+       );\n
```
For 3.7 Application.php usage:
```php
$this->addPlugin('Tools');
$this->addPlugin('...');
```

Should be autompleteable