### PR TITLE
Virtual association

### DIFF
--- a/src/Annotator/EntityAnnotator.php
+++ b/src/Annotator/EntityAnnotator.php
@@ -57,15 +57,11 @@ class EntityAnnotator extends AbstractAnnotator {
 		$propertyHintMap = $helper->buildEntityPropertyHintTypeMap($schema);
 		$propertyHintMap = $this->buildExtendedEntityPropertyHintTypeMap($schema, $helper) + $propertyHintMap;
 		$propertyHintMap += $this->buildVirtualPropertyHintTypeMap($content);
+		$propertyHintMap += $helper->buildEntityAssociationHintTypeMap($schema);
 
 		$propertyHintMap = array_filter($propertyHintMap);
 
 		$annotations = $helper->propertyHints($propertyHintMap);
-		$associationHintMap = $helper->buildEntityAssociationHintTypeMap($schema);
-
-		if ($associationHintMap) {
-			$annotations = array_merge($annotations, $helper->propertyHints($associationHintMap));
-		}
 
 		foreach ($annotations as $key => $annotation) {
 			$annotationObject = AnnotationFactory::createFromString($annotation);

--- a/tests/test_app/src/Model/Entity/Wheel.php
+++ b/tests/test_app/src/Model/Entity/Wheel.php
@@ -24,4 +24,13 @@ class Wheel extends Entity {
 		return 'Virtual Two';
 	}
 
+	/**
+	 * @param \App\Model\Entity\Wheel[] $wheels
+	 *
+	 * @return \App\Model\Entity\Wheel[]
+	 */
+	protected function _getWheels($wheels = []) {
+		return $wheels;
+	}
+
 }

--- a/tests/test_files/Model/Entity/Wheel.php
+++ b/tests/test_files/Model/Entity/Wheel.php
@@ -34,4 +34,13 @@ class Wheel extends Entity {
 		return 'Virtual Two';
 	}
 
+	/**
+	 * @param \App\Model\Entity\Wheel[] $wheels
+	 *
+	 * @return \App\Model\Entity\Wheel[]
+	 */
+	protected function _getWheels($wheels = []) {
+		return $wheels;
+	}
+
 }


### PR DESCRIPTION
Fixes an issue where an entity has a getter method for a association (For use with lazy loading for example).

With the recent virtual property change, the annotator would create duplicate annotations.