### PR TITLE
Add support for new addHelper() method.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ matrix:
     - php: 7.2
       env: PREFER_LOWEST=1
 
-    - php: 7.4
+    - php: 7.3
       env: CHECKS=1 DEFAULT=0
 
     - php: 7.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ matrix:
     - php: 7.2
       env: PREFER_LOWEST=1
 
-    - php: 7.3
+    - php: 7.4
       env: CHECKS=1 DEFAULT=0
 
     - php: 7.3

--- a/docs/Generator.md
+++ b/docs/Generator.md
@@ -78,6 +78,12 @@ The following is now auto-completed, for example:
 ```php
 $this->loadHelper('Tools.Tree');
 ```
+And so is the ``addHelper()`` (added in CakePHP 4.1) on the `ViewBuilder`:
+```php
+$this->viewBuilder()
+    ->addHelper('TinyAuth.AuthUser')
+    ->addHelper('Tools.Tree');
+```
 
 #### Types
 In your bootstrap (app, or plugin), you might add additional database Type classes, or you reconfigure existing ones:

--- a/docs/Generator.md
+++ b/docs/Generator.md
@@ -112,11 +112,17 @@ With this generator PHPStorm can auto-complete this, including all elements for 
 
 Now not just bool true/false, but also the possible "magic strings" are typehinted and usable as single click/enter.
 
+#### Request params
+`$this->request->getParam()` auto-completes for `prefix`, `controller` and other common keys.
+
 #### ENV keys
-`env()` is now auto-completed for most common and used keys.
+`env()` is auto-completed for most common and used keys.
 
 #### Translation keys
-Using `__()` and `__d()` can now also be auto-completed based on your project's `.po` files.
+Using `__()` and `__d()` can be auto-completed based on your project's `.po` files.
+
+#### ConnectionManager
+`ConnectionManager::get()` is auto-completed for the currently configured connection aliases.
 
 #### Migrations plugin database tables
 When using the Migrations plugin, this task will come in handy to quickly autocomplete existing tables,

--- a/src/Generator/Task/ConnectionTask.php
+++ b/src/Generator/Task/ConnectionTask.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace IdeHelper\Generator\Task;
+
+use Cake\Datasource\ConnectionManager;
+use IdeHelper\Generator\Directive\ExpectedArguments;
+use IdeHelper\ValueObject\StringName;
+
+class ConnectionTask extends ModelTask {
+
+	protected const METHOD_GET = '\\' . ConnectionManager::class . '::get()';
+
+	/**
+	 * @return \IdeHelper\Generator\Directive\BaseDirective[]
+	 */
+	public function collect(): array {
+		$result = [];
+
+		$keys = $this->connectionKeys();
+
+		ksort($keys);
+
+		$directive = new ExpectedArguments(static::METHOD_GET, 0, $keys);
+		$result[$directive->key()] = $directive;
+
+		return $result;
+	}
+
+	/**
+	 * @return \IdeHelper\ValueObject\StringName[]
+	 */
+	protected function connectionKeys(): array {
+		$configured = ConnectionManager::configured();
+
+		$list = [];
+		foreach ($configured as $key) {
+			$list[$key] = StringName::create($key);
+		}
+
+		return $list;
+	}
+
+}

