### PR TITLE
Plugin property

### DIFF
--- a/src/Annotator/ModelAnnotator.php
+++ b/src/Annotator/ModelAnnotator.php
@@ -200,7 +200,7 @@ class ModelAnnotator extends AbstractAnnotator {
 			$association = $tableAssociations->get($key);
 			$type = get_class($association);
 
-			$name = $association->getAlias();
+			list(, $name) = pluginSplit($association->getAlias());
 			$table = $association->getClassName() ?: $association->getAlias();
 			$className = App::className($table, 'Model/Table', 'Table') ?: static::CLASS_TABLE;
 
@@ -217,13 +217,13 @@ class ModelAnnotator extends AbstractAnnotator {
 			}
 
 			$className = App::className($through, 'Model/Table', 'Table') ?: static::CLASS_TABLE;
-
+			list(, $throughName) = pluginSplit($through);
 			$type = HasMany::class;
-			if (isset($associations[$type][$through])) {
+			if (isset($associations[$type][$throughName])) {
 				continue;
 			}
 
-			$associations[$type][$through] = $className;
+			$associations[$type][$throughName] = $className;
 		}
 
 		return $associations;

--- a/tests/TestCase/Annotator/ModelAnnotatorTest.php
+++ b/tests/TestCase/Annotator/ModelAnnotatorTest.php
@@ -24,6 +24,7 @@ class ModelAnnotatorTest extends TestCase {
 	public $fixtures = [
 		'plugin.ide_helper.foo',
 		'plugin.ide_helper.wheels',
+		'plugin.ide_helper.bar_bars',
 	];
 
 	/**
@@ -106,7 +107,7 @@ class ModelAnnotatorTest extends TestCase {
 	public function testAnnotate() {
 		$annotator = $this->_getAnnotatorMock([]);
 
-		$expectedContent = str_replace("\r\n", "\n", file_get_contents(TEST_FILES . 'Model/Table/FooTable.php'));
+		$expectedContent = str_replace("\r\n", "\n", file_get_contents(TEST_FILES . 'Model/Table/BarBarsTable.php'));
 		$callback = function($value) use ($expectedContent) {
 			$value = str_replace(["\r\n", "\r"], "\n", $value);
 			if ($value !== $expectedContent) {
@@ -116,12 +117,12 @@ class ModelAnnotatorTest extends TestCase {
 		};
 		$annotator->expects($this->once())->method('_storeFile')->with($this->anything(), $this->callback($callback));
 
-		$path = APP . 'Model/Table/FooTable.php';
+		$path = APP . 'Model/Table/BarBarsTable.php';
 		$annotator->annotate($path);
 
 		$output = (string)$this->out->output();
 
-		$this->assertTextContains('  -> 11 annotations added', $output);
+		$this->assertTextContains('  -> 14 annotations added', $output);
 	}
 
 	/**

--- a/tests/test_app/src/Model/Entity/BarBar.php
+++ b/tests/test_app/src/Model/Entity/BarBar.php
@@ -1,0 +1,7 @@
+<?php
+namespace App\Model\Entity;
+
+use Cake\ORM\Entity;
+
+class BarBar extends Entity {
+}

--- a/tests/test_app/src/Model/Table/BarBarsTable.php
+++ b/tests/test_app/src/Model/Table/BarBarsTable.php
@@ -4,4 +4,17 @@ namespace App\Model\Table;
 use Cake\ORM\Table;
 
 class BarBarsTable extends Table {
+
+	public function initialize(array $config) {
+		parent::initialize($config);
+
+		$this->belongsTo('Foo');
+		$this->belongsToMany('Houses', [
+			'className' => 'Awesome.Houses',
+			'through' => 'Awesome.Windows',
+		]);
+		$this->addBehavior('Tools.Confirmable');
+		$this->addBehavior('Timestamp');
+		$this->addBehavior('MyNamespace/MyPlugin.My');
+	}
 }

--- a/tests/test_app/src/Model/Table/BarBarsTable.php
+++ b/tests/test_app/src/Model/Table/BarBarsTable.php
@@ -17,4 +17,5 @@ class BarBarsTable extends Table {
 		$this->addBehavior('Timestamp');
 		$this->addBehavior('MyNamespace/MyPlugin.My');
 	}
+
 }

--- a/tests/test_files/Controller/BarController.php
+++ b/tests/test_files/Controller/BarController.php
@@ -6,7 +6,7 @@ namespace App\Controller;
  * @property \App\Model\Table\BarBarsTable $BarBars
  * @property \Shim\Controller\Component\SessionComponent $Session
  *
- * @method \Cake\ORM\Entity[]|\Cake\Datasource\ResultSetInterface paginate($object = null, array $settings = [])
+ * @method \App\Model\Entity\BarBar[]|\Cake\Datasource\ResultSetInterface paginate($object = null, array $settings = [])
  */
 class BarController extends AppController {
 

--- a/tests/test_files/Model/Table/BarBarsTable.php
+++ b/tests/test_files/Model/Table/BarBarsTable.php
@@ -35,4 +35,5 @@ class BarBarsTable extends Table {
 		$this->addBehavior('Timestamp');
 		$this->addBehavior('MyNamespace/MyPlugin.My');
 	}
+
 }

--- a/tests/test_files/Model/Table/BarBarsTable.php
+++ b/tests/test_files/Model/Table/BarBarsTable.php
@@ -1,0 +1,38 @@
+<?php
+namespace App\Model\Table;
+
+use Cake\ORM\Table;
+
+/**
+ * @property \App\Model\Table\FooTable|\Cake\ORM\Association\BelongsTo $Foo
+ * @property \Awesome\Model\Table\HousesTable|\Cake\ORM\Association\BelongsToMany $Houses
+ * @property \Awesome\Model\Table\WindowsTable|\Cake\ORM\Association\HasMany $Windows
+ *
+ * @method \App\Model\Entity\BarBar get($primaryKey, $options = [])
+ * @method \App\Model\Entity\BarBar newEntity($data = null, array $options = [])
+ * @method \App\Model\Entity\BarBar[] newEntities(array $data, array $options = [])
+ * @method \App\Model\Entity\BarBar|bool save(\Cake\Datasource\EntityInterface $entity, $options = [])
+ * @method \App\Model\Entity\BarBar|bool saveOrFail(\Cake\Datasource\EntityInterface $entity, $options = [])
+ * @method \App\Model\Entity\BarBar patchEntity(\Cake\Datasource\EntityInterface $entity, array $data, array $options = [])
+ * @method \App\Model\Entity\BarBar[] patchEntities($entities, array $data, array $options = [])
+ * @method \App\Model\Entity\BarBar findOrCreate($search, callable $callback = null, $options = [])
+ *
+ * @mixin \Tools\Model\Behavior\ConfirmableBehavior
+ * @mixin \Cake\ORM\Behavior\TimestampBehavior
+ * @mixin \MyNamespace\MyPlugin\Model\Behavior\MyBehavior
+ */
+class BarBarsTable extends Table {
+
+	public function initialize(array $config) {
+		parent::initialize($config);
+
+		$this->belongsTo('Foo');
+		$this->belongsToMany('Houses', [
+			'className' => 'Awesome.Houses',
+			'through' => 'Awesome.Windows',
+		]);
+		$this->addBehavior('Tools.Confirmable');
+		$this->addBehavior('Timestamp');
+		$this->addBehavior('MyNamespace/MyPlugin.My');
+	}
+}

--- a/tests/test_files/Model/Table/FooTable.php
+++ b/tests/test_files/Model/Table/FooTable.php
@@ -26,6 +26,10 @@ class FooTable extends Table {
 	public function initialize(array $config) {
 		parent::initialize($config);
 
+		$this->belongsTo('BarBars');
+		$this->belongsTo('Houses', [
+			'className' => 'Awesome.Houses'
+		]);
 		$this->addBehavior('Tools.Confirmable');
 		$this->addBehavior('Timestamp');
 		$this->addBehavior('MyNamespace/MyPlugin.My');


### PR DESCRIPTION
When using a belongs to many relationship with a through class that belongs to a plugin, the through property was created as `$Plugin.Table`, which is incorrect and doesn't match what CakePHP does internally.