### PR TITLE
Fix controller model annotating for plugins.

### DIFF
--- a/src/Annotator/ControllerAnnotator.php
+++ b/src/Annotator/ControllerAnnotator.php
@@ -273,14 +273,13 @@ class ControllerAnnotator extends AbstractAnnotator {
 
 		if ($this->getConfig(static::CONFIG_PLUGIN)) {
 			$pluginModelClass = $this->getConfig(static::CONFIG_PLUGIN) . '.' . $modelClass;
-			if (App::className($pluginModelClass, 'Model/Table', 'Table')) {
-				$modelClass = $pluginModelClass;
-			}
+			$className = App::className($pluginModelClass, 'Model/Table', 'Table');
 		} else {
 			$className = App::className($modelClass, 'Model/Table', 'Table');
-			if (!$className) {
-				return null;
-			}
+		}
+
+		if (!$className) {
+			return null;
 		}
 
 		return $modelClass;


### PR DESCRIPTION
This solves the issue of https://github.com/dereuromark/cakephp-ide-helper/issues/128 for now

The core itself is a bit dirty here as it sets a guessed/inflected name even if set to false. 
But thats another issue.