### PR TITLE
fix instantiation of abstract components

### DIFF
--- a/src/Annotator/AbstractAnnotator.php
+++ b/src/Annotator/AbstractAnnotator.php
@@ -817,11 +817,12 @@ abstract class AbstractAnnotator {
 
 	/**
 	 * @param string $className
-	 * @return bool
 	 *
+	 * @return bool
 	 */
 	protected function _isAbstract($className) {
 		$reflection = new ReflectionClass($className);
 		return $reflection->isAbstract();
 	}
+
 }

--- a/src/Annotator/AbstractAnnotator.php
+++ b/src/Annotator/AbstractAnnotator.php
@@ -815,4 +815,13 @@ abstract class AbstractAnnotator {
 		return $beginningOfLineIndex;
 	}
 
+	/**
+	 * @param string $className
+	 * @return bool
+	 *
+	 */
+	protected function _isAbstract($className) {
+		$reflection = new ReflectionClass($className);
+		return $reflection->isAbstract();
+	}
 }

--- a/src/Annotator/ComponentAnnotator.php
+++ b/src/Annotator/ComponentAnnotator.php
@@ -58,6 +58,10 @@ class ComponentAnnotator extends AbstractAnnotator {
 	 * @return \IdeHelper\Annotation\AbstractAnnotation[]
 	 */
 	protected function _getComponentAnnotations($className) {
+		if ($this->_isAbstract($className)) {
+			return [];
+		}
+
 		$controller = new Controller();
 		try {
 			$object = new $className(new ComponentRegistry($controller));


### PR DESCRIPTION
Resolving next issue happen when trying to analyze abstact component class.

# bin/cake annotations components -d
Exception: Cannot instantiate abstract class App\Controller\Component\SessionFilterComponent in [vendor/dereuromark/cakephp-ide-helper/src/Annotator/ComponentAnnotator.php, line 63]
2020-02-23 15:46:38 Error: [Error] Cannot instantiate abstract class App\Controller\Component\SessionFilterComponent in vendor/dereuromark/cakephp-ide-helper/src/Annotator/ComponentAnnotator.php on line 63
Stack Trace:
#0 vendor/dereuromark/cakephp-ide-helper/src/Annotator/ComponentAnnotator.php(48): IdeHelper\Annotator\ComponentAnnotator->_getComponentAnnotations('App\\Controller\\...')