### PR TITLE
Add Illuminator basics.

### DIFF
--- a/docs/Illuminator.md
+++ b/docs/Illuminator.md
@@ -15,7 +15,7 @@ If that doesnt match, it will be skipped.
 Your entities expose their fields either via get()/set() or as class properties.
 Especially when using them through methods, you will have no typehinting/autocomplete on those magic strings.
 In these cases, having class constants is the solution. 
-This task will add those based on the defined property annotations in the doc block as well as the declared virtual properties:
+This task will add those based on the defined property annotations in the doc block:
 ```php
 /**
  * @property int $id
@@ -99,7 +99,7 @@ Using associative arrays you can even exchange any native task with your own imp
 ```php
 'IdeHelper' => [
 	'IlluminatorTasks' => [
-		\IdeHelper\Illuminator\Task\ModelTask::class => \App\Illuminator\Task\MyEnhancedModelTask::class,
+		\IdeHelper\Illuminator\Task\FooBarTask::class => \App\Illuminator\Task\MyEnhancedFooBarTask::class,
 	],
 ],
 ```
@@ -108,7 +108,7 @@ Setting the value to `null` completely disables a native task.
 
 
 ### Important constraint
-This tool is based on the results of the Annotator. So make sure you run that first, e.g.
+Some tasks may be based on the results of the Annotator. So make sure you run that first, e.g.
 
 ```
 bin/cake annotations all && bin/cake illuminator illuminate <path>

--- a/docs/Illuminator.md
+++ b/docs/Illuminator.md
@@ -1,0 +1,96 @@
+# PHP File Illuminator
+
+The Illuminator can modify your PHP files based on Illuminator rulesets.
+You can use the pre-set tasks, or create your own to enhance your PHP files and classes.
+
+Each task has its own scope defined, based on path or filename.
+If that doesnt match, it will be skipped.
+
+### Available tasks
+
+#### EntityField
+Your entities expose their fields either via get()/set() or as class properties.
+Especially when using them through methods, you will have no typehinting/autocomplete on those magic strings.
+In these cases, having class constants is the solution. This task will add those based on the defined property annotations in the doc block:
+```php
+/**
+ * @property int $id
+ * @property string $brand_name
+ * @property \Cake\I18n\FrozenTime $created
+ * @property \Cake\I18n\FrozenTime|null $modified
+ * @property \App\Model\Entity\Wheel[] $wheels
+ */
+class Car extends Entity {
+
+	const FIELD_ID = 'id';
+	const FIELD_BRAND_NAME = 'brand_name';
+	...
+	
+}
+```
+This is especially useful then for e.g.
+```php
+//old
+$carEntity->setDirty('wheels');
+
+//new
+$carEntity->setDirty($carEntity::FIELD_WHEELS);
+```
+This allows for less typing as autocomplete finds it immediately - and for usage display (IDE => rightclick => get usage).
+That also means refactoring on those is much easier this way (via IDE usually a clean one-modification-refactor across the whole project).
+
+Note: For PHP 7.1+ it will also add the visibility flag `public` if you don't configure it otherwise.
+
+
+### Adding your own tasks
+Just create your own Task class:
+```php
+namespace App\Illuminator\Task;
+
+use IdeHelper\Illuminator\Task\TaskInterface;
+
+class MyTask implements TaskInterface {
+
+	/**
+	 * @return array
+	 */
+	public function collect() {
+		...
+	}
+	
+}
+```
+
+Then add it to the config:
+```php
+'IdeHelper' => [
+	'IlluminatorTasks' => [
+		'MyTask' => \App\Illuminator\Task\MyTask::class,
+	],
+],
+```
+The key `'MyTask'` can be any string.
+
+#### Replacing native tasks
+Using associative arrays you can even exchange any native task with your own implementation:
+```php
+'IdeHelper' => [
+	'IlluminatorTasks' => [
+		\IdeHelper\Illuminator\Task\ModelTask::class => \App\Illuminator\Task\MyEnhancedModelTask::class,
+	],
+],
+```
+The native class name is the key then, your replacement the value.
+Setting the value to `null` completely disables a native task.
+
+
+### Important constraint
+This tool is based on the results of the Annotator. So make sure you run that first, e.g.
+
+```
+bin/cake annotations all && bin/cake illuminator illuminate <path>
+```
+
+### CI or pre-commit check
+Using `-d` (dry run) option you will get an error code 2 if the file would need updating.
+This way you can automate the check for CI tooling or commit hooks.

--- a/docs/Illuminator.md
+++ b/docs/Illuminator.md
@@ -3,6 +3,9 @@
 The Illuminator can modify your PHP files based on Illuminator rulesets.
 You can use the pre-set tasks, or create your own to enhance your PHP files and classes.
 
+Note: Instead of meta modifications (doc blocks, annotations) like the Annotator, this Illuminator actually modifies existing code.
+Make sure to backup/commit your changes before running it.
+
 Each task has its own scope defined, based on path or filename.
 If that doesnt match, it will be skipped.
 
@@ -11,13 +14,14 @@ If that doesnt match, it will be skipped.
 #### EntityField
 Your entities expose their fields either via get()/set() or as class properties.
 Especially when using them through methods, you will have no typehinting/autocomplete on those magic strings.
-In these cases, having class constants is the solution. This task will add those based on the defined property annotations in the doc block:
+In these cases, having class constants is the solution. 
+This task will add those based on the defined property annotations in the doc block as well as the declared virtual properties:
 ```php
 /**
  * @property int $id
  * @property string $brand_name
  * @property \Cake\I18n\FrozenTime $created
- * @property \Cake\I18n\FrozenTime|null $modified
+ * @property \Cake\I18n\FrozenTime|null $retired
  * @property \App\Model\Entity\Wheel[] $wheels
  */
 class Car extends Entity {
@@ -30,12 +34,21 @@ class Car extends Entity {
 ```
 This is especially useful then for e.g.
 ```php
-//old
+// old
 $carEntity->setDirty('wheels');
 
-//new
+// new
 $carEntity->setDirty($carEntity::FIELD_WHEELS);
 ```
+or
+```php
+// old
+$query->orderDesc('publish_date');
+
+// new
+$query->orderDesc(Post::FIELD_PUBLISH_DATE);
+```
+
 This allows for less typing as autocomplete finds it immediately - and for usage display (IDE => rightclick => get usage).
 That also means refactoring on those is much easier this way (via IDE usually a clean one-modification-refactor across the whole project).
 