--- a/src/Generator/Task/EnvTask.php
+++ b/src/Generator/Task/EnvTask.php
@@ -7,7 +7,7 @@ use IdeHelper\ValueObject\StringName;
 
 class EnvTask extends ModelTask {
 
-	public const METHOD_ENV = 'env()';
+	protected const METHOD_ENV = '\\' . 'env()';
 
 	/**
 	 * Keys from Web based request, will be merged with CLI ones.
@@ -56,7 +56,7 @@ class EnvTask extends ModelTask {
 
 		ksort($keys);
 
-		$method = '\\' . static::METHOD_ENV;
+		$method = static::METHOD_ENV;
 		$directive = new ExpectedArguments($method, 0, $keys);
 		$result[$directive->key()] = $directive;
 

--- a/src/Generator/Task/HelperTask.php
+++ b/src/Generator/Task/HelperTask.php
@@ -21,13 +21,6 @@ class HelperTask implements TaskInterface {
 	protected const METHOD_VIEW_BUILDER = '\\' . self::CLASS_VIEW_BUILDER . '::addHelper()';
 
 	/**
-	 * @var string[]
-	 */
-	protected $aliases = [
-		'\\' . self::CLASS_VIEW . '::loadHelper(0)',
-	];
-
-	/**
 	 * @return \IdeHelper\Generator\Directive\BaseDirective[]
 	 */
 	public function collect(): array {
@@ -79,7 +72,7 @@ class HelperTask implements TaskInterface {
 	}
 
 	/**
-	 * @param array $helpers
+	 * @param string[] $helpers
 	 * @param string $folder
 	 * @param string|null $plugin
 	 *

--- a/src/Generator/Task/HelperTask.php
+++ b/src/Generator/Task/HelperTask.php
@@ -3,6 +3,8 @@
 namespace IdeHelper\Generator\Task;
 
 use Cake\Filesystem\Folder;
+use Cake\View\ViewBuilder;
+use IdeHelper\Generator\Directive\ExpectedArguments;
 use Cake\View\View;
 use IdeHelper\Generator\Directive\Override;
 use IdeHelper\Utility\App;
@@ -13,6 +15,10 @@ use IdeHelper\ValueObject\ClassName;
 class HelperTask implements TaskInterface {
 
 	public const CLASS_VIEW = View::class;
+	public const CLASS_VIEW_BUILDER = ViewBuilder::class;
+
+	protected const METHOD_VIEW = '\\' . self::CLASS_VIEW . '::loadHelper(0)';
+	protected const METHOD_VIEW_BUILDER = '\\' . self::CLASS_VIEW_BUILDER . '::addHelper()';
 
 	/**
 	 * @var string[]
@@ -25,20 +31,27 @@ class HelperTask implements TaskInterface {
 	 * @return \IdeHelper\Generator\Directive\BaseDirective[]
 	 */
 	public function collect(): array {
-		$map = [];
-
 		$helpers = $this->collectHelpers();
+
+		$map = [];
 		foreach ($helpers as $name => $className) {
 			$map[$name] = ClassName::create($className);
 		}
-
 		ksort($map);
 
 		$result = [];
-		foreach ($this->aliases as $alias) {
-			$directive = new Override($alias, $map);
-			$result[$directive->key()] = $directive;
+
+		$directive = new Override(static::METHOD_VIEW, $map);
+		$result[$directive->key()] = $directive;
+
+		$list = [];
+		foreach ($helpers as $name => $className) {
+			$list[$name] = "'$name'";
 		}
+		ksort($list);
+
+		$directive = new ExpectedArguments(static::METHOD_VIEW_BUILDER, 0, $list);
+		$result[$directive->key()] = $directive;
 
 		return $result;
 	}

--- a/src/Generator/Task/HelperTask.php
+++ b/src/Generator/Task/HelperTask.php
@@ -3,9 +3,9 @@
 namespace IdeHelper\Generator\Task;
 
 use Cake\Filesystem\Folder;
+use Cake\View\View;
 use Cake\View\ViewBuilder;
 use IdeHelper\Generator\Directive\ExpectedArguments;
-use Cake\View\View;
 use IdeHelper\Generator\Directive\Override;
 use IdeHelper\Utility\App;
 use IdeHelper\Utility\AppPath;

--- a/src/Generator/Task/RequestTask.php
+++ b/src/Generator/Task/RequestTask.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace IdeHelper\Generator\Task;
+
+use Cake\Http\ServerRequest;
+use IdeHelper\Generator\Directive\ExpectedArguments;
+use IdeHelper\ValueObject\StringName;
+
+class RequestTask implements TaskInterface {
+
+	public const CLASS_REQUEST = ServerRequest::class;
+
+	/**
+	 * @var string[]
+	 */
+	protected static $paramKeys = [
+		'controller',
+		'action',
+		'plugin',
+		'prefix',
+		'pass',
+		'_matchedRoute',
+		'_ext',
+	];
+
+	/**
+	 * @return \IdeHelper\Generator\Directive\BaseDirective[]
+	 */
+	public function collect(): array {
+		$result = [];
+
+		$list = $this->collectParamKeys();
+
+		$method = '\\' . static::CLASS_REQUEST . '::getParam()';
+		$directive = new ExpectedArguments($method, 0, $list);
+		$result[$directive->key()] = $directive;
+
+		return $result;
+	}
+
+	/**
+	 * @return string[]
+	 */
+	protected function collectParamKeys(): array {
+		$keys = [];
+		foreach (static::$paramKeys as $key) {
+			$keys[$key] = StringName::create($key);
+		}
+
+		ksort($keys);
+
+		return $keys;
+	}
+
+}

--- a/src/Generator/Task/TranslationKeyTask.php
+++ b/src/Generator/Task/TranslationKeyTask.php
@@ -18,17 +18,15 @@ use RegexIterator;
  */
 class TranslationKeyTask implements TaskInterface {
 
-	public const SET_TRANSLATION_KEYS = 'translationKeys';
-
 	/**
 	 * function __(string $singular, ...$args): string
 	 */
-	public const METHOD_DEFAULT = '__()';
+	protected const METHOD_DEFAULT = '__()';
 
 	/**
 	 * function __d(string $domain, string $msg, ...$args): string
 	 */
-	public const METHOD_DOMAIN = '__d()';
+	protected const METHOD_DOMAIN = '__d()';
 
 	/**
 	 * @return \IdeHelper\Generator\Directive\BaseDirective[]

--- a/src/Generator/TaskCollection.php
+++ b/src/Generator/TaskCollection.php
@@ -6,6 +6,7 @@ use Cake\Core\Configure;
 use IdeHelper\Generator\Task\BehaviorTask;
 use IdeHelper\Generator\Task\CacheTask;
 use IdeHelper\Generator\Task\ComponentTask;
+use IdeHelper\Generator\Task\ConnectionTask;
 use IdeHelper\Generator\Task\DatabaseTableColumnNameTask;
 use IdeHelper\Generator\Task\DatabaseTableColumnTypeTask;
 use IdeHelper\Generator\Task\DatabaseTableTask;
@@ -16,6 +17,7 @@ use IdeHelper\Generator\Task\HelperTask;
 use IdeHelper\Generator\Task\LayoutTask;
 use IdeHelper\Generator\Task\ModelTask;
 use IdeHelper\Generator\Task\PluginTask;
+use IdeHelper\Generator\Task\RequestTask;
 use IdeHelper\Generator\Task\RoutePathTask;
 use IdeHelper\Generator\Task\TableAssociationTask;
 use IdeHelper\Generator\Task\TableFinderTask;
@@ -43,7 +45,9 @@ class TaskCollection {
 		ValidationTask::class => ValidationTask::class,
 		RoutePathTask::class => RoutePathTask::class,
 		CacheTask::class => CacheTask::class,
+		RequestTask::class => RequestTask::class,
 		EnvTask::class => EnvTask::class,
+		ConnectionTask::class => ConnectionTask::class,
 		DatabaseTableTask::class => DatabaseTableTask::class,
 		DatabaseTableColumnNameTask::class => DatabaseTableColumnNameTask::class,
 		DatabaseTableColumnTypeTask::class => DatabaseTableColumnTypeTask::class,

--- a/tests/TestCase/Generator/Task/ConnectionTaskTest.php
+++ b/tests/TestCase/Generator/Task/ConnectionTaskTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace IdeHelper\Test\TestCase\Generator\Task;
+
+use IdeHelper\Generator\Task\ConnectionTask;
+use Shim\TestSuite\TestCase;
+
+class ConnectionTaskTest extends TestCase {
+
+	/**
+	 * @var \IdeHelper\Generator\Task\ConnectionTask
+	 */
+	protected $task;
+
+	/**
+	 * @return void
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->task = new ConnectionTask();
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testCollect() {
+		$result = $this->task->collect();
+
+		$this->assertCount(1, $result);
+
+		/** @var \IdeHelper\Generator\Directive\ExpectedArguments $directive */
+		$directive = array_shift($result);
+		$this->assertSame('\Cake\Datasource\ConnectionManager::get()', $directive->toArray()['method']);
+
+		$list = $directive->toArray()['list'];
+		$list = array_map(function ($className) {
+			return (string)$className;
+		}, $list);
+
+		$expected = [
+			'test' => "'test'",
+		];
+		$this->assertSame($expected, $list);
+	}
+
+}

--- a/tests/TestCase/Generator/Task/HelperTaskTest.php
+++ b/tests/TestCase/Generator/Task/HelperTaskTest.php
@@ -27,7 +27,7 @@ class HelperTaskTest extends TestCase {
 	public function testCollect() {
 		$result = $this->task->collect();
 
-		$this->assertCount(1, $result);
+		$this->assertCount(2, $result);
 
 		/** @var \IdeHelper\Generator\Directive\Override $directive */
 		$directive = array_shift($result);
@@ -40,6 +40,18 @@ class HelperTaskTest extends TestCase {
 
 		$expected = '\Shim\View\Helper\ConfigureHelper::class';
 		$this->assertSame($expected, (string)$map['Shim.Configure']);
+
+		/** @var \IdeHelper\Generator\Directive\ExpectedArguments $directive */
+		$directive = array_shift($result);
+		$this->assertSame('\Cake\View\ViewBuilder::addHelper()', $directive->toArray()['method']);
+
+		$list = $directive->toArray()['list'];
+
+		$expected = "'Form'";
+		$this->assertSame($expected, (string)$list['Form']);
+
+		$expected = "'Shim.Configure'";
+		$this->assertSame($expected, (string)$list['Shim.Configure']);
 	}
 
 }

--- a/tests/TestCase/Generator/Task/RequestTaskTest.php
+++ b/tests/TestCase/Generator/Task/RequestTaskTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace IdeHelper\Test\TestCase\Generator\Task;
+
+use IdeHelper\Generator\Task\RequestTask;
+use Shim\TestSuite\TestCase;
+
+class RequestTaskTest extends TestCase {
+
+	/**
+	 * @var \IdeHelper\Generator\Task\RequestTask
+	 */
+	protected $task;
+
+	/**
+	 * @return void
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->task = new RequestTask();
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testCollect() {
+		$result = $this->task->collect();
+
+		$this->assertCount(1, $result);
+
+		/** @var \IdeHelper\Generator\Directive\ExpectedArguments $directive */
+		$directive = array_shift($result);
+		$this->assertSame('\Cake\Http\ServerRequest::getParam()', $directive->toArray()['method']);
+
+		$list = $directive->toArray()['list'];
+		$list = array_map(function ($className) {
+			return (string)$className;
+		}, $list);
+
+		$expected = [
+			'_ext' => "'_ext'",
+			'_matchedRoute' => "'_matchedRoute'",
+			'action' => "'action'",
+			'controller' => "'controller'",
+			'pass' => "'pass'",
+			'plugin' => "'plugin'",
+			'prefix' => "'prefix'",
+		];
+		$this->assertSame($expected, $list);
+	}
+
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -112,14 +112,3 @@ Cake\Datasource\ConnectionManager::setConfig('test', [
 	'quoteIdentifiers' => true,
 	'cacheMetadata' => true,
 ]);
-
-Cake\Datasource\ConnectionManager::setConfig('test_database_log', [
-	'url' => getenv('db_dsn'),
-	'driver' => getenv('db_class'),
-	'database' => getenv('db_database'),
-	'username' => getenv('db_username'),
-	'password' => getenv('db_password'),
-	'timezone' => 'UTC',
-	'quoteIdentifiers' => true,
-	'cacheMetadata' => true,
-]);

--- a/tests/shim.php
+++ b/tests/shim.php
@@ -7,3 +7,7 @@ if (!class_exists(Config::class) && file_exists($manualAutoload)) {
 }
 
 error_reporting(E_ALL & ~E_USER_DEPRECATED);
+
+if (!defined('T_NULLABLE')) {
+	define('T_NULLABLE', 'PHPCS_T_NULLABLE');
+}

--- a/tests/test_files/meta/phpstorm/.meta.php
+++ b/tests/test_files/meta/phpstorm/.meta.php
@@ -120,6 +120,12 @@ namespace PHPSTORM_META {
 		])
 	);
 
+	expectedArguments(
+		\Cake\Datasource\ConnectionManager::get(),
+		0,
+		'test'
+	);
+
 	override(
 		\Cake\Datasource\ModelAwareTrait::loadModel(0),
 		map([
@@ -152,6 +158,18 @@ namespace PHPSTORM_META {
 			'list' => \Cake\ORM\Query::class,
 			'threaded' => \Cake\ORM\Query::class,
 		])
+	);
+
+	expectedArguments(
+		\Cake\Http\ServerRequest::getParam(),
+		0,
+		'_ext',
+		'_matchedRoute',
+		'action',
+		'controller',
+		'pass',
+		'plugin',
+		'prefix'
 	);
 
 	override(

--- a/tests/test_files/meta/phpstorm/.meta.php
+++ b/tests/test_files/meta/phpstorm/.meta.php
@@ -379,6 +379,25 @@ namespace PHPSTORM_META {
 	);
 
 	expectedArguments(
+		\Cake\View\ViewBuilder::addHelper(),
+		0,
+		'Breadcrumbs',
+		'Flash',
+		'Form',
+		'Html',
+		'IdeHelper.DocBlock',
+		'My',
+		'Number',
+		'Paginator',
+		'Shim.Configure',
+		'Shim.Cookie',
+		'Shim.Form',
+		'Text',
+		'Time',
+		'Url'
+	);
+
+	expectedArguments(
 		\Cake\View\ViewBuilder::setLayout(),
 		0,
 		'ajax'


### PR DESCRIPTION
Requires 
- [x] ~~https://github.com/cakephp/cakephp/pull/14435~~ https://github.com/cakephp/cakephp/pull/14436 to be merged
- [ ] We might want a version detect and only enable this for 4.1+

![ide_autocomplete](https://user-images.githubusercontent.com/39854/79009379-962f1900-7b5f-11ea-9439-cdb50a5eb4e6.png)
