### PR TITLE
Add uses annotations for magically/indirectly invoked test classes.

### DIFF
--- a/docs/Annotations.md
+++ b/docs/Annotations.md
@@ -266,6 +266,15 @@ Out of the box the following tasks are run:
 
 Any `use ModelAwareTrait` usage together with `$this->loadModel(...)` calls will add the required annotation on top of the class.
 
+### Test
+
+Any test class of specific types can be annotated with the corresponding class it tests.
+This is mainly useful for the following types, as they are invoked indirectly via Integration test harness:
+- Controller
+- Command
+
+Here the `@uses` statements added help to quick-jump to the class if needed.
+
 ### Custom Tasks
 
 Just create your own Task class:

--- a/src/Annotation/AnnotationFactory.php
+++ b/src/Annotation/AnnotationFactory.php
@@ -45,10 +45,14 @@ class AnnotationFactory {
 	public static function createFromString($annotation) {
 		preg_match('/^\@mixin (.+)\s*(.+)?$/', $annotation, $matches);
 		if ($matches) {
-			return static::create('@mixin', $matches[1]);
+			return static::create(MixinAnnotation::TAG, $matches[1]);
+		}
+		preg_match('/^\@uses (.+)\s*(.+)?$/', $annotation, $matches);
+		if ($matches) {
+			return static::create(UsesAnnotation::TAG, $matches[1]);
 		}
 
-		preg_match('/^(\@property|\@method|\@var|\@param|\@uses) ([^ ]+) (.+)$/', $annotation, $matches);
+		preg_match('/^(\@property|\@method|\@var|\@param) ([^ ]+) (.+)$/', $annotation, $matches);
 		if (!$matches) {
 			return null;
 		}

--- a/src/Annotation/AnnotationFactory.php
+++ b/src/Annotation/AnnotationFactory.php
@@ -30,6 +30,8 @@ class AnnotationFactory {
 				return new MixinAnnotation($type, $index);
 			case ParamAnnotation::TAG:
 				return new ParamAnnotation($type, $content, $index);
+			case UsesAnnotation::TAG:
+				return new UsesAnnotation($type, $index);
 		}
 
 		return null;
@@ -46,7 +48,7 @@ class AnnotationFactory {
 			return static::create('@mixin', $matches[1]);
 		}
 
-		preg_match('/^(\@property|\@method|\@var|\@param) ([^ ]+) (.+)$/', $annotation, $matches);
+		preg_match('/^(\@property|\@method|\@var|\@param|\@uses) ([^ ]+) (.+)$/', $annotation, $matches);
 		if (!$matches) {
 			return null;
 		}

--- a/src/Annotation/UsesAnnotation.php
+++ b/src/Annotation/UsesAnnotation.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace IdeHelper\Annotation;
+
+class UsesAnnotation extends AbstractAnnotation {
+
+	const TAG = '@uses';
+
+	/**
+	 * @var string
+	 */
+	protected $description;
+
+	/**
+	 * @param string $type
+	 * @param int|null $index
+	 */
+	public function __construct($type, $index = null) {
+		$description = '';
+		if (strpos($type, ' ') !== false) {
+			list($type, $description) = explode(' ', $type, 2);
+		}
+
+		parent::__construct($type, $index);
+
+		$this->description = $description;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getDescription() {
+		return $this->description;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function build() {
+		$description = $this->description !== '' ? (' ' . $this->description) : '';
+
+		return $this->type . $description;
+	}
+
+	/**
+	 * @param \IdeHelper\Annotation\AbstractAnnotation|\IdeHelper\Annotation\MixinAnnotation $annotation
+	 *
+	 * @return bool
+	 */
+	public function matches(AbstractAnnotation $annotation) {
+		if (!$annotation instanceof self) {
+			return false;
+		}
+		if ($annotation->getType() !== $this->type) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * @param \IdeHelper\Annotation\AbstractAnnotation|\IdeHelper\Annotation\MixinAnnotation $annotation
+	 * @return void
+	 */
+	public function replaceWith(AbstractAnnotation $annotation) {
+		$this->type = $annotation->getType();
+	}
+
+}

--- a/src/Annotator/AbstractAnnotator.php
+++ b/src/Annotator/AbstractAnnotator.php
@@ -46,7 +46,7 @@ abstract class AbstractAnnotator {
 	const COUNT_ADDED = 'added';
 	const COUNT_SKIPPED = 'skipped';
 
-	const TYPES = ['@property', '@var', '@method', '@mixin'];
+	const TYPES = ['@property', '@var', '@method', '@mixin', '@uses'];
 
 	/**
 	 * @var bool

--- a/src/Annotator/CallbackAnnotatorTaskCollection.php
+++ b/src/Annotator/CallbackAnnotatorTaskCollection.php
@@ -38,7 +38,7 @@ class CallbackAnnotatorTaskCollection {
 	/**
 	 * @return string[]
 	 */
-	protected function defaultTasks() {
+	public function defaultTasks() {
 		$tasks = (array)Configure::read('IdeHelper.callbackAnnotatorTasks') + $this->defaultTasks;
 
 		foreach ($tasks as $k => $v) {

--- a/src/Annotator/ClassAnnotatorTask/AbstractClassAnnotatorTask.php
+++ b/src/Annotator/ClassAnnotatorTask/AbstractClassAnnotatorTask.php
@@ -24,6 +24,15 @@ abstract class AbstractClassAnnotatorTask extends AbstractAnnotator {
 	}
 
 	/**
+	 * For testing only
+	 *
+	 * @return string
+	 */
+	public function getContent() {
+		return $this->content;
+	}
+
+	/**
 	 * @param string $path
 	 * @param string $content
 	 * @param \IdeHelper\Annotation\AbstractAnnotation[] $annotations
@@ -59,6 +68,8 @@ abstract class AbstractClassAnnotatorTask extends AbstractAnnotator {
 			$this->_reportSkipped();
 			return false;
 		}
+
+		$this->content = $newContent;
 
 		$this->_displayDiff($content, $newContent);
 		$this->_storeFile($path, $newContent);

--- a/src/Annotator/ClassAnnotatorTask/TestClassAnnotatorTask.php
+++ b/src/Annotator/ClassAnnotatorTask/TestClassAnnotatorTask.php
@@ -51,8 +51,7 @@ class TestClassAnnotatorTask extends AbstractClassAnnotatorTask implements Class
 	 * @param array $types
 	 * @return bool
 	 */
-	protected function matchesType($content, array $types)
-	{
+	protected function matchesType($content, array $types) {
 		foreach ($types as $type => $pattern) {
 			if (preg_match($pattern, $content)) {
 				return true;

--- a/src/Annotator/ClassAnnotatorTask/TestClassAnnotatorTask.php
+++ b/src/Annotator/ClassAnnotatorTask/TestClassAnnotatorTask.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace IdeHelper\Annotator\ClassAnnotatorTask;
+
+use Cake\Core\Configure;
+use IdeHelper\Annotation\AnnotationFactory;
+use IdeHelper\Annotation\UsesAnnotation;
+
+/**
+ * Classes that test a class in a magic-call way should automatically have `@uses` annotated.
+ * By default:
+ * - Controller tests
+ * - Command tests
+ *
+ * Use Configure key `IdeHelper.testClassPatterns` to add more types and their regex pattern.
+ */
+class TestClassAnnotatorTask extends AbstractClassAnnotatorTask implements ClassAnnotatorTaskInterface {
+
+	/**
+	 * Deprecated: $content, use $this->content instead.
+	 *
+	 * @param string $path
+	 * @param string $content
+	 * @return bool
+	 */
+	public function shouldRun($path, $content) {
+		if (strpos($path, DS . 'tests' . DS . 'TestCase' . DS) === false) {
+			return false;
+		}
+
+		$defaultTypes = (array)Configure::read('IdeHelper.testClassPatterns');
+		$types = $defaultTypes + [
+			'Controller' => '#class .+ControllerTest extends\b#',
+			'Command' => '#class .+CommandTest extends\b#'
+		];
+		$typeList = implode('|', array_keys($types));
+
+		if (!preg_match('#namespace .+\\\\Test\\\\TestCase\\\\(' . $typeList . ')\b#', $content)) {
+			return false;
+		}
+
+		if (!$this->matchesType($content, $types)) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * @param string $content
+	 * @param array $types
+	 * @return bool
+	 */
+	protected function matchesType($content, array $types)
+	{
+		foreach ($types as $type => $pattern) {
+			if (preg_match($pattern, $content)) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * @param string $path
+	 * @return bool
+	 */
+	public function annotate($path) {
+		$class = $this->_getTestedClass($this->content);
+		if (!$class) {
+			return false;
+		}
+
+		$annotations = $this->_buildUsesAnnotations([$class]);
+
+		return $this->_annotate($path, $this->content, $annotations);
+	}
+
+	/**
+	 * @param string $content
+	 *
+	 * @return string|null
+	 */
+	protected function _getTestedClass($content) {
+		preg_match('#namespace (.+);#', $content, $matches);
+		if (!$matches) {
+			return null;
+		}
+
+		$namespace = str_replace('\\Test\\TestCase\\', '\\', $matches[1]);
+
+		preg_match('#\bclass (.+)Test extends#', $content, $matches);
+		if (!$matches) {
+			return null;
+		}
+		$className = $matches[1];
+
+		$fullClassName = $namespace . '\\' . $className;
+		if (!class_exists($fullClassName)) {
+			return null;
+		}
+
+		return $fullClassName;
+	}
+
+	/**
+	 * @param string[] $classes
+	 * @return \IdeHelper\Annotation\AbstractAnnotation[]
+	 */
+	protected function _buildUsesAnnotations(array $classes) {
+		$annotations = [];
+
+		foreach ($classes as $className) {
+			$annotations[] = AnnotationFactory::createOrFail(UsesAnnotation::TAG, '\\' . $className);
+		}
+
+		return $annotations;
+	}
+
+}

--- a/src/Annotator/ClassAnnotatorTaskCollection.php
+++ b/src/Annotator/ClassAnnotatorTaskCollection.php
@@ -3,6 +3,7 @@ namespace IdeHelper\Annotator;
 
 use Cake\Core\Configure;
 use IdeHelper\Annotator\ClassAnnotatorTask\ModelAwareClassAnnotatorTask;
+use IdeHelper\Annotator\ClassAnnotatorTask\TestClassAnnotatorTask;
 use IdeHelper\Console\Io;
 
 class ClassAnnotatorTaskCollection {
@@ -12,6 +13,7 @@ class ClassAnnotatorTaskCollection {
 	 */
 	protected $defaultTasks = [
 		ModelAwareClassAnnotatorTask::class => ModelAwareClassAnnotatorTask::class,
+		TestClassAnnotatorTask::class => TestClassAnnotatorTask::class,
 	];
 
 	/**
@@ -38,7 +40,7 @@ class ClassAnnotatorTaskCollection {
 	/**
 	 * @return string[]
 	 */
-	protected function defaultTasks() {
+	public function defaultTasks() {
 		$tasks = (array)Configure::read('IdeHelper.classAnnotatorTasks') + $this->defaultTasks;
 
 		foreach ($tasks as $k => $v) {

--- a/src/Annotator/ComponentAnnotator.php
+++ b/src/Annotator/ComponentAnnotator.php
@@ -4,6 +4,7 @@ namespace IdeHelper\Annotator;
 use Cake\Controller\ComponentRegistry;
 use Cake\Controller\Controller;
 use Cake\Core\App;
+use Exception;
 use IdeHelper\Annotation\AnnotationFactory;
 use IdeHelper\Annotation\PropertyAnnotation;
 use IdeHelper\Annotator\Traits\ComponentTrait;
@@ -48,7 +49,7 @@ class ComponentAnnotator extends AbstractAnnotator {
 		$controller = new Controller();
 		try {
 			$object = new $className(new ComponentRegistry($controller));
-		} catch (\Exception $e) {
+		} catch (Exception $e) {
 			if ($this->getConfig(static::CONFIG_VERBOSE)) {
 				$this->_io->warn('   Skipping component annotations: ' . $e->getMessage());
 			}

--- a/src/Annotator/HelperAnnotator.php
+++ b/src/Annotator/HelperAnnotator.php
@@ -7,6 +7,7 @@ use Exception;
 use IdeHelper\Annotation\AnnotationFactory;
 use IdeHelper\Annotation\PropertyAnnotation;
 use IdeHelper\Annotator\Traits\HelperTrait;
+use Throwable;
 
 class HelperAnnotator extends AbstractAnnotator {
 
@@ -36,7 +37,7 @@ class HelperAnnotator extends AbstractAnnotator {
 				$this->_io->warn('   Skipping helper annotations: ' . $e->getMessage());
 			}
 			return false;
-		} catch (\Throwable $e) {
+		} catch (Throwable $e) {
 			if ($this->getConfig(static::CONFIG_VERBOSE)) {
 				$this->_io->warn('   Skipping helper annotations: ' . $e->getMessage());
 			}

--- a/src/Annotator/ShellAnnotator.php
+++ b/src/Annotator/ShellAnnotator.php
@@ -6,6 +6,7 @@ use Exception;
 use IdeHelper\Annotation\AnnotationFactory;
 use IdeHelper\Annotation\PropertyAnnotation;
 use ReflectionClass;
+use Throwable;
 
 class ShellAnnotator extends AbstractAnnotator {
 
@@ -100,7 +101,7 @@ class ShellAnnotator extends AbstractAnnotator {
 				$this->_io->warn('   Skipping shell task annotations: ' . $e->getMessage());
 			}
 			return [];
-		} catch (\Throwable $e) {
+		} catch (Throwable $e) {
 			if ($this->getConfig(static::CONFIG_VERBOSE)) {
 				$this->_io->warn('   Skipping shell task annotations: ' . $e->getMessage());
 			}

--- a/src/Shell/AnnotationsShell.php
+++ b/src/Shell/AnnotationsShell.php
@@ -9,6 +9,8 @@ use Cake\Utility\Inflector;
 use IdeHelper\Annotator\AbstractAnnotator;
 use IdeHelper\Annotator\CallbackAnnotator;
 use IdeHelper\Annotator\ClassAnnotator;
+use IdeHelper\Annotator\ClassAnnotatorTaskCollection;
+use IdeHelper\Annotator\ClassAnnotatorTask\TestClassAnnotatorTask;
 use IdeHelper\Annotator\CommandAnnotator;
 use IdeHelper\Annotator\ComponentAnnotator;
 use IdeHelper\Annotator\ControllerAnnotator;
@@ -218,13 +220,28 @@ class AnnotationsShell extends Shell {
 		$plugin = $this->param('plugin') ?: null;
 
 		$path = $plugin ? PluginPath::get($plugin) : ROOT . DS;
-
 		$path .= 'src' . DS;
 
 		$folder = new Folder($path);
-
 		$folders = $folder->subdirectories();
+		foreach ($folders as $folder) {
+			$this->_classes($folder . DS);
+		}
 
+		$collection = new ClassAnnotatorTaskCollection();
+		$tasks = $collection->defaultTasks();
+		if (!in_array(TestClassAnnotatorTask::class, $tasks, true)) {
+			return;
+		}
+
+		$path = $plugin ? PluginPath::get($plugin) : ROOT . DS;
+		$path .= 'tests' . DS . 'TestCase' . DS;
+		if (!is_dir($path)) {
+			return;
+		}
+
+		$folder = new Folder($path);
+		$folders = $folder->subdirectories();
 		foreach ($folders as $folder) {
 			$this->_classes($folder . DS);
 		}

--- a/src/Utility/PluginPath.php
+++ b/src/Utility/PluginPath.php
@@ -2,6 +2,7 @@
 
 namespace IdeHelper\Utility;
 
+use Cake\Core\Exception\MissingPluginException;
 use Cake\Core\Plugin;
 
 class PluginPath {
@@ -14,7 +15,7 @@ class PluginPath {
 	public static function get($plugin) {
 		try {
 			return Plugin::path($plugin);
-		} catch (\Cake\Core\Exception\MissingPluginException $exception) {
+		} catch (MissingPluginException $exception) {
 		}
 
 		$pathToPlugin = Plugin::getCollection()->findPath($plugin);

--- a/tests/TestCase/Annotation/AnnotationFactoryTest.php
+++ b/tests/TestCase/Annotation/AnnotationFactoryTest.php
@@ -80,6 +80,11 @@ class AnnotationFactoryTest extends TestCase {
 		$annotation = AnnotationFactory::createFromString('@mixin \\Foo\\Model\\Entity\\Bar !');
 		$this->assertInstanceOf(MixinAnnotation::class, $annotation);
 		$this->assertSame('!', $annotation->getDescription());
+
+		/** @var \IdeHelper\Annotation\UsesAnnotation $annotation */
+		$annotation = AnnotationFactory::createFromString('@uses \\Foo\\Model\\Entity\\Bar');
+		$this->assertInstanceOf(UsesAnnotation::class, $annotation);
+		$this->assertSame('', $annotation->getDescription());
 	}
 
 }

--- a/tests/TestCase/Annotation/AnnotationFactoryTest.php
+++ b/tests/TestCase/Annotation/AnnotationFactoryTest.php
@@ -6,6 +6,7 @@ use IdeHelper\Annotation\AnnotationFactory;
 use IdeHelper\Annotation\MethodAnnotation;
 use IdeHelper\Annotation\MixinAnnotation;
 use IdeHelper\Annotation\PropertyAnnotation;
+use IdeHelper\Annotation\UsesAnnotation;
 use Tools\TestSuite\TestCase;
 
 class AnnotationFactoryTest extends TestCase {
@@ -25,6 +26,9 @@ class AnnotationFactoryTest extends TestCase {
 
 		$annotation = AnnotationFactory::create('@mixin', '\\Foo\\Model\\Entity\\Bar');
 		$this->assertInstanceOf(MixinAnnotation::class, $annotation);
+
+		$annotation = AnnotationFactory::create('@uses', '\\Foo\\Model\\Entity\\Bar');
+		$this->assertInstanceOf(UsesAnnotation::class, $annotation);
 
 		$annotation = AnnotationFactory::create('@foooo', '\\Foo', '$foo');
 		$this->assertNull($annotation);

--- a/tests/TestCase/Annotation/UsesAnnotationTest.php
+++ b/tests/TestCase/Annotation/UsesAnnotationTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace IdeHelper\Test\TestCase\Annotation;
+
+use IdeHelper\Annotation\PropertyAnnotation;
+use IdeHelper\Annotation\UsesAnnotation;
+use Tools\TestSuite\TestCase;
+
+class UsesAnnotationTest extends TestCase {
+
+	/**
+	 * @return void
+	 */
+	public function testBuild() {
+		$annotation = new UsesAnnotation('\\Foo\\Model\\Entity\\Bar');
+
+		$result = (string)$annotation;
+		$this->assertSame('@uses \\Foo\\Model\\Entity\\Bar', $result);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testReplaceWith() {
+		$replacementAnnotation = new UsesAnnotation('\\Something\\Model\\Entity\\Else');
+
+		$annotation = new UsesAnnotation('\\Foo\\Model\\Entity\\Bar');
+		$annotation->replaceWith($replacementAnnotation);
+
+		$result = (string)$annotation;
+		$this->assertSame('@uses \\Something\\Model\\Entity\\Else', $result);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testMatches() {
+		$annotation = new UsesAnnotation('\\Foo\\Model\\Entity\\Bar');
+		$comparisonAnnotation = new UsesAnnotation('\\Foo\\Model\\Entity\\Bar');
+		$result = $annotation->matches($comparisonAnnotation);
+		$this->assertTrue($result);
+
+		$annotation = new UsesAnnotation('\\Foo\\Model\\Entity\\Bar');
+		$comparisonAnnotation = new UsesAnnotation('\\Foo\\Model\\Entity\\BarBaz');
+		$result = $annotation->matches($comparisonAnnotation);
+		$this->assertFalse($result);
+
+		$annotation = new UsesAnnotation('\\Foo\\Model\\Entity\\Bar');
+		$comparisonAnnotation = new PropertyAnnotation('\\Foo\\Model\\Entity\\Bar', '$bar');
+		$result = $annotation->matches($comparisonAnnotation);
+		$this->assertFalse($result);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testMatchesWithDescription() {
+		$annotation = new UsesAnnotation('\\Foo\\Model\\Entity\\Bar !');
+		$comparisonAnnotation = new UsesAnnotation('\\Foo\\Model\\Entity\\Bar');
+		$result = $annotation->matches($comparisonAnnotation);
+		$this->assertTrue($result);
+		$this->assertSame('!', $annotation->getDescription());
+		$this->assertSame('', $comparisonAnnotation->getDescription());
+
+		$annotation = new UsesAnnotation('\\Foo\\Model\\Entity\\Bar');
+		$comparisonAnnotation = new UsesAnnotation('\\Foo\\Model\\Entity\\Bar !');
+		$result = $annotation->matches($comparisonAnnotation);
+		$this->assertTrue($result);
+		$this->assertSame('', $annotation->getDescription());
+		$this->assertSame('!', $comparisonAnnotation->getDescription());
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testIndex() {
+		$annotation = new UsesAnnotation('', 1);
+
+		$this->assertTrue($annotation->hasIndex());
+		$this->assertSame(1, $annotation->getIndex());
+	}
+
+	/**
+	 * @expectedException \RuntimeException
+	 * @return void
+	 */
+	public function testIndexInvalidCall() {
+		$annotation = new UsesAnnotation('');
+
+		$this->assertFalse($annotation->hasIndex());
+
+		$annotation->getIndex();
+	}
+
+}

--- a/tests/TestCase/Annotator/ClassAnnotatorTask/TestClassAnnotatorTaskTest.php
+++ b/tests/TestCase/Annotator/ClassAnnotatorTask/TestClassAnnotatorTaskTest.php
@@ -85,6 +85,35 @@ TXT;
 	}
 
 	/**
+	 * @return void
+	 */
+	public function testAnnotateExisting() {
+		$content = <<<TXT
+<?php
+namespace App\Test\TestCase\Controller;
+
+use Cake\TestSuite\IntegrationTestCase;
+
+/**
+ * @uses \App\Controller\BarController
+ */
+class BarControllerTest extends IntegrationTestCase {}
+TXT;
+		$task = $this->getTask($content);
+		$path = '/tests/TestCase/Controller/BarControllerTest.php';
+
+		$result = $task->annotate($path);
+		$this->assertFalse($result);
+
+		$content = $task->getContent();
+		$count = substr_count($content, '@uses');
+		$this->assertSame(1, $count);
+
+		$output = (string)$this->out->output();
+		$this->assertSame('', $output);
+	}
+
+	/**
 	 * @param string $content
 	 * @param array $params
 	 *

--- a/tests/TestCase/Annotator/ClassAnnotatorTask/TestClassAnnotatorTaskTest.php
+++ b/tests/TestCase/Annotator/ClassAnnotatorTask/TestClassAnnotatorTaskTest.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace IdeHelper\Test\TestCase\Annotator\ClassAnnotatorTask;
+
+use Cake\Console\ConsoleIo;
+use IdeHelper\Annotator\AbstractAnnotator;
+use IdeHelper\Annotator\ClassAnnotatorTask\TestClassAnnotatorTask;
+use IdeHelper\Console\Io;
+use Tools\TestSuite\ConsoleOutput;
+use Tools\TestSuite\TestCase;
+
+class TestClassAnnotatorTaskTest extends TestCase {
+
+	/**
+	 * @var \Tools\TestSuite\ConsoleOutput
+	 */
+	protected $out;
+
+	/**
+	 * @var \Tools\TestSuite\ConsoleOutput
+	 */
+	protected $err;
+
+	/**
+	 * @var \IdeHelper\Console\Io
+	 */
+	protected $io;
+
+	/**
+	 * @return void
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->out = new ConsoleOutput();
+		$this->err = new ConsoleOutput();
+		$consoleIo = new ConsoleIo($this->out, $this->err);
+		$this->io = new Io($consoleIo);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testShouldRun() {
+		$task = $this->getTask('');
+
+		$content = 'namespace App\Test\TestCase\Controller\FooControllerTest.php' . PHP_EOL . 'class FooControllerTest extends ControllerIntegrationTestCase';
+		$result = $task->shouldRun('/tests/TestCase/Foo.php', $content);
+		$this->assertTrue($result);
+
+		$content = 'namespace App\Test\TestCase\Command\FooCommandTest.php' . PHP_EOL . 'class FooCommandTest extends ConsoleIntegrationTestCase';
+		$result = $task->shouldRun('/tests/TestCase/Foo.php', $content);
+		$this->assertTrue($result);
+
+		$result = $task->shouldRun('/tests/TestCase/Foo.php', 'namespace App\Foo\Foo.php');
+		$this->assertFalse($result);
+
+		$result = $task->shouldRun('/tests/Foo.php', $content);
+		$this->assertFalse($result);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testAnnotate() {
+		$content = <<<TXT
+<?php
+namespace App\Test\TestCase\Controller;
+
+use Cake\TestSuite\IntegrationTestCase;
+
+class BarControllerTest extends IntegrationTestCase {}
+TXT;
+		$task = $this->getTask($content);
+		$path = '/tests/TestCase/Controller/BarControllerTest.php';
+
+		$result = $task->annotate($path);
+		$this->assertTrue($result);
+
+		$content = $task->getContent();
+		$this->assertTextContains('* @uses \App\Controller\BarController', $content);
+
+		$output = (string)$this->out->output();
+		$this->assertTextContains('  -> 1 annotation added.', $output);
+	}
+
+	/**
+	 * @param string $content
+	 * @param array $params
+	 *
+	 * @return \IdeHelper\Annotator\ClassAnnotatorTask\TestClassAnnotatorTask
+	 */
+	protected function getTask($content, array $params = []) {
+		$params += [
+			AbstractAnnotator::CONFIG_DRY_RUN => true,
+			AbstractAnnotator::CONFIG_VERBOSE => true,
+		];
+		return new TestClassAnnotatorTask($this->io, $params, $content);
+	}
+
+}


### PR DESCRIPTION
Resolves https://github.com/dereuromark/cakephp-ide-helper/issues/132 in a more useful way