### PR TITLE
Allow new major of sebastian/diff.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
 		"php": ">=7.2",
 		"cakephp/cakephp": "^4.0.2",
 		"cakephp/bake": "^2.0.3",
-		"sebastian/diff": "^3.0.0",
+		"sebastian/diff": "^3.0.0|^4.0.0",
 		"squizlabs/php_codesniffer": "^3.5.2"
 	},
 	"require-dev": {


### PR DESCRIPTION
This can only be tested with PHPUnit 9 though.

also: sebastian/diff           4.0.0      requires  php ^7.3