### PR TITLE
Fix up nullable for optional relation property annotations.

### DIFF
--- a/src/Annotator/AbstractAnnotator.php
+++ b/src/Annotator/AbstractAnnotator.php
@@ -644,7 +644,7 @@ abstract class AbstractAnnotator {
 	}
 
 	/**
-	 * @param array $usedModels
+	 * @param string[] $usedModels
 	 * @param string $content
 	 * @return \IdeHelper\Annotation\AbstractAnnotation[]
 	 */

--- a/src/Annotator/ClassAnnotatorTask/ModelAwareClassAnnotatorTask.php
+++ b/src/Annotator/ClassAnnotatorTask/ModelAwareClassAnnotatorTask.php
@@ -37,7 +37,7 @@ class ModelAwareClassAnnotatorTask extends AbstractClassAnnotatorTask implements
 	/**
 	 * @param string $content
 	 *
-	 * @return array
+	 * @return string[]
 	 */
 	protected function _getUsedModels($content) {
 		preg_match_all('/\$this-\>loadModel\(\'([a-z.]+)\'/i', $content, $matches);

--- a/src/Annotator/CommandAnnotator.php
+++ b/src/Annotator/CommandAnnotator.php
@@ -44,7 +44,7 @@ class CommandAnnotator extends AbstractAnnotator {
 	/**
 	 * @param string $content
 	 *
-	 * @return array
+	 * @return string[]
 	 */
 	protected function _getUsedModels($content) {
 		preg_match_all('/\$this-\>loadModel\(\'([a-z.\/]+)\'/i', $content, $matches);

--- a/src/Annotator/ComponentAnnotator.php
+++ b/src/Annotator/ComponentAnnotator.php
@@ -30,15 +30,26 @@ class ComponentAnnotator extends AbstractAnnotator {
 			return false;
 		}
 
-		$annotations = [];
 		$content = file_get_contents($path);
+		$annotations = $this->_buildAnnotations($className);
+
+		return $this->_annotate($path, $content, $annotations);
+	}
+
+	/**
+	 * @param string $className
+	 *
+	 * @return \IdeHelper\Annotation\AbstractAnnotation[]
+	 */
+	protected function _buildAnnotations($className) {
+		$annotations = [];
 
 		$componentAnnotations = $this->_getComponentAnnotations($className);
 		foreach ($componentAnnotations as $componentAnnotation) {
 			$annotations[] = $componentAnnotation;
 		}
 
-		return $this->_annotate($path, $content, $annotations);
+		return $annotations;
 	}
 
 	/**

--- a/src/Annotator/ControllerAnnotator.php
+++ b/src/Annotator/ControllerAnnotator.php
@@ -83,7 +83,7 @@ class ControllerAnnotator extends AbstractAnnotator {
 	/**
 	 * @param string $content
 	 *
-	 * @return array
+	 * @return string[]
 	 */
 	protected function _getUsedModels($content) {
 		preg_match_all('/\$this-\>loadModel\(\'([a-z.]+)\'/i', $content, $matches);
@@ -132,7 +132,7 @@ class ControllerAnnotator extends AbstractAnnotator {
 	/**
 	 * @param string $controllerName
 	 *
-	 * @return array
+	 * @return string[]
 	 */
 	protected function _getUsedComponents($controllerName) {
 		$plugin = $controllerName !== 'AppController' ? $this->getConfig(static::CONFIG_PLUGIN) : null;
@@ -184,7 +184,7 @@ class ControllerAnnotator extends AbstractAnnotator {
 	 * @param string $content
 	 * @param string $primaryModelClass
 	 *
-	 * @return array
+	 * @return string[]
 	 */
 	protected function _extractPaginateEntityTypehints($content, $primaryModelClass) {
 		$models = [];

--- a/src/Annotator/EntityAnnotator.php
+++ b/src/Annotator/EntityAnnotator.php
@@ -166,7 +166,7 @@ class EntityAnnotator extends AbstractAnnotator {
 	 * @param array $propertySchema
 	 * @param \IdeHelper\View\Helper\DocBlockHelper $helper
 	 *
-	 * @return array
+	 * @return string[]
 	 */
 	protected function buildExtendedEntityPropertyHintTypeMap(array $propertySchema, DocBlockHelper $helper) {
 		$propertyHintMap = [];
@@ -207,7 +207,7 @@ class EntityAnnotator extends AbstractAnnotator {
 
 	/**
 	 * @param string $content
-	 * @return array
+	 * @return string[]
 	 */
 	protected function buildVirtualPropertyHintTypeMap($content) {
 		if (!preg_match('#\bfunction \_get[A-Z][a-zA-Z0-9]+\(\)#', $content)) {

--- a/src/Annotator/ModelAnnotator.php
+++ b/src/Annotator/ModelAnnotator.php
@@ -92,10 +92,21 @@ class ModelAnnotator extends AbstractAnnotator {
 	protected function _table($path, $entityName, array $associations, array $behaviors) {
 		$content = file_get_contents($path);
 
-		$entity = $entityName;
-
 		$behaviors += $this->_parseLoadedBehaviors($content);
+		$annotations = $this->_buildAnnotations($associations, $entityName, $behaviors);
 
+		return $this->_annotate($path, $content, $annotations);
+	}
+
+	/**
+	 * @param array $associations
+	 * @param string $entity
+	 * @param string[] $behaviors
+	 *
+	 * @return \IdeHelper\Annotation\AbstractAnnotation[]
+	 * @throws \RuntimeException
+	 */
+	protected function _buildAnnotations(array $associations, $entity, array $behaviors) {
 		$namespace = $this->getConfig(static::CONFIG_NAMESPACE);
 		$annotations = [];
 		foreach ($associations as $type => $assocs) {
@@ -137,7 +148,7 @@ class ModelAnnotator extends AbstractAnnotator {
 			$annotations[] = AnnotationFactory::createOrFail(MixinAnnotation::TAG, "\\{$className}");
 		}
 
-		return $this->_annotate($path, $content, $annotations);
+		return $annotations;
 	}
 
 	/**

--- a/src/Annotator/ModelAnnotator.php
+++ b/src/Annotator/ModelAnnotator.php
@@ -84,7 +84,7 @@ class ModelAnnotator extends AbstractAnnotator {
 	 * @param string $path
 	 * @param string $entityName
 	 * @param array $associations
-	 * @param array $behaviors
+	 * @param string[] $behaviors
 	 *
 	 * @return bool
 	 * @throws \RuntimeException
@@ -175,7 +175,7 @@ class ModelAnnotator extends AbstractAnnotator {
 
 	/**
 	 * @param string $content
-	 * @return array
+	 * @return string[]
 	 */
 	protected function _parseLoadedBehaviors($content) {
 		preg_match_all('/\$this-\>addBehavior\(\'([a-z.\/]+)\'/i', $content, $matches);
@@ -202,6 +202,9 @@ class ModelAnnotator extends AbstractAnnotator {
 		$associations = [];
 		foreach ($tableAssociations->keys() as $key) {
 			$association = $tableAssociations->get($key);
+			if (!$association) {
+				continue;
+			}
 			$type = get_class($association);
 
 			list(, $name) = pluginSplit($association->getAlias());
@@ -272,7 +275,7 @@ class ModelAnnotator extends AbstractAnnotator {
 
 	/**
 	 * @param \Cake\ORM\Table $table
-	 * @return array
+	 * @return string[]
 	 */
 	protected function _getBehaviors($table) {
 		$object = $table->behaviors();
@@ -299,8 +302,7 @@ class ModelAnnotator extends AbstractAnnotator {
 
 	/**
 	 * @param array $map
-	 *
-	 * @return array
+	 * @return string[]
 	 */
 	protected function _extractBehaviors(array $map) {
 		$result = [];

--- a/src/Annotator/ShellAnnotator.php
+++ b/src/Annotator/ShellAnnotator.php
@@ -56,7 +56,7 @@ class ShellAnnotator extends AbstractAnnotator {
 	/**
 	 * @param string $content
 	 *
-	 * @return array
+	 * @return string[]
 	 */
 	protected function _getUsedModels($content) {
 		preg_match_all('/\$this-\>loadModel\(\'([a-z.\/]+)\'/i', $content, $matches);

--- a/src/Annotator/TemplateAnnotator.php
+++ b/src/Annotator/TemplateAnnotator.php
@@ -20,19 +20,7 @@ class TemplateAnnotator extends AbstractAnnotator {
 	public function annotate($path) {
 		$content = file_get_contents($path);
 
-		$annotations = [];
-		$needsAnnotation = $this->_needsViewAnnotation($content);
-		if ($needsAnnotation) {
-			$annotations[] = $this->_getViewAnnotation();
-		}
-
-		$entityAnnotations = $this->_getEntityAnnotations($content);
-		foreach ($entityAnnotations as $entityAnnotation) {
-			if (!$entityAnnotation) {
-				continue;
-			}
-			$annotations[] = $entityAnnotation;
-		}
+		$annotations = $this->_buildAnnotations($content);
 
 		return $this->_annotate($path, $content, $annotations);
 	}
@@ -313,7 +301,8 @@ class TemplateAnnotator extends AbstractAnnotator {
 				continue;
 			}
 
-			$result[$matches[1][$key]] = AnnotationFactory::createOrFail(VariableAnnotation::TAG, '\\' . $className . '[]|\Cake\Collection\CollectionInterface', '$' . $matches[1][$key]);
+			$resultKey = $matches[1][$key];
+			$result[$resultKey] = AnnotationFactory::createOrFail(VariableAnnotation::TAG, '\\' . $className . '[]|\Cake\Collection\CollectionInterface', '$' . $matches[1][$key]);
 			// We do not need the singular then
 			$result[$entity] = null;
 		}
@@ -372,6 +361,31 @@ class TemplateAnnotator extends AbstractAnnotator {
 		}
 
 		return false;
+	}
+
+	/**
+	 * @param string $content
+	 *
+	 * @return \IdeHelper\Annotation\AbstractAnnotation[]
+	 */
+	protected function _buildAnnotations($content) {
+		$annotations = [];
+
+		$needsAnnotation = $this->_needsViewAnnotation($content);
+		if ($needsAnnotation) {
+			$annotations[] = $this->_getViewAnnotation();
+		}
+
+		$entityAnnotations = $this->_getEntityAnnotations($content);
+		/** @var \IdeHelper\Annotation\AbstractAnnotation|null $entityAnnotation */
+		foreach ($entityAnnotations as $entityAnnotation) {
+			if (!$entityAnnotation) {
+				continue;
+			}
+			$annotations[] = $entityAnnotation;
+		}
+
+		return $annotations;
 	}
 
 }

--- a/src/Annotator/ViewAnnotator.php
+++ b/src/Annotator/ViewAnnotator.php
@@ -15,7 +15,7 @@ class ViewAnnotator extends AbstractAnnotator {
 	use HelperTrait;
 
 	/**
-	 * @var array
+	 * @var string[]
 	 */
 	protected $helpers = [];
 
@@ -27,16 +27,13 @@ class ViewAnnotator extends AbstractAnnotator {
 		$content = file_get_contents($path);
 
 		$helpers = $this->_getHelpers();
-		$annotations = [];
-		foreach ($helpers as $alias => $className) {
-			$annotations[] = AnnotationFactory::createOrFail(PropertyAnnotation::TAG, '\\' . $className, '$' . $alias);
-		}
+		$annotations = $this->_buildAnnotations($helpers);
 
 		return $this->_annotate($path, $content, $annotations);
 	}
 
 	/**
-	 * @return array
+	 * @return string[]
 	 */
 	protected function _getHelpers() {
 		$helperArray = $this->_parseViewClass();
@@ -89,7 +86,7 @@ class ViewAnnotator extends AbstractAnnotator {
 	/**
 	 * @param string $content
 	 *
-	 * @return array
+	 * @return string[]
 	 */
 	protected function _parseHelpersInContent($content) {
 		preg_match_all('/\$this-\>([A-Z][A-Za-z]+)-\>/', $content, $matches);
@@ -103,7 +100,7 @@ class ViewAnnotator extends AbstractAnnotator {
 	}
 
 	/**
-	 * @return array
+	 * @return string[]
 	 */
 	protected function _parseViewClass() {
 		$helpers = [];
@@ -127,9 +124,9 @@ class ViewAnnotator extends AbstractAnnotator {
 	}
 
 	/**
-	 * @param array $helperArray
+	 * @param string[] $helperArray
 	 *
-	 * @return array
+	 * @return string[]
 	 */
 	protected function _addAppHelpers($helperArray) {
 		$paths = AppPath::get('View/Helper');
@@ -158,7 +155,21 @@ class ViewAnnotator extends AbstractAnnotator {
 	}
 
 	/**
-	 * @return array
+	 * @param string[] $helpers
+	 *
+	 * @return \IdeHelper\Annotation\AbstractAnnotation[]
+	 */
+	protected function _buildAnnotations(array $helpers) {
+		$annotations = [];
+		foreach ($helpers as $alias => $className) {
+			$annotations[] = AnnotationFactory::createOrFail(PropertyAnnotation::TAG, '\\' . $className, '$' . $alias);
+		}
+
+		return $annotations;
+	}
+
+	/**
+	 * @return string[]
 	 */
 	protected function _getFolders() {
 		$plugin = null;

--- a/src/Generator/Task/DatabaseTypeTask.php
+++ b/src/Generator/Task/DatabaseTypeTask.php
@@ -26,7 +26,7 @@ class DatabaseTypeTask implements TaskInterface {
 	}
 
 	/**
-	 * @return array
+	 * @return string[]
 	 */
 	protected function getTypes() {
 		$types = [];

--- a/src/Generator/Task/ElementTask.php
+++ b/src/Generator/Task/ElementTask.php
@@ -31,7 +31,7 @@ class ElementTask extends ModelTask {
 	}
 
 	/**
-	 * @return array
+	 * @return string[]
 	 */
 	protected function collectElements() {
 		$paths = AppPath::get('Template');
@@ -51,11 +51,11 @@ class ElementTask extends ModelTask {
 	}
 
 	/**
-	 * @param array $result
-	 * @param array $paths
+	 * @param string[] $result
+	 * @param string[] $paths
 	 * @param string|null $plugin
 	 *
-	 * @return array
+	 * @return string[]
 	 */
 	protected function addElements(array $result, array $paths, $plugin = null) {
 		foreach ($paths as $path) {

--- a/src/Generator/Task/TableFinderTask.php
+++ b/src/Generator/Task/TableFinderTask.php
@@ -111,7 +111,7 @@ class TableFinderTask extends ModelTask {
 	/**
 	 * @param string $className
 	 *
-	 * @return array
+	 * @return string[]
 	 */
 	protected function getFinderMethods($className) {
 		$result = [];
@@ -125,10 +125,10 @@ class TableFinderTask extends ModelTask {
 	}
 
 	/**
-	 * @param array $result
+	 * @param string[] $result
 	 * @param string $method
 	 *
-	 * @return array
+	 * @return string[]
 	 */
 	protected function addMethod(array $result, $method) {
 		// We must exclude all find...By... patterns as possible false positives for now (refs https://github.com/cakephp/cakephp/issues/11240)

--- a/src/Illuminator/Illuminator.php
+++ b/src/Illuminator/Illuminator.php
@@ -58,7 +58,7 @@ class Illuminator {
 
 	/**
 	 * @param string $path
-	 * @return array
+	 * @return string[]
 	 */
 	protected function getFiles($path) {
 		$folder = new Folder($path);

--- a/src/View/Helper/DocBlockHelper.php
+++ b/src/View/Helper/DocBlockHelper.php
@@ -16,7 +16,7 @@ class DocBlockHelper extends BakeDocBlockHelper {
 	 * Overwrite Bake plugin class method until https://github.com/cakephp/bake/pull/470 lands.
 	 *
 	 * @param array $propertySchema The property schema to use for generating the type map.
-	 * @return array The property DocType map.
+	 * @return string[] The property DocType map.
 	 */
 	public function buildEntityPropertyHintTypeMap(array $propertySchema) {
 		$properties = [];
@@ -61,10 +61,9 @@ class DocBlockHelper extends BakeDocBlockHelper {
 	 * Overwrite with nullable option for now until Bake is adjusted ( https://github.com/cakephp/bake/issues/579 )
 	 *
 	 * @param array $propertySchema The property schema to use for generating the type map.
-	 * @return array The property DocType map.
+	 * @return string[] The property DocType map.
 	 */
-	public function buildEntityAssociationHintTypeMap(array $propertySchema)
-	{
+	public function buildEntityAssociationHintTypeMap(array $propertySchema) {
 		$properties = [];
 		foreach ($propertySchema as $property => $info) {
 			if ($info['kind'] === 'association') {

--- a/tests/phpstan.neon
+++ b/tests/phpstan.neon
@@ -10,4 +10,4 @@ parameters:
         - tests/shim.php
     ignoreErrors:
         - '#Call to an undefined method Cake\\ORM\\Association::getAlias\(\)#'
-        - '#Parameter \#1 $association of method .+ModelAnnotator::throughAlias\(\) expects .+BelongsToMany, .+Association|null given.#'
+        - '#Parameter \#1 \$association of method .+ModelAnnotator::throughAlias\(\) expects .+BelongsToMany, .+Association given.#'


### PR DESCRIPTION
Resolves https://github.com/dereuromark/cakephp-ide-helper/issues/122 for
- HasOne
- BelongsTo

relations for now. If they are found to be nullable fields in DB, we also expect the property to be annotated as such now.

PHPStan is now happy with the

    if ($user->something) {}

checks here if those are optional relations