--- a/docs/Illuminator.md
+++ b/docs/Illuminator.md
@@ -52,12 +52,22 @@ use IdeHelper\Illuminator\Task\TaskInterface;
 class MyTask implements TaskInterface {
 
 	/**
-	 * @return array
+	 * @param string $path
+	 * @return bool
 	 */
-	public function collect() {
+	public function shouldRun($path) {
 		...
 	}
-	
+
+	/**
+	 * @param string $content
+	 * @param string $path
+	 * @return string
+	 */
+	public function run($content, $path) {
+		...
+	}
+
 }
 ```
 
@@ -69,7 +79,7 @@ Then add it to the config:
 	],
 ],
 ```
-The key `'MyTask'` can be any string.
+The key `'MyTask'` can be any string but it must be unique across all existing tasks.
 
 #### Replacing native tasks
 Using associative arrays you can even exchange any native task with your own implementation:

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,6 +33,13 @@ would always just return the abstract or parent class.
 
 * [Generator shell](Generator.md)
 
+### PHP File Illuminator
+The Illuminator can modify your PHP files based on Illuminator rulesets.
+You can use the pre-set tasks, or create your own to enhance your PHP files and classes.
+
+* [Illuminator shell](Illuminator.md)
+
+
 ## Usage
 Quick-Guide, see the above links for details.
 
@@ -71,3 +78,18 @@ Generate your app `.phpstorm.meta.php` meta file:
 ```
 bin/cake phpstorm generate
 ```
+
+### Using the illuminator shell
+Improve your PHP files:
+```
+bin/cake illuminator illuminate <path>
+```
+
+Use `-v` for verbose and detailed output:
+```
+bin/cake illuminator illuminate <path> -v
+```
+
+Use `-t` (`--task`) to only run specific task(s), can be a comma separated list.
+
+You can add `-d` (`--dry-run`) to simulate the output without actually modifying the files.

--- a/src/Annotator/AbstractAnnotator.php
+++ b/src/Annotator/AbstractAnnotator.php
@@ -9,12 +9,10 @@ use Cake\Core\InstanceConfigTrait;
 use Cake\View\View;
 use IdeHelper\Annotation\AbstractAnnotation;
 use IdeHelper\Annotation\AnnotationFactory;
+use IdeHelper\Annotator\Traits\FileTrait;
 use IdeHelper\Console\Io;
 use PHP_CodeSniffer\Config;
 use PHP_CodeSniffer\Files\File;
-use PHP_CodeSniffer\Fixer;
-use PHP_CodeSniffer\Ruleset;
-use PHP_CodeSniffer\Runner;
 use PHP_CodeSniffer\Util\Tokens;
 use ReflectionClass;
 use RuntimeException;
@@ -33,6 +31,7 @@ if (!class_exists(Config::class) && file_exists($manualAutoload)) {
 
 abstract class AbstractAnnotator {
 
+	use FileTrait;
 	use InstanceConfigTrait;
 
 	const CONFIG_DRY_RUN = 'dry-run';
@@ -84,34 +83,6 @@ abstract class AbstractAnnotator {
 	 * @return bool
 	 */
 	abstract public function annotate($path);
-
-	/**
-	 * @param string $file
-	 * @param string|null $content
-	 *
-	 * @return \PHP_CodeSniffer\Files\File
-	 */
-	protected function _getFile($file, $content = null) {
-		$_SERVER['argv'] = [];
-
-		$phpcs = new Runner();
-
-		if (!defined('PHP_CODESNIFFER_CBF')) {
-			define('PHP_CODESNIFFER_CBF', false);
-		}
-		// Explictly specifying standard prevents it from searching for phpcs.xml type files.
-		$config = new Config(['--standard=PSR2']);
-		$phpcs->config = $config;
-		$phpcs->init();
-
-		$ruleset = new Ruleset($config);
-
-		$fileObject = new File($file, $ruleset, $config);
-		$fileObject->setContent($content !== null ? $content : file_get_contents($file));
-		$fileObject->parse();
-
-		return $fileObject;
-	}
 
 	/**
 	 * @param string $oldContent
@@ -170,19 +141,6 @@ abstract class AbstractAnnotator {
 			return;
 		}
 		file_put_contents($path, $contents);
-	}
-
-	/**
-	 * @param \PHP_CodeSniffer\Files\File $file
-	 *
-	 * @return \PHP_CodeSniffer\Fixer
-	 */
-	protected function _getFixer($file) {
-		$fixer = new Fixer();
-
-		$fixer->startFile($file);
-
-		return $fixer;
 	}
 
 	/**

--- a/src/Annotator/CallbackAnnotatorTaskCollection.php
+++ b/src/Annotator/CallbackAnnotatorTaskCollection.php
@@ -8,14 +8,14 @@ use IdeHelper\Console\Io;
 class CallbackAnnotatorTaskCollection {
 
 	/**
-	 * @var array
+	 * @var string[]
 	 */
 	protected $defaultTasks = [
 		TableCallbackAnnotatorTask::class => TableCallbackAnnotatorTask::class,
 	];
 
 	/**
-	 * @var array
+	 * @var string[]
 	 */
 	protected $tasks;
 

--- a/src/Annotator/ClassAnnotatorTaskCollection.php
+++ b/src/Annotator/ClassAnnotatorTaskCollection.php
@@ -8,14 +8,14 @@ use IdeHelper\Console\Io;
 class ClassAnnotatorTaskCollection {
 
 	/**
-	 * @var array
+	 * @var string[]
 	 */
 	protected $defaultTasks = [
 		ModelAwareClassAnnotatorTask::class => ModelAwareClassAnnotatorTask::class,
 	];
 
 	/**
-	 * @var array
+	 * @var string[]
 	 */
 	protected $tasks;
 

--- a/src/Annotator/Traits/FileTrait.php
+++ b/src/Annotator/Traits/FileTrait.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace IdeHelper\Annotator\Traits;
+
+use PHP_CodeSniffer\Config;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Fixer;
+use PHP_CodeSniffer\Ruleset;
+use PHP_CodeSniffer\Runner;
+
+trait FileTrait {
+
+	/**
+	 * @param string $file
+	 * @param string|null $content
+	 *
+	 * @return \PHP_CodeSniffer\Files\File
+	 */
+	protected function _getFile($file, $content = null) {
+		$_SERVER['argv'] = [];
+
+		$phpcs = new Runner();
+
+		if (!defined('PHP_CODESNIFFER_CBF')) {
+			define('PHP_CODESNIFFER_CBF', false);
+		}
+		// Explictly specifying standard prevents it from searching for phpcs.xml type files.
+		$config = new Config(['--standard=PSR2']);
+		$phpcs->config = $config;
+		$phpcs->init();
+
+		$ruleset = new Ruleset($config);
+
+		$fileObject = new File($file, $ruleset, $config);
+		$fileObject->setContent($content !== null ? $content : file_get_contents($file));
+		$fileObject->parse();
+
+		return $fileObject;
+	}
+
+	/**
+	 * @param \PHP_CodeSniffer\Files\File $file
+	 *
+	 * @return \PHP_CodeSniffer\Fixer
+	 */
+	protected function _getFixer($file) {
+		$fixer = new Fixer();
+
+		$fixer->startFile($file);
+
+		return $fixer;
+	}
+
+}

--- a/src/CodeCompletion/TaskCollection.php
+++ b/src/CodeCompletion/TaskCollection.php
@@ -43,7 +43,7 @@ class TaskCollection {
 	 * @return $this
 	 * @throws \InvalidArgumentException
 	 */
-	public function add($task) {
+	protected function add($task) {
 		if (is_string($task)) {
 			$task = new $task();
 		}

--- a/src/CodeCompletion/TaskCollection.php
+++ b/src/CodeCompletion/TaskCollection.php
@@ -9,7 +9,7 @@ use InvalidArgumentException;
 class TaskCollection {
 
 	/**
-	 * @var array
+	 * @var string[]
 	 */
 	protected $defaultTasks = [
 		BehaviorTask::class => BehaviorTask::class,

--- a/src/Generator/TaskCollection.php
+++ b/src/Generator/TaskCollection.php
@@ -59,7 +59,7 @@ class TaskCollection {
 	 * @return $this
 	 * @throws \InvalidArgumentException
 	 */
-	public function add($task) {
+	protected function add($task) {
 		if (is_string($task)) {
 			$task = new $task();
 		}

--- a/src/Generator/TaskCollection.php
+++ b/src/Generator/TaskCollection.php
@@ -17,7 +17,7 @@ use InvalidArgumentException;
 class TaskCollection {
 
 	/**
-	 * @var array
+	 * @var string[]
 	 */
 	protected $defaultTasks = [
 		ModelTask::class => ModelTask::class,

--- a/src/Illuminator/Illuminator.php
+++ b/src/Illuminator/Illuminator.php
@@ -1,0 +1,50 @@
+<?php
+namespace IdeHelper\Illuminator;
+
+use Cake\Filesystem\Folder;
+
+class Illuminator {
+
+	/**
+	 * @var \IdeHelper\Illuminator\TaskCollection
+	 */
+	protected $taskCollection;
+
+	/**
+	 * @param \IdeHelper\Illuminator\TaskCollection $taskCollection
+	 */
+	public function __construct(TaskCollection $taskCollection) {
+		$this->taskCollection = $taskCollection;
+	}
+
+	/**
+	 * @param string $path
+	 * @return string
+	 */
+	public function illuminate($path) {
+		$files = $this->getFiles($path);
+
+		$count = 0;
+		foreach ($files as $file) {
+			if (!$this->taskCollection->run($file)) {
+				continue;
+			}
+
+			$count++;
+		}
+
+		return $count;
+	}
+
+	/**
+	 * @param string $path
+	 * @return array
+	 */
+	protected function getFiles($path) {
+		$folder = new Folder($path);
+		$result = $folder->findRecursive('.*\.php', true);
+
+		return $result;
+	}
+
+}

--- a/src/Illuminator/Illuminator.php
+++ b/src/Illuminator/Illuminator.php
@@ -19,7 +19,7 @@ class Illuminator {
 
 	/**
 	 * @param string $path
-	 * @return string
+	 * @return int
 	 */
 	public function illuminate($path) {
 		$files = $this->getFiles($path);

--- a/src/Illuminator/Task/AbstractTask.php
+++ b/src/Illuminator/Task/AbstractTask.php
@@ -54,7 +54,7 @@ abstract class AbstractTask {
 	 * @param string $path
 	 * @return bool
 	 */
-	abstract public function isApplicable($path);
+	abstract public function shouldRun($path);
 
 	/**
 	 * @param string $content

--- a/src/Illuminator/Task/AbstractTask.php
+++ b/src/Illuminator/Task/AbstractTask.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace IdeHelper\Illuminator\Task;
+
+use Cake\Core\Configure;
+use Cake\Core\InstanceConfigTrait;
+use IdeHelper\Annotator\Traits\FileTrait;
+use PHP_CodeSniffer\Config;
+
+$composerVendorDir = getcwd() . DS . 'vendor';
+$codesnifferDir = 'squizlabs' . DS . 'php_codesniffer';
+if (!is_dir($composerVendorDir . DS . $codesnifferDir)) {
+	$ideHelperDir = substr(__DIR__, 0, strpos(__DIR__, DS . 'cakephp-ide-helper'));
+	$composerVendorDir = dirname($ideHelperDir);
+}
+$manualAutoload = $composerVendorDir . DS . $codesnifferDir . DS . 'autoload.php';
+if (!class_exists(Config::class) && file_exists($manualAutoload)) {
+	require $manualAutoload;
+}
+
+/**
+ * Reads the annotated properties of an entity and adds the constants based on those.
+ */
+abstract class AbstractTask {
+
+	use FileTrait;
+	use InstanceConfigTrait;
+
+	const CONFIG_DRY_RUN = 'dry-run';
+	const CONFIG_PLUGIN = 'plugin';
+	const CONFIG_NAMESPACE = 'namespace';
+	const CONFIG_VERBOSE = 'verbose';
+
+	const COUNT_ADDED = 'added';
+
+	/**
+	 * @var array
+	 */
+	protected $_defaultConfig = [
+	];
+
+	/**
+	 * @param array $config
+	 */
+	public function __construct(array $config) {
+		$this->setConfig($config);
+
+		$namespace = $this->getConfig(static::CONFIG_PLUGIN) ?: Configure::read('App.namespace', 'App');
+		$namespace = str_replace('/', '\\', $namespace);
+		$this->setConfig(static::CONFIG_NAMESPACE, $namespace);
+	}
+
+	/**
+	 * @param string $path
+	 * @return bool
+	 */
+	abstract public function isApplicable($path);
+
+	/**
+	 * @param string $content
+	 * @param string $path
+	 * @return string
+	 */
+	abstract public function run($content, $path);
+
+}

--- a/src/Illuminator/Task/EntityFieldTask.php
+++ b/src/Illuminator/Task/EntityFieldTask.php
@@ -47,7 +47,7 @@ class EntityFieldTask extends AbstractTask {
 	 * @param string $path
 	 * @return bool
 	 */
-	public function isApplicable($path) {
+	public function shouldRun($path) {
 		return (bool)preg_match('#\\/Model\\/Entity/.+\\.php$#', $path);
 	}
 
@@ -84,7 +84,7 @@ class EntityFieldTask extends AbstractTask {
 	/**
 	 * @param \PHP_CodeSniffer\Files\File $file
 	 * @param int $classIndex
-	 * @return string[]
+	 * @return array
 	 */
 	protected function getFields(File $file, $classIndex) {
 		$tokens = $file->getTokens();
@@ -111,6 +111,8 @@ class EntityFieldTask extends AbstractTask {
 			$field = mb_substr($pieces[1], 1);
 			$fields[$field] = [
 				'name' => $field,
+				//constant
+				//index
 			];
 		}
 
@@ -177,9 +179,13 @@ class EntityFieldTask extends AbstractTask {
 	}
 
 	/**
+	 * @param int $startIndex
+	 * @param int $endIndex
 	 * @return array
 	 */
-	protected function getFieldConstants() {
+	protected function getFieldConstants($startIndex, $endIndex) {
+		//TODO
+
 		return [];
 	}
 

--- a/src/Illuminator/Task/EntityFieldTask.php
+++ b/src/Illuminator/Task/EntityFieldTask.php
@@ -28,22 +28,6 @@ class EntityFieldTask extends AbstractTask {
 	protected $_visibility;
 
 	/**
-	 * @return bool
-	 */
-	protected function visibility() {
-		if ($this->_visibility !== null) {
-			return $this->_visibility;
-		}
-
-		$visConfig = $this->getConfig('visibility');
-		if ($visConfig === null) {
-			$visConfig = version_compare(PHP_VERSION, '7.1') >= 0;
-		}
-
-		return $this->_visibility = $visConfig;
-	}
-
-	/**
 	 * @param string $path
 	 * @return bool
 	 */
@@ -187,6 +171,22 @@ class EntityFieldTask extends AbstractTask {
 		//TODO
 
 		return [];
+	}
+
+	/**
+	 * @return bool
+	 */
+	protected function visibility() {
+		if ($this->_visibility !== null) {
+			return $this->_visibility;
+		}
+
+		$visConfig = $this->getConfig('visibility');
+		if ($visConfig === null) {
+			$visConfig = version_compare(PHP_VERSION, '7.1') >= 0;
+		}
+
+		return $this->_visibility = $visConfig;
 	}
 
 }

--- a/src/Illuminator/Task/EntityFieldTask.php
+++ b/src/Illuminator/Task/EntityFieldTask.php
@@ -97,6 +97,10 @@ class EntityFieldTask extends AbstractTask {
 				continue;
 			}
 			$field = mb_substr($pieces[1], 1);
+			if (strpos($field, ' ') === 0) {
+				continue;
+			}
+
 			$fields[$field] = [
 				'name' => $field,
 				'constant' => static::PREFIX . mb_strtoupper($field),

--- a/src/Illuminator/Task/EntityFieldTask.php
+++ b/src/Illuminator/Task/EntityFieldTask.php
@@ -99,7 +99,7 @@ class EntityFieldTask extends AbstractTask {
 			$field = mb_substr($pieces[1], 1);
 			$fields[$field] = [
 				'name' => $field,
-				'constant' => 'FIELD_' . mb_strtoupper($field),
+				'constant' => static::PREFIX . mb_strtoupper($field),
 				'index' => $i,
 			];
 		}
@@ -205,6 +205,10 @@ class EntityFieldTask extends AbstractTask {
 
 			$pos = strpos($constant, '_');
 			$prefix = substr($constant, 0, $pos);
+			if ($prefix . '_' !== static::PREFIX) {
+				continue;
+			}
+
 			$field = substr($constant, $pos + 1);
 			$field = strtolower($field);
 

--- a/src/Illuminator/Task/EntityFieldTask.php
+++ b/src/Illuminator/Task/EntityFieldTask.php
@@ -58,11 +58,11 @@ class EntityFieldTask extends AbstractTask {
 		} else {
 			$index = $file->findNext(T_WHITESPACE, $tokens[$classIndex]['scope_opener'] + 1, $tokens[$classIndex]['scope_closer'], true);
 			if ($index === false) {
-				return $content;
+				$index = $tokens[$classIndex]['scope_closer'];
 			}
 		}
 
-		return $this->addClassConstants($file, $fields, $index) ?: $content;
+		return $this->addClassConstants($file, $fields, $index, 0) ?: $content;
 	}
 
 	/**
@@ -122,9 +122,10 @@ class EntityFieldTask extends AbstractTask {
 	 * @param \PHP_CodeSniffer\Files\File $file
 	 * @param array $fields
 	 * @param int $index
+	 * @param int $level
 	 * @return string|null
 	 */
-	protected function addClassConstants(File $file, array $fields, $index) {
+	protected function addClassConstants(File $file, array $fields, $index, $level = 1) {
 		if (!$fields) {
 			return null;
 		}
@@ -136,6 +137,9 @@ class EntityFieldTask extends AbstractTask {
 		while ($tokens[$firstOfLineIndex - 1]['line'] === $tokens[$index]['line']) {
 			$firstOfLineIndex--;
 			$whitespace .= $tokens[$firstOfLineIndex]['content'];
+		}
+		if ($level < 1) {
+			$whitespace = str_repeat(' ', 4);
 		}
 
 		$beginIndex = $firstOfLineIndex - 1;

--- a/src/Illuminator/Task/EntityFieldTask.php
+++ b/src/Illuminator/Task/EntityFieldTask.php
@@ -1,0 +1,186 @@
+<?php
+
+namespace IdeHelper\Illuminator\Task;
+
+use IdeHelper\Annotator\Traits\FileTrait;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+
+/**
+ * Reads the annotated properties of an entity and adds the constants based on those.
+ */
+class EntityFieldTask extends AbstractTask {
+
+	use FileTrait;
+
+	const PREFIX = 'FIELD_';
+
+	/**
+	 * @var array
+	 */
+	protected $_defaultConfig = [
+		'visibility' => null,
+	];
+
+	/**
+	 * @var bool|null
+	 */
+	protected $_visibility;
+
+	/**
+	 * @return bool
+	 */
+	protected function visibility() {
+		if ($this->_visibility !== null) {
+			return $this->_visibility;
+		}
+
+		$visConfig = $this->getConfig('visibility');
+		if ($visConfig === null) {
+			$visConfig = version_compare(PHP_VERSION, '7.1') >= 0;
+		}
+
+		return $this->_visibility = $visConfig;
+	}
+
+	/**
+	 * @param string $path
+	 * @return bool
+	 */
+	public function isApplicable($path) {
+		return (bool)preg_match('#\\/Model\\/Entity/.+\\.php$#', $path);
+	}
+
+	/**
+	 * @param string $content
+	 * @param string $path Path to file.
+	 * @return string
+	 */
+	public function run($content, $path) {
+		$file = $this->_getFile('', $content);
+
+		$classIndex = $file->findNext(T_CLASS, 0);
+		if (!$classIndex) {
+			return $content;
+		}
+
+		$tokens = $file->getTokens();
+
+		$fields = $this->getFields($file, $classIndex);
+
+		$existingConstants = $this->getFieldConstants($tokens[$classIndex]['scope_opener'], $tokens[$classIndex]['scope_closer']);
+		if ($existingConstants) {
+			$index = null; //TODO
+		} else {
+			$index = $file->findNext(T_WHITESPACE, $tokens[$classIndex]['scope_opener'] + 1, $tokens[$classIndex]['scope_closer'], true);
+			if ($index === false) {
+				return $content;
+			}
+		}
+
+		return $this->addClassConstants($file, $fields, $index) ?: $content;
+	}
+
+	/**
+	 * @param \PHP_CodeSniffer\Files\File $file
+	 * @param int $classIndex
+	 * @return string[]
+	 */
+	protected function getFields(File $file, $classIndex) {
+		$tokens = $file->getTokens();
+
+		$docBlockCloseTagIndex = $this->_findDocBlockCloseTagIndex($file, $classIndex);
+		if (!$docBlockCloseTagIndex || empty($tokens[$docBlockCloseTagIndex]['comment_opener'])) {
+			return [];
+		}
+
+		$fields = [];
+		for ($i = $tokens[$docBlockCloseTagIndex]['comment_opener'] + 1; $i < $docBlockCloseTagIndex; $i++) {
+
+			if ($tokens[$i]['code'] !== T_DOC_COMMENT_TAG) {
+				continue;
+			}
+			if ($tokens[$i]['content'] !== '@property') {
+				continue;
+			}
+
+			$pieces = explode(' ', $tokens[$i + 2]['content']);
+			if (count($pieces) < 2) {
+				continue;
+			}
+			$field = mb_substr($pieces[1], 1);
+			$fields[$field] = [
+				'name' => $field,
+			];
+		}
+
+		return $fields;
+	}
+
+	/**
+	 * @param \PHP_CodeSniffer\Files\File $file
+	 * @param int $index First functional code after docblock
+	 *
+	 * @return int|false
+	 */
+	protected function _findDocBlockCloseTagIndex(File $file, $index) {
+		$prevCode = $file->findPrevious(Tokens::$emptyTokens, $index - 1, null, true);
+		if (!$prevCode) {
+			return false;
+		}
+
+		return $file->findPrevious(T_DOC_COMMENT_CLOSE_TAG, $index - 1, $prevCode);
+	}
+
+	/**
+	 * @param \PHP_CodeSniffer\Files\File $file
+	 * @param array $fields
+	 * @param int $index
+	 * @return string|null
+	 */
+	protected function addClassConstants(File $file, array $fields, $index) {
+		if (!$fields) {
+			return null;
+		}
+
+		$tokens = $file->getTokens();
+
+		$whitespace = '';
+		$firstOfLineIndex = $index;
+		while ($tokens[$firstOfLineIndex - 1]['line'] === $tokens[$index]['line']) {
+			$firstOfLineIndex--;
+			$whitespace .= $tokens[$firstOfLineIndex]['content'];
+		}
+
+		$beginIndex = $firstOfLineIndex - 1;
+		$visibility = '';
+		if ($this->visibility()) {
+			$visibility = 'public ';
+		}
+
+		$fixer = $this->_getFixer($file);
+
+		$fixer->beginChangeset();
+
+		foreach ($fields as $field) {
+			$constant = 'FIELD_' . mb_strtoupper($field['name']);
+
+			$fixer->addContent($beginIndex, $whitespace . $visibility . 'const ' . $constant . ' = \'' . $field['name'] . '\';');
+			$fixer->addNewline($beginIndex);
+		}
+
+		$fixer->addNewline($beginIndex);
+
+		$fixer->endChangeset();
+
+		return $fixer->getContents();
+	}
+
+	/**
+	 * @return array
+	 */
+	protected function getFieldConstants() {
+		return [];
+	}
+
+}

--- a/src/Illuminator/TaskCollection.php
+++ b/src/Illuminator/TaskCollection.php
@@ -1,0 +1,204 @@
+<?php
+namespace IdeHelper\Illuminator;
+
+use Cake\Console\Shell;
+use Cake\Core\Configure;
+use IdeHelper\Console\Io;
+use IdeHelper\Illuminator\Task\AbstractTask;
+use IdeHelper\Illuminator\Task\EntityFieldTask;
+use InvalidArgumentException;
+use RuntimeException;
+use SebastianBergmann\Diff\Differ;
+
+class TaskCollection {
+
+	const CONFIG_DRY_RUN = 'dry-run';
+	const CONFIG_VISIBILITY = 'visibility';
+
+	/**
+	 * @var \IdeHelper\Console\Io
+	 */
+	protected $_io;
+
+	/**
+	 * @var array
+	 */
+	protected $_config;
+
+	/**
+	 * @var string[]
+	 */
+	protected $defaultTasks = [
+		EntityFieldTask::class => EntityFieldTask::class,
+	];
+
+	/**
+	 * @var \IdeHelper\Illuminator\Task\AbstractTask[]
+	 */
+	protected $tasks;
+
+	/**
+	 * @param \IdeHelper\Console\Io $io
+	 * @param array $config
+	 * @param string[] $tasks
+	 * @throws \InvalidArgumentException
+	 * @throws \RuntimeException
+	 */
+	public function __construct(Io $io, array $config, array $tasks = []) {
+		$this->_io = $io;
+		$this->_config = $config;
+
+		$defaultTasks = (array)Configure::read('IdeHelper.illuminatorTasks') + $this->defaultTasks;
+
+		$keys = array_keys($defaultTasks);
+		$keyMap = array_combine($keys, $keys);
+		foreach ($keyMap as $k => $v) {
+			preg_match('#\bTask\\\\([A-Za-z0-9]+)Task$#', $v, $matches);
+			if (!$matches) {
+				throw new RuntimeException('Invalid task name: ' . $v);
+			}
+			$keyMap[$k] = $matches[1];
+		}
+		$filterMap = array_diff($tasks, $keyMap);
+		if ($filterMap) {
+			throw new InvalidArgumentException('Tasks do not exist: ' . implode(', ', $filterMap) . '.');
+		}
+
+		foreach ($defaultTasks as $key => $task) {
+			if (!$task) {
+				continue;
+			}
+			$lookupKey = $keyMap[$key];
+			if ($tasks && !in_array($lookupKey, $tasks, true)) {
+				continue;
+			}
+
+			$this->add($task);
+		}
+	}
+
+	/**
+	 * Adds a task to the collection.
+	 *
+	 * @param string|\IdeHelper\Illuminator\Task\AbstractTask $task The task to map.
+	 * @return $this
+	 * @throws \InvalidArgumentException
+	 */
+	public function add($task) {
+		if (is_string($task)) {
+			$task = new $task($this->_config);
+		}
+
+		$class = get_class($task);
+		if (!$task instanceof AbstractTask) {
+			throw new InvalidArgumentException(
+				"Cannot use '$class' as task, it is not implementing " . AbstractTask::class . '.'
+			);
+		}
+
+		$this->tasks[$class] = $task;
+
+		return $this;
+	}
+
+	/**
+	 * @return \IdeHelper\Illuminator\Task\AbstractTask[]
+	 */
+	public function tasks() {
+		return $this->tasks;
+	}
+
+	/**
+	 * @param string $path File path
+	 * @return bool True if file is/was modified; false if nothing changed.
+	 */
+	public function run($path) {
+		$file = str_replace(ROOT . DS, DS, $path);
+		$this->_io->verbose('# ' . $file);
+
+		$content = $result = null;
+
+		foreach ($this->tasks as $task) {
+			if (!$task->isApplicable($path)) {
+				continue;
+			}
+
+			if ($content === null) {
+				$content = file_get_contents($path);
+				$result = $content;
+			}
+
+			$result = $task->run($result, $path);
+		}
+
+		if ($content === null || $result === $content) {
+			return false;
+		}
+
+		$this->_displayDiff($content, $result);
+		$this->_storeFile($path, $result, $this->_config[static::CONFIG_DRY_RUN]);
+
+		return true;
+	}
+
+	/**
+	 * @param string $oldContent
+	 * @param string $newContent
+	 * @return void
+	 */
+	protected function _displayDiff($oldContent, $newContent) {
+		$differ = new Differ(null);
+		$array = $differ->diffToArray($oldContent, $newContent);
+
+		$begin = null;
+		$end = null;
+		foreach ($array as $key => $row) {
+			if ($row[1] === 0) {
+				continue;
+			}
+
+			if ($begin === null) {
+				$begin = $key;
+			}
+			$end = $key;
+		}
+		if ($begin === null) {
+			return;
+		}
+		$firstLineOfOutput = $begin > 0 ? $begin - 1 : 0;
+		$lastLineOfOutput = count($array) - 1 > $end ? $end + 1 : $end;
+
+		for ($i = $firstLineOfOutput; $i <= $lastLineOfOutput; $i++) {
+			$row = $array[$i];
+
+			$char = ' ';
+			$output = trim($row[0], "\n\r\0\x0B");
+
+			if ($row[1] === 1) {
+				$char = '+';
+				$this->_io->info('   | ' . $char . $output, 1, Shell::VERBOSE);
+			} elseif ($row[1] === 2) {
+				$char = '-';
+				$this->_io->out('<warning>' . '   | ' . $char . $output . '</warning>', 1, Shell::VERBOSE);
+			} else {
+				$this->_io->out('   | ' . $char . $output, 1, Shell::VERBOSE);
+			}
+		}
+	}
+
+	/**
+	 * @param string $path
+	 * @param string $contents
+	 * @param bool $dryRun
+	 * @return void
+	 */
+	protected function _storeFile($path, $contents, $dryRun) {
+		//static::$output = true;
+		if ($dryRun) {
+			return;
+		}
+
+		file_put_contents($path, $contents);
+	}
+
+}

--- a/src/Illuminator/TaskCollection.php
+++ b/src/Illuminator/TaskCollection.php
@@ -119,7 +119,7 @@ class TaskCollection {
 		$content = $result = null;
 
 		foreach ($this->tasks as $task) {
-			if (!$task->isApplicable($path)) {
+			if (!$task->shouldRun($path)) {
 				continue;
 			}
 

--- a/src/Shell/AnnotationsShell.php
+++ b/src/Shell/AnnotationsShell.php
@@ -508,7 +508,7 @@ class AnnotationsShell extends Shell {
 			'options' => [
 				'dry-run' => [
 					'short' => 'd',
-					'help' => 'Dry run the task. Don\'t modify any files.',
+					'help' => 'Dry run the task(s). Don\'t modify any files.',
 					'boolean' => true,
 				],
 				'plugin' => [

--- a/src/Shell/CodeCompletionShell.php
+++ b/src/Shell/CodeCompletionShell.php
@@ -40,7 +40,7 @@ class CodeCompletionShell extends Shell {
 			'options' => [
 				'dry-run' => [
 					'short' => 'd',
-					'help' => 'Dry run the task. This will not actually generate any files.',
+					'help' => 'Dry run the generation. This will not actually generate any files.',
 					'boolean' => true,
 				],
 			]

--- a/src/Shell/IlluminatorShell.php
+++ b/src/Shell/IlluminatorShell.php
@@ -2,6 +2,7 @@
 namespace IdeHelper\Shell;
 
 use Cake\Console\Shell;
+use Cake\Core\Plugin;
 use IdeHelper\Console\Io;
 use IdeHelper\Illuminator\Illuminator;
 use IdeHelper\Illuminator\TaskCollection;
@@ -19,10 +20,20 @@ class IlluminatorShell extends Shell {
 	/**
 	 * @param string|null $path
 	 * @return int
+	 * @throws \InvalidArgumentException
 	 */
 	public function illuminate($path = null) {
 		if (!$path) {
 			$path = 'src/';
+		}
+
+		$root = ROOT . DS;
+		if ($this->param('plugin')) {
+			$root = Plugin::path($this->param('plugin'));
+		}
+		$path = $root . $path;
+		if (!is_dir($path)) {
+			throw new \InvalidArgumentException('Path does not exist: ' . $path);
 		}
 
 		$illuminator = $this->getIlluminator();
@@ -49,6 +60,11 @@ class IlluminatorShell extends Shell {
 
 		$subcommandParser = [
 			'options' => [
+				'plugin' => [
+					'short' => 'p',
+					'help' => 'The plugin to run. Defaults to the application otherwise.',
+					'default' => null,
+				],
 				'dry-run' => [
 					'short' => 'd',
 					'help' => 'Dry run the task(s). This will output an error code ' . static::CODE_CHANGES . ' if file needs changing. Can be used for CI checking.',

--- a/src/Shell/IlluminatorShell.php
+++ b/src/Shell/IlluminatorShell.php
@@ -1,0 +1,98 @@
+<?php
+namespace IdeHelper\Shell;
+
+use Cake\Console\Shell;
+use IdeHelper\Console\Io;
+use IdeHelper\Illuminator\Illuminator;
+use IdeHelper\Illuminator\TaskCollection;
+
+/**
+ * Shell for modifying your PHP files based on Illuminator rulesets.
+ *
+ * @author Mark Scherer
+ * @license MIT
+ */
+class IlluminatorShell extends Shell {
+
+	const CODE_CHANGES = 2;
+
+	/**
+	 * Generates CodeCompletation.php files.
+	 *
+	 * @param string|null $path
+	 * @return int
+	 */
+	public function illuminate($path = null) {
+		if (!$path) {
+			$path = 'src/';
+		}
+
+		$illuminator = $this->getIlluminator();
+		$filesChanged = $illuminator->illuminate($path);
+		if (!$filesChanged) {
+			return static::CODE_SUCCESS;
+		}
+
+		if ($this->param('dry-run')) {
+			$this->out($filesChanged . ' files need(s) updating.');
+			return static::CODE_CHANGES;
+		}
+
+		$this->out('Files updated: ' . $filesChanged);
+
+		return static::CODE_SUCCESS;
+	}
+
+	/**
+	 * @return \Cake\Console\ConsoleOptionParser
+	 */
+	public function getOptionParser() {
+		$subcommandParser = [
+			'options' => [
+				'dry-run' => [
+					'short' => 'd',
+					'help' => 'Dry run the task(s). This will output an error code ' . static::CODE_CHANGES . ' if file needs changing. Can be used for CI checking.',
+					'boolean' => true,
+				],
+				'task' => [
+					'short' => 't',
+					'help' => 'Run specific task(s). Can be comma separated list.',
+					'default' => null,
+				],
+			],
+			'arguments' => [
+				'path' => [
+					'name' => 'path',
+					'help' => 'Path in your project or plugin. Defaults to src/',
+					'required' => false,
+				],
+			]
+		];
+
+		return parent::getOptionParser()
+			->setDescription('Illuminator PHP File Modifier.')
+			->addSubcommand('illuminate', [
+				'help' => 'Run Illuminator tasks over your PHP files.',
+				'parser' => $subcommandParser
+			]);
+	}
+
+	/**
+	 * @return \IdeHelper\Illuminator\Illuminator
+	 */
+	protected function getIlluminator() {
+		$tasks = $this->param('task') ? explode(',', $this->param('task')) : [];
+
+		$taskCollection = new TaskCollection($this->_io(), $this->params, $tasks);
+
+		return new Illuminator($taskCollection);
+	}
+
+	/**
+	 * @return \IdeHelper\Console\Io
+	 */
+	protected function _io() {
+		return new Io($this->getIo());
+	}
+
+}

--- a/src/Shell/IlluminatorShell.php
+++ b/src/Shell/IlluminatorShell.php
@@ -17,8 +17,6 @@ class IlluminatorShell extends Shell {
 	const CODE_CHANGES = 2;
 
 	/**
-	 * Generates CodeCompletation.php files.
-	 *
 	 * @param string|null $path
 	 * @return int
 	 */

--- a/src/Shell/IlluminatorShell.php
+++ b/src/Shell/IlluminatorShell.php
@@ -6,6 +6,7 @@ use Cake\Core\Plugin;
 use IdeHelper\Console\Io;
 use IdeHelper\Illuminator\Illuminator;
 use IdeHelper\Illuminator\TaskCollection;
+use InvalidArgumentException;
 
 /**
  * Shell for modifying your PHP files based on Illuminator rulesets.
@@ -33,7 +34,7 @@ class IlluminatorShell extends Shell {
 		}
 		$path = $root . $path;
 		if (!is_dir($path)) {
-			throw new \InvalidArgumentException('Path does not exist: ' . $path);
+			throw new InvalidArgumentException('Path does not exist: ' . $path);
 		}
 
 		$illuminator = $this->getIlluminator();

--- a/src/Shell/IlluminatorShell.php
+++ b/src/Shell/IlluminatorShell.php
@@ -47,6 +47,8 @@ class IlluminatorShell extends Shell {
 	 * @return \Cake\Console\ConsoleOptionParser
 	 */
 	public function getOptionParser() {
+		$tasks = $this->getTaskList();
+
 		$subcommandParser = [
 			'options' => [
 				'dry-run' => [
@@ -56,7 +58,7 @@ class IlluminatorShell extends Shell {
 				],
 				'task' => [
 					'short' => 't',
-					'help' => 'Run specific task(s). Can be comma separated list.',
+					'help' => 'Run specific task(s). Can be comma separated list. Available: ' . implode(', ', $tasks),
 					'default' => null,
 				],
 			],
@@ -93,6 +95,17 @@ class IlluminatorShell extends Shell {
 	 */
 	protected function _io() {
 		return new Io($this->getIo());
+	}
+
+	/**
+	 * @return string[]
+	 * @throws \RuntimeException
+	 * @throws \InvalidArgumentException
+	 */
+	protected function getTaskList() {
+		$taskCollection = new TaskCollection($this->_io(), $this->params);
+
+		return $taskCollection->taskNames();
 	}
 
 }

--- a/src/Shell/PhpstormShell.php
+++ b/src/Shell/PhpstormShell.php
@@ -54,7 +54,7 @@ class PhpstormShell extends Shell {
 			'options' => [
 				'dry-run' => [
 					'short' => 'd',
-					'help' => 'Dry run the task. This will output an error code ' . static::CODE_CHANGES . ' if file needs changing. Can be used for CI checking.',
+					'help' => 'Dry run the generation. This will output an error code ' . static::CODE_CHANGES . ' if file needs changing. Can be used for CI checking.',
 					'boolean' => true,
 				],
 			]

--- a/tests/TestCase/CodeCompletion/TaskCollectionTest.php
+++ b/tests/TestCase/CodeCompletion/TaskCollectionTest.php
@@ -24,7 +24,7 @@ class TaskCollectionTest extends TestCase {
 	/**
 	 * @return void
 	 */
-	public function testCollect() {
+	public function testTasks() {
 		$result = $this->taskCollection->tasks();
 
 		$this->assertNotEmpty($result);

--- a/tests/TestCase/Generator/TaskCollectionTest.php
+++ b/tests/TestCase/Generator/TaskCollectionTest.php
@@ -24,7 +24,7 @@ class TaskCollectionTest extends TestCase {
 	/**
 	 * @return void
 	 */
-	public function testCollect() {
+	public function testTasks() {
 		$result = $this->taskCollection->tasks();
 
 		$this->assertNotEmpty($result);

--- a/tests/TestCase/Illuminator/IlluminatorTest.php
+++ b/tests/TestCase/Illuminator/IlluminatorTest.php
@@ -60,7 +60,9 @@ class IlluminatorTest extends TestCase {
 		$this->assertSame(5, $count);
 
 		$out = $this->out->output();
-		$this->assertTextContains('public const FIELD_ID = \'id\';', $out);
+
+		$visbility = version_compare(PHP_VERSION, '7.1') >= 0 ? 'public ' : '';
+		$this->assertTextContains($visbility . 'const FIELD_ID = \'id\';', $out);
 	}
 
 }

--- a/tests/TestCase/Illuminator/IlluminatorTest.php
+++ b/tests/TestCase/Illuminator/IlluminatorTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace IdeHelper\Test\TestCase\Annotator;
+
+use Cake\Console\ConsoleIo;
+use IdeHelper\Console\Io;
+use IdeHelper\Illuminator\Illuminator;
+use IdeHelper\Illuminator\TaskCollection;
+use Tools\TestSuite\ConsoleOutput;
+use Tools\TestSuite\TestCase;
+
+class IlluminatorTest extends TestCase {
+
+	use DiffHelperTrait;
+
+	/**
+	 * @var \Tools\TestSuite\ConsoleOutput
+	 */
+	protected $out;
+
+	/**
+	 * @var \Tools\TestSuite\ConsoleOutput
+	 */
+	protected $err;
+
+	/**
+	 * @var \IdeHelper\Console\Io
+	 */
+	protected $io;
+
+	/**
+	 * @var \IdeHelper\Illuminator\Illuminator
+	 */
+	protected $illuminator;
+
+	/**
+	 * @return void
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->out = new ConsoleOutput();
+		$this->err = new ConsoleOutput();
+		$consoleIo = new ConsoleIo($this->out, $this->err);
+		$consoleIo->level($consoleIo::VERBOSE);
+		$this->io = new Io($consoleIo);
+
+		$taskCollection = new TaskCollection($this->io, ['dry-run' => true]);
+
+		$this->illuminator = new Illuminator($taskCollection);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testIlluminate() {
+		$path = TEST_FILES;
+		$count = $this->illuminator->illuminate($path);
+
+		$this->assertSame(5, $count);
+
+		$out = $this->out->output();
+		$this->assertTextContains('public const FIELD_ID = \'id\';', $out);
+	}
+
+}

--- a/tests/TestCase/Illuminator/Task/EntityFieldTaskTest.php
+++ b/tests/TestCase/Illuminator/Task/EntityFieldTaskTest.php
@@ -74,6 +74,38 @@ class EntityFieldTaskTest extends TestCase {
 	/**
 	 * @return void
 	 */
+	public function testIlluminateExisting() {
+		$task = $this->_getTask([
+			'visibility' => false,
+		]);
+
+		$path = TEST_FILES . 'Model/Entity/Constants/Wheel.php';
+		$result = $task->run(file_get_contents($path), $path);
+
+		$result = str_replace('    ', "\t", $result);
+		$expected = file_get_contents(TEST_FILES . 'Model/Entity/Constants/Wheel.php');
+		$this->assertTextEquals($expected, $result);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testIlluminateExistingPartial() {
+		$task = $this->_getTask([
+			'visibility' => false,
+		]);
+
+		$path = TEST_FILES . 'Model/Entity/ConstantsPartial/Wheel.php';
+		$result = $task->run(file_get_contents($path), $path);
+
+		$result = str_replace('    ', "\t", $result);
+		$expected = file_get_contents(TEST_FILES . 'Model/Entity/ConstantsPartialResult/Wheel.php');
+		$this->assertTextEquals($expected, $result);
+	}
+
+	/**
+	 * @return void
+	 */
 	public function testIlluminateVisibility() {
 		$task = $this->_getTask([
 			'visibility' => true,

--- a/tests/TestCase/Illuminator/Task/EntityFieldTaskTest.php
+++ b/tests/TestCase/Illuminator/Task/EntityFieldTaskTest.php
@@ -43,13 +43,13 @@ class EntityFieldTaskTest extends TestCase {
 	/**
 	 * @return void
 	 */
-	public function testIsApplicable() {
+	public function testShouldRun() {
 		$task = $this->_getTask();
 
-		$result = $task->isApplicable('src/Model/Entity/Wheel.php');
+		$result = $task->shouldRun('src/Model/Entity/Wheel.php');
 		$this->assertTrue($result);
 
-		$result = $task->isApplicable('src/Model/Table/Wheels.php');
+		$result = $task->shouldRun('src/Model/Table/Wheels.php');
 		$this->assertFalse($result);
 	}
 

--- a/tests/TestCase/Illuminator/Task/EntityFieldTaskTest.php
+++ b/tests/TestCase/Illuminator/Task/EntityFieldTaskTest.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace IdeHelper\Test\TestCase\Annotator;
+
+use Cake\Console\ConsoleIo;
+use IdeHelper\Annotator\AbstractAnnotator;
+use IdeHelper\Console\Io;
+use IdeHelper\Illuminator\Task\EntityFieldTask;
+use Tools\TestSuite\ConsoleOutput;
+use Tools\TestSuite\TestCase;
+
+class EntityFieldTaskTest extends TestCase {
+
+	use DiffHelperTrait;
+
+	/**
+	 * @var \Tools\TestSuite\ConsoleOutput
+	 */
+	protected $out;
+
+	/**
+	 * @var \Tools\TestSuite\ConsoleOutput
+	 */
+	protected $err;
+
+	/**
+	 * @var \IdeHelper\Console\Io
+	 */
+	protected $io;
+
+	/**
+	 * @return void
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->out = new ConsoleOutput();
+		$this->err = new ConsoleOutput();
+		$consoleIo = new ConsoleIo($this->out, $this->err);
+		$this->io = new Io($consoleIo);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testIsApplicable() {
+		$task = $this->_getTask();
+
+		$result = $task->isApplicable('src/Model/Entity/Wheel.php');
+		$this->assertTrue($result);
+
+		$result = $task->isApplicable('src/Model/Table/Wheels.php');
+		$this->assertFalse($result);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testIlluminate() {
+		$task = $this->_getTask([
+			'visibility' => false,
+		]);
+
+		$path = TEST_FILES . 'Model/Entity/Wheel.php';
+		$result = $task->run(file_get_contents($path), $path);
+
+		$this->assertTextContains('const FIELD_ID = \'id\';', $result);
+
+		$expected = file_get_contents(TEST_FILES . 'Model/Entity/Constants/Wheel.php');
+		$this->assertTextEquals($expected, $result);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testIlluminateVisibility() {
+		$task = $this->_getTask([
+			'visibility' => true,
+		]);
+
+		$path = TEST_FILES . 'Model/Entity/Wheel.php';
+		$result = $task->run(file_get_contents($path), $path);
+
+		$this->assertTextContains('public const FIELD_ID = \'id\';', $result);
+	}
+
+	/**
+	 * @param array $params
+	 * @return \IdeHelper\Illuminator\Task\EntityFieldTask
+	 */
+	protected function _getTask(array $params = []) {
+		$params += [
+			AbstractAnnotator::CONFIG_DRY_RUN => true,
+			AbstractAnnotator::CONFIG_VERBOSE => true,
+		];
+		return new EntityFieldTask($params);
+	}
+
+}

--- a/tests/TestCase/Illuminator/Task/EntityFieldTaskTest.php
+++ b/tests/TestCase/Illuminator/Task/EntityFieldTaskTest.php
@@ -66,6 +66,7 @@ class EntityFieldTaskTest extends TestCase {
 
 		$this->assertTextContains('const FIELD_ID = \'id\';', $result);
 
+		$result = str_replace('    ', "\t", $result);
 		$expected = file_get_contents(TEST_FILES . 'Model/Entity/Constants/Wheel.php');
 		$this->assertTextEquals($expected, $result);
 	}

--- a/tests/TestCase/Shell/IlluminatorShellTest.php
+++ b/tests/TestCase/Shell/IlluminatorShellTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace IdeHelper\Test\TestCase\Shell;
+
+use Cake\Console\ConsoleIo;
+use IdeHelper\Shell\IlluminatorShell;
+use Tools\TestSuite\ConsoleOutput;
+use Tools\TestSuite\TestCase;
+
+class IlluminatorShellTest extends TestCase {
+
+	/**
+	 * @var array
+	 */
+	public $fixtures = [
+		'plugin.ide_helper.cars',
+		'plugin.ide_helper.wheels',
+	];
+
+	/**
+	 * @var \IdeHelper\Shell\IlluminatorShell|\PHPUnit\Framework\MockObject\MockObject
+	 */
+	protected $Shell;
+
+	/**
+	 * @var \Tools\TestSuite\ConsoleOutput
+	 */
+	protected $out;
+
+	/**
+	 * @var \Tools\TestSuite\ConsoleOutput
+	 */
+	protected $err;
+
+	/**
+	 * @return void
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->out = new ConsoleOutput();
+		$this->err = new ConsoleOutput();
+		$io = new ConsoleIo($this->out, $this->err);
+
+		$this->Shell = $this->getMockBuilder(IlluminatorShell::class)
+			->setMethods(['_stop'])
+			->setConstructorArgs([$io])
+			->getMock();
+	}
+
+	/**
+	 * @return void
+	 */
+	public function tearDown() {
+		parent::tearDown();
+		unset($this->Shell);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testIlluminateDryRun() {
+		$result = $this->Shell->runCommand(['illuminate', '-d', '-v']);
+
+		$output = $this->out->output();
+		$this->assertTextContains('# /src/Illuminator/Illuminator.php', $output);
+
+		$this->assertSame(IlluminatorShell::CODE_SUCCESS, $result);
+	}
+
+}

--- a/tests/test_files/Model/Entity/Constants/Wheel.php
+++ b/tests/test_files/Model/Entity/Constants/Wheel.php
@@ -15,14 +15,14 @@ use Cake\ORM\Entity;
  */
 class Wheel extends Entity {
 
-    const FIELD_ID = 'id';
-    const FIELD_NAME = 'name';
-    const FIELD_CONTENT = 'content';
-    const FIELD_CREATED = 'created';
-    const FIELD_MODIFIED = 'modified';
-    const FIELD_VIRTUAL_ONE = 'virtual_one';
-    const FIELD_VIRTUAL_TWO = 'virtual_two';
-    const FIELD_WHEELS = 'wheels';
+	const FIELD_ID = 'id';
+	const FIELD_NAME = 'name';
+	const FIELD_CONTENT = 'content';
+	const FIELD_CREATED = 'created';
+	const FIELD_MODIFIED = 'modified';
+	const FIELD_VIRTUAL_ONE = 'virtual_one';
+	const FIELD_VIRTUAL_TWO = 'virtual_two';
+	const FIELD_WHEELS = 'wheels';
 
 	/**
 	 * @var array

--- a/tests/test_files/Model/Entity/Constants/Wheel.php
+++ b/tests/test_files/Model/Entity/Constants/Wheel.php
@@ -1,0 +1,55 @@
+<?php
+namespace App\Model\Entity;
+
+use Cake\ORM\Entity;
+
+/**
+ * @property int $id
+ * @property string $name
+ * @property string $content
+ * @property \Cake\I18n\FrozenTime $created
+ * @property \Cake\I18n\FrozenTime|null $modified
+ * @property string|null $virtual_one
+ * @property mixed $virtual_two
+ * @property \App\Model\Entity\Wheel[] $wheels
+ */
+class Wheel extends Entity {
+
+    const FIELD_ID = 'id';
+    const FIELD_NAME = 'name';
+    const FIELD_CONTENT = 'content';
+    const FIELD_CREATED = 'created';
+    const FIELD_MODIFIED = 'modified';
+    const FIELD_VIRTUAL_ONE = 'virtual_one';
+    const FIELD_VIRTUAL_TWO = 'virtual_two';
+    const FIELD_WHEELS = 'wheels';
+
+	/**
+	 * @var array
+	 */
+	protected $_virtual = [
+		'virtual_one',
+	];
+
+	/**
+	 * @return string|null
+	 */
+	protected function _getVirtualOne() {
+		return 'Virtual One';
+	}
+
+	protected function _getVirtualTwo() {
+		// Missing return type and docblock means mixed as result
+		return 'Virtual Two';
+	}
+
+	/**
+	 * @param \App\Model\Entity\Wheel[] $wheels
+	 *
+	 * @return \App\Model\Entity\Wheel[]
+	 */
+	protected function _getWheels($wheels = []) {
+		return $wheels;
+	}
+
+}

--- a/tests/test_files/Model/Entity/ConstantsPartial/Wheel.php
+++ b/tests/test_files/Model/Entity/ConstantsPartial/Wheel.php
@@ -15,6 +15,8 @@ use Cake\ORM\Entity;
  */
 class Wheel extends Entity {
 
+	const OTHER_NAME = 'unrelated';
+
 	const FIELD_ID = 'id';
 	const FIELD_NAME = 'name';
 	const FIELD_CONTENT = 'content';

--- a/tests/test_files/Model/Entity/ConstantsPartial/Wheel.php
+++ b/tests/test_files/Model/Entity/ConstantsPartial/Wheel.php
@@ -15,6 +15,13 @@ use Cake\ORM\Entity;
  */
 class Wheel extends Entity {
 
+	const FIELD_ID = 'id';
+	const FIELD_NAME = 'name';
+	const FIELD_CONTENT = 'content';
+	const FIELD_CREATED = 'created';
+	const FIELD_VIRTUAL_TWO = 'virtual_two';
+	const FIELD_WHEELS = 'wheels';
+
 	/**
 	 * @var array
 	 */
@@ -42,14 +49,5 @@ class Wheel extends Entity {
 	protected function _getWheels($wheels = []) {
 		return $wheels;
 	}
-
-	const FIELD_ID = 'id';
-	const FIELD_NAME = 'name';
-	const FIELD_CONTENT = 'content';
-	const FIELD_CREATED = 'created';
-	const FIELD_MODIFIED = 'modified';
-	const FIELD_VIRTUAL_ONE = 'virtual_one';
-	const FIELD_VIRTUAL_TWO = 'virtual_two';
-	const FIELD_WHEELS = 'wheels';
 
 }

--- a/tests/test_files/Model/Entity/ConstantsPartialResult/Wheel.php
+++ b/tests/test_files/Model/Entity/ConstantsPartialResult/Wheel.php
@@ -15,6 +15,8 @@ use Cake\ORM\Entity;
  */
 class Wheel extends Entity {
 
+	const OTHER_NAME = 'unrelated';
+
 	const FIELD_ID = 'id';
 	const FIELD_NAME = 'name';
 	const FIELD_CONTENT = 'content';

--- a/tests/test_files/Model/Entity/ConstantsPartialResult/Wheel.php
+++ b/tests/test_files/Model/Entity/ConstantsPartialResult/Wheel.php
@@ -15,6 +15,15 @@ use Cake\ORM\Entity;
  */
 class Wheel extends Entity {
 
+	const FIELD_ID = 'id';
+	const FIELD_NAME = 'name';
+	const FIELD_CONTENT = 'content';
+	const FIELD_CREATED = 'created';
+	const FIELD_VIRTUAL_TWO = 'virtual_two';
+	const FIELD_WHEELS = 'wheels';
+	const FIELD_MODIFIED = 'modified';
+	const FIELD_VIRTUAL_ONE = 'virtual_one';
+
 	/**
 	 * @var array
 	 */
@@ -42,14 +51,5 @@ class Wheel extends Entity {
 	protected function _getWheels($wheels = []) {
 		return $wheels;
 	}
-
-	const FIELD_ID = 'id';
-	const FIELD_NAME = 'name';
-	const FIELD_CONTENT = 'content';
-	const FIELD_CREATED = 'created';
-	const FIELD_MODIFIED = 'modified';
-	const FIELD_VIRTUAL_ONE = 'virtual_one';
-	const FIELD_VIRTUAL_TWO = 'virtual_two';
-	const FIELD_WHEELS = 'wheels';
 
 }


### PR DESCRIPTION
Starting https://github.com/dereuromark/cakephp-ide-helper/issues/107

Tasks:
- EntityField: Add class const for all fields for cleaner usage in IDEs (incl refactor possibilities).

Todo:
- auto skip already existing const.
- tests
- edge cases (const at end, mixed with comments, etc)
- **refactor to use schema!** The annotations are not helpful as they also contain virtual fields etc. Those should probably be VIRTUAL_X instead of FIELD_X here?

I think we could even use F_ and V_ prefix here, to make things shorter while still being clear.