### PR TITLE
Use BrokerAwareExtension instead of BrokerAwareClassReflectionExtension;

### DIFF
--- a/tests/PHPStan/AssociationTableMixinClassReflectionExtension.php
+++ b/tests/PHPStan/AssociationTableMixinClassReflectionExtension.php
@@ -5,14 +5,14 @@ namespace IdeHelper\PHPStan;
 use Cake\ORM\Association;
 use Cake\ORM\Table;
 use PHPStan\Broker\Broker;
-use PHPStan\Reflection\BrokerAwareClassReflectionExtension;
+use PHPStan\Reflection\BrokerAwareExtension;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\MethodsClassReflectionExtension;
 use PHPStan\Reflection\PropertiesClassReflectionExtension;
 use PHPStan\Reflection\PropertyReflection;
 
-class AssociationTableMixinClassReflectionExtension implements PropertiesClassReflectionExtension, MethodsClassReflectionExtension, BrokerAwareClassReflectionExtension {
+class AssociationTableMixinClassReflectionExtension implements PropertiesClassReflectionExtension, MethodsClassReflectionExtension, BrokerAwareExtension {
 
 	/**
 	 * @var \PHPStan\Broker\Broker


### PR DESCRIPTION
To support PHPStan 0.12 its best to use BrokerAwareExtension instead of BrokerAwareClassReflectionExtension. BrokerAwareExtenion was added in version 0.9 of PHPStan