### PR TITLE
Prevent property-read duplicating property tags.

### DIFF
--- a/docs/Annotations.md
+++ b/docs/Annotations.md
@@ -128,9 +128,11 @@ Using Configure key `'IdeHelper.nullableMap'` you can set a custom array of type
     ],
 ```
 
-Note: For virtual properties it looks up the respective `_get...()` methods (e.g. `_getVirtualProperty()` for `$virtual_property`).
+For virtual properties it looks up the respective `_get...()` methods (e.g. `_getVirtualProperty()` for `$virtual_property`).
 It first checks the documented type in the doc block's `@return`, otherwise (given PHP 7.0+) tries to read it from the
 return type hint (e.g. `: ?string`). Only if that is also not present it will use the fallback type `mixed`.
+
+Note: You can also use `@property-read` tag here if it is a pure virtual field getter.
 
 ## Shells
 Shells and Tasks should annotate their primary model as well as all manually loaded models.

--- a/src/Annotation/AnnotationFactory.php
+++ b/src/Annotation/AnnotationFactory.php
@@ -22,6 +22,8 @@ class AnnotationFactory {
 		switch ($tag) {
 			case PropertyAnnotation::TAG:
 				return new PropertyAnnotation($type, $content, $index);
+			case PropertyReadAnnotation::TAG:
+				return new PropertyReadAnnotation($type, $content, $index);
 			case MethodAnnotation::TAG:
 				return new MethodAnnotation($type, $content, $index);
 			case VariableAnnotation::TAG:
@@ -43,16 +45,16 @@ class AnnotationFactory {
 	 * @return \IdeHelper\Annotation\AbstractAnnotation|null
 	 */
 	public static function createFromString($annotation) {
-		preg_match('/^\@mixin (.+)\s*(.+)?$/', $annotation, $matches);
+		preg_match('/^@mixin (.+)\s*(.+)?$/', $annotation, $matches);
 		if ($matches) {
 			return static::create(MixinAnnotation::TAG, $matches[1]);
 		}
-		preg_match('/^\@uses (.+)\s*(.+)?$/', $annotation, $matches);
+		preg_match('/^@uses (.+)\s*(.+)?$/', $annotation, $matches);
 		if ($matches) {
 			return static::create(UsesAnnotation::TAG, $matches[1]);
 		}
 
-		preg_match('/^(\@property|\@method|\@var|\@param) ([^ ]+) (.+)$/', $annotation, $matches);
+		preg_match('/^(@property|@property-read|@method|@var|@param) ([^ ]+) (.+)$/', $annotation, $matches);
 		if (!$matches) {
 			return null;
 		}

--- a/src/Annotation/PropertyReadAnnotation.php
+++ b/src/Annotation/PropertyReadAnnotation.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace IdeHelper\Annotation;
+
+class PropertyReadAnnotation extends PropertyAnnotation {
+
+	const TAG = '@property-read';
+
+}

--- a/src/Annotator/ClassAnnotatorTask/ModelAwareClassAnnotatorTask.php
+++ b/src/Annotator/ClassAnnotatorTask/ModelAwareClassAnnotatorTask.php
@@ -40,7 +40,7 @@ class ModelAwareClassAnnotatorTask extends AbstractClassAnnotatorTask implements
 	 * @return string[]
 	 */
 	protected function _getUsedModels($content) {
-		preg_match_all('/\$this-\>loadModel\(\'([a-z.]+)\'/i', $content, $matches);
+		preg_match_all('/\$this->loadModel\(\'([a-z.]+)\'/i', $content, $matches);
 		if (empty($matches[1])) {
 			return [];
 		}

--- a/src/Annotator/CommandAnnotator.php
+++ b/src/Annotator/CommandAnnotator.php
@@ -47,7 +47,7 @@ class CommandAnnotator extends AbstractAnnotator {
 	 * @return string[]
 	 */
 	protected function _getUsedModels($content) {
-		preg_match_all('/\$this-\>loadModel\(\'([a-z.\/]+)\'/i', $content, $matches);
+		preg_match_all('/\$this->loadModel\(\'([a-z.\/]+)\'/i', $content, $matches);
 		if (empty($matches[1])) {
 			return [];
 		}

--- a/src/Annotator/ControllerAnnotator.php
+++ b/src/Annotator/ControllerAnnotator.php
@@ -86,7 +86,7 @@ class ControllerAnnotator extends AbstractAnnotator {
 	 * @return string[]
 	 */
 	protected function _getUsedModels($content) {
-		preg_match_all('/\$this-\>loadModel\(\'([a-z.]+)\'/i', $content, $matches);
+		preg_match_all('/\$this->loadModel\(\'([a-z.]+)\'/i', $content, $matches);
 		if (empty($matches[1])) {
 			return [];
 		}
@@ -189,12 +189,12 @@ class ControllerAnnotator extends AbstractAnnotator {
 	protected function _extractPaginateEntityTypehints($content, $primaryModelClass) {
 		$models = [];
 
-		preg_match_all('/\$this-\>paginate\(\)/i', $content, $matches);
+		preg_match_all('/\$this->paginate\(\)/i', $content, $matches);
 		if (!empty($matches[0])) {
 			$models[] = $primaryModelClass;
 		}
 
-		preg_match_all('/\$this-\>paginate\(\$this-\>([a-z]+)\)/i', $content, $matches);
+		preg_match_all('/\$this->paginate\(\$this->([a-z]+)\)/i', $content, $matches);
 		if (!empty($matches[1])) {
 			$models = array_merge($models, $matches[1]);
 		}

--- a/src/Annotator/EntityAnnotator.php
+++ b/src/Annotator/EntityAnnotator.php
@@ -210,7 +210,7 @@ class EntityAnnotator extends AbstractAnnotator {
 	 * @return string[]
 	 */
 	protected function buildVirtualPropertyHintTypeMap($content) {
-		if (!preg_match('#\bfunction \_get[A-Z][a-zA-Z0-9]+\(\)#', $content)) {
+		if (!preg_match('#\bfunction _get[A-Z][a-zA-Z0-9]+\(\)#', $content)) {
 			return [];
 		}
 
@@ -246,7 +246,7 @@ class EntityAnnotator extends AbstractAnnotator {
 
 			$startIndex = $methodNameIndex + 1;
 
-			if (!preg_match('#^\_get([A-Z][a-zA-Z0-9]+)$#', $methodName, $matches)) {
+			if (!preg_match('#^_get([A-Z][a-zA-Z0-9]+)$#', $methodName, $matches)) {
 				continue;
 			}
 

--- a/src/Annotator/ShellAnnotator.php
+++ b/src/Annotator/ShellAnnotator.php
@@ -59,7 +59,7 @@ class ShellAnnotator extends AbstractAnnotator {
 	 * @return string[]
 	 */
 	protected function _getUsedModels($content) {
-		preg_match_all('/\$this-\>loadModel\(\'([a-z.\/]+)\'/i', $content, $matches);
+		preg_match_all('/\$this->loadModel\(\'([a-z.\/]+)\'/i', $content, $matches);
 		if (empty($matches[1])) {
 			return [];
 		}

--- a/src/Annotator/TemplateAnnotator.php
+++ b/src/Annotator/TemplateAnnotator.php
@@ -252,7 +252,7 @@ class TemplateAnnotator extends AbstractAnnotator {
 	 * @return array
 	 */
 	protected function _parseFormEntities($content) {
-		preg_match_all('/\$this-\>Form->create\(\$(\w+)\W/i', $content, $matches);
+		preg_match_all('/\$this->Form->create\(\$(\w+)\W/i', $content, $matches);
 		if (empty($matches[1])) {
 			return [];
 		}
@@ -316,7 +316,7 @@ class TemplateAnnotator extends AbstractAnnotator {
 	 * @return array
 	 */
 	protected function _parseEntities($content) {
-		preg_match_all('/\$([a-z]+)-\>[a-z]+/i', $content, $matches);
+		preg_match_all('/\$([a-z]+)->[a-z]+/i', $content, $matches);
 		if (empty($matches[1])) {
 			return [];
 		}

--- a/src/Annotator/ViewAnnotator.php
+++ b/src/Annotator/ViewAnnotator.php
@@ -89,7 +89,7 @@ class ViewAnnotator extends AbstractAnnotator {
 	 * @return string[]
 	 */
 	protected function _parseHelpersInContent($content) {
-		preg_match_all('/\$this-\>([A-Z][A-Za-z]+)-\>/', $content, $matches);
+		preg_match_all('/\$this->([A-Z][A-Za-z]+)->/', $content, $matches);
 		if (empty($matches[1])) {
 			return [];
 		}

--- a/src/Illuminator/Task/EntityFieldTask.php
+++ b/src/Illuminator/Task/EntityFieldTask.php
@@ -33,7 +33,7 @@ class EntityFieldTask extends AbstractTask {
 	 * @return bool
 	 */
 	public function shouldRun($path) {
-		return (bool)preg_match('#\\/Model\\/Entity/.+\\.php$#', $path);
+		return (bool)preg_match('#/Model/Entity/.+\\.php$#', $path);
 	}
 
 	/**

--- a/tests/TestCase/Annotation/AnnotationFactoryTest.php
+++ b/tests/TestCase/Annotation/AnnotationFactoryTest.php
@@ -6,6 +6,7 @@ use IdeHelper\Annotation\AnnotationFactory;
 use IdeHelper\Annotation\MethodAnnotation;
 use IdeHelper\Annotation\MixinAnnotation;
 use IdeHelper\Annotation\PropertyAnnotation;
+use IdeHelper\Annotation\PropertyReadAnnotation;
 use IdeHelper\Annotation\UsesAnnotation;
 use Tools\TestSuite\TestCase;
 
@@ -23,6 +24,9 @@ class AnnotationFactoryTest extends TestCase {
 
 		$annotation = AnnotationFactory::create('@property', '\\Foo\\Model\\Entity\\Bar', 'baz', 1);
 		$this->assertInstanceOf(PropertyAnnotation::class, $annotation);
+
+		$annotation = AnnotationFactory::create('@property-read', '\\Foo\\Model\\Entity\\Bar', 'baz', 1);
+		$this->assertInstanceOf(PropertyReadAnnotation::class, $annotation);
 
 		$annotation = AnnotationFactory::create('@mixin', '\\Foo\\Model\\Entity\\Bar');
 		$this->assertInstanceOf(MixinAnnotation::class, $annotation);
@@ -60,6 +64,11 @@ class AnnotationFactoryTest extends TestCase {
 
 		$annotation = AnnotationFactory::createFromString('@property\\Foo\\Model\\Entity\\Bar$baz');
 		$this->assertNull($annotation);
+
+		/** @var \IdeHelper\Annotation\PropertyReadAnnotation $annotation */
+		$annotation = AnnotationFactory::createFromString('@property-read \\Foo\\Model\\Entity\\Bar baz');
+		$this->assertInstanceOf(PropertyReadAnnotation::class, $annotation);
+		$this->assertSame('$baz', $annotation->getProperty());
 
 		/** @var \IdeHelper\Annotation\MethodAnnotation $annotation */
 		$annotation = AnnotationFactory::createFromString('@method \\Foo\\Model\\Entity\\Bar complex($x, $y = [], $z = null)');

--- a/tests/TestCase/Annotator/EntityAnnotatorTest.php
+++ b/tests/TestCase/Annotator/EntityAnnotatorTest.php
@@ -242,6 +242,36 @@ class EntityAnnotatorTest extends TestCase {
 
 		$output = (string)$this->out->output();
 
+		$this->assertTextContains('   -> 7 annotations added', $output);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testAnnotateWithVirtualPropertiesReadOnly() {
+		/** @var \App\Model\Table\FooTable $Table */
+		$Table = TableRegistry::get('Foo');
+		$Table->hasMany('Wheels');
+
+		$schema = $Table->getSchema();
+		$associations = $Table->associations();
+		$annotator = $this->_getAnnotatorMock(['schema' => $schema, 'associations' => $associations]);
+
+		$expectedContent = str_replace(["\r\n", "\r"], "\n", file_get_contents(TEST_FILES . 'Model/Entity/Virtual.php'));
+		$callback = function ($value) use ($expectedContent) {
+			$value = str_replace(["\r\n", "\r"], "\n", $value);
+			if ($value !== $expectedContent) {
+				$this->_displayDiff($expectedContent, $value);
+			}
+			return $value === $expectedContent;
+		};
+		$annotator->expects($this->once())->method('_storeFile')->with($this->anything(), $this->callback($callback));
+
+		$path = APP . 'Model/Entity/Virtual.php';
+		$annotator->annotate($path);
+
+		$output = (string)$this->out->output();
+
 		$this->assertTextContains('   -> 8 annotations added', $output);
 	}
 

--- a/tests/TestCase/Illuminator/IlluminatorTest.php
+++ b/tests/TestCase/Illuminator/IlluminatorTest.php
@@ -57,7 +57,7 @@ class IlluminatorTest extends TestCase {
 		$path = TEST_FILES;
 		$count = $this->illuminator->illuminate($path, null);
 
-		$this->assertSame(5, $count);
+		$this->assertSame(6, $count);
 
 		$out = $this->out->output();
 

--- a/tests/test_app/src/Model/Entity/Virtual.php
+++ b/tests/test_app/src/Model/Entity/Virtual.php
@@ -1,0 +1,46 @@
+<?php
+namespace App\Model\Entity;
+
+use Cake\ORM\Entity;
+
+/**
+ * @property-read bool $virtual_read_only This should be kept.
+ */
+class Virtual extends Entity {
+
+	/**
+	 * @var array
+	 */
+	protected $_virtual = [
+		'virtual_one',
+	];
+
+	/**
+	 * @return string|null
+	 */
+	protected function _getVirtualOne() {
+		return 'Virtual One';
+	}
+
+	protected function _getVirtualTwo() {
+		// Missing return type and docblock means mixed as result
+		return 'Virtual Two';
+	}
+
+	/**
+	 * @return bool
+	 */
+	protected function _getVirtualReadOnly() {
+		return true;
+	}
+
+	/**
+	 * @param \App\Model\Entity\Wheel[] $wheels
+	 *
+	 * @return \App\Model\Entity\Wheel[]
+	 */
+	protected function _getWheels($wheels = []) {
+		return $wheels;
+	}
+
+}

--- a/tests/test_app/src/Model/Entity/Wheel.php
+++ b/tests/test_app/src/Model/Entity/Wheel.php
@@ -19,18 +19,4 @@ class Wheel extends Entity {
 		return 'Virtual One';
 	}
 
-	protected function _getVirtualTwo() {
-		// Missing return type and docblock means mixed as result
-		return 'Virtual Two';
-	}
-
-	/**
-	 * @param \App\Model\Entity\Wheel[] $wheels
-	 *
-	 * @return \App\Model\Entity\Wheel[]
-	 */
-	protected function _getWheels($wheels = []) {
-		return $wheels;
-	}
-
 }

--- a/tests/test_app/src/Template/Foos/existing.ctp
+++ b/tests/test_app/src/Template/Foos/existing.ctp
@@ -8,6 +8,6 @@
  */
 ?>
 <div>
-	<?php foreach ($cars as $car); ?>
+	<?php foreach ($cars as $car) {} ?>
 	<?php echo h($wheel->id); ?>
 </div>

--- a/tests/test_files/Model/Entity/Constants/Wheel.php
+++ b/tests/test_files/Model/Entity/Constants/Wheel.php
@@ -10,7 +10,6 @@ use Cake\ORM\Entity;
  * @property \Cake\I18n\FrozenTime $created
  * @property \Cake\I18n\FrozenTime|null $modified
  * @property string|null $virtual_one
- * @property mixed $virtual_two
  * @property \App\Model\Entity\Wheel[] $wheels
  */
 class Wheel extends Entity {
@@ -29,27 +28,12 @@ class Wheel extends Entity {
 		return 'Virtual One';
 	}
 
-	protected function _getVirtualTwo() {
-		// Missing return type and docblock means mixed as result
-		return 'Virtual Two';
-	}
-
-	/**
-	 * @param \App\Model\Entity\Wheel[] $wheels
-	 *
-	 * @return \App\Model\Entity\Wheel[]
-	 */
-	protected function _getWheels($wheels = []) {
-		return $wheels;
-	}
-
 	const FIELD_ID = 'id';
 	const FIELD_NAME = 'name';
 	const FIELD_CONTENT = 'content';
 	const FIELD_CREATED = 'created';
 	const FIELD_MODIFIED = 'modified';
 	const FIELD_VIRTUAL_ONE = 'virtual_one';
-	const FIELD_VIRTUAL_TWO = 'virtual_two';
 	const FIELD_WHEELS = 'wheels';
 
 }

--- a/tests/test_files/Model/Entity/Virtual.php
+++ b/tests/test_files/Model/Entity/Virtual.php
@@ -1,0 +1,54 @@
+<?php
+namespace App\Model\Entity;
+
+use Cake\ORM\Entity;
+
+/**
+ * @property-read bool $virtual_read_only This should be kept.
+ * @property int $id
+ * @property string $name
+ * @property string $content
+ * @property \Cake\I18n\FrozenTime $created
+ * @property \Cake\I18n\FrozenTime|null $modified
+ * @property string|null $virtual_one
+ * @property mixed $virtual_two
+ * @property \App\Model\Entity\Wheel[] $wheels
+ */
+class Virtual extends Entity {
+
+	/**
+	 * @var array
+	 */
+	protected $_virtual = [
+		'virtual_one',
+	];
+
+	/**
+	 * @return string|null
+	 */
+	protected function _getVirtualOne() {
+		return 'Virtual One';
+	}
+
+	protected function _getVirtualTwo() {
+		// Missing return type and docblock means mixed as result
+		return 'Virtual Two';
+	}
+
+	/**
+	 * @return bool
+	 */
+	protected function _getVirtualReadOnly() {
+		return true;
+	}
+
+	/**
+	 * @param \App\Model\Entity\Wheel[] $wheels
+	 *
+	 * @return \App\Model\Entity\Wheel[]
+	 */
+	protected function _getWheels($wheels = []) {
+		return $wheels;
+	}
+
+}

--- a/tests/test_files/Model/Entity/Wheel.php
+++ b/tests/test_files/Model/Entity/Wheel.php
@@ -10,7 +10,6 @@ use Cake\ORM\Entity;
  * @property \Cake\I18n\FrozenTime $created
  * @property \Cake\I18n\FrozenTime|null $modified
  * @property string|null $virtual_one
- * @property mixed $virtual_two
  * @property \App\Model\Entity\Wheel[] $wheels
  */
 class Wheel extends Entity {
@@ -27,20 +26,6 @@ class Wheel extends Entity {
 	 */
 	protected function _getVirtualOne() {
 		return 'Virtual One';
-	}
-
-	protected function _getVirtualTwo() {
-		// Missing return type and docblock means mixed as result
-		return 'Virtual Two';
-	}
-
-	/**
-	 * @param \App\Model\Entity\Wheel[] $wheels
-	 *
-	 * @return \App\Model\Entity\Wheel[]
-	 */
-	protected function _getWheels($wheels = []) {
-		return $wheels;
 	}
 
 }

--- a/tests/test_files/Template/existing.ctp
+++ b/tests/test_files/Template/existing.ctp
@@ -10,6 +10,6 @@
  */
 ?>
 <div>
-	<?php foreach ($cars as $car); ?>
+	<?php foreach ($cars as $car) {} ?>
 	<?php echo h($wheel->id); ?>
 </div>


### PR DESCRIPTION
Solves https://github.com/dereuromark/cakephp-ide-helper/issues/140
```php
/**
 * @property-read bool $virtual_read_only This should be kept.
 * @property int $id
 * @property string $name
 * @property string $content
 * @property \Cake\I18n\FrozenTime $created
 * @property \Cake\I18n\FrozenTime|null $modified
 * @property string|null $virtual_one
 * @property mixed $virtual_two
 * @property \App\Model\Entity\Wheel[] $wheels
 */
class MyEntity extends Entity {
}
```

@raul338 Can you please confirm?