### PR TITLE
env() and __() translation key auto-complete.

### DIFF
--- a/docs/Generator.md
+++ b/docs/Generator.md
@@ -100,6 +100,12 @@ With this generator PHPStorm can auto-complete this, including all elements for 
 
 Now not just bool true/false, but also the possible "magic strings" are typehinted and usable as single click/enter.
 
+#### ENV keys
+`env()` is now auto-completed for most common and used keys.
+
+#### Translation keys
+Using `__()` and `__d()` can now also be auto-completed based on your project's `.po` files.
+
 #### Migrations plugin database tables
 When using the Migrations plugin, this task will come in handy to quickly autocomplete existing tables,
 their column names and possible column types.
@@ -206,7 +212,7 @@ $list = [
 ];
 $directive = new RegisterArgumentsSet($set, $list);
 ```
-Now you can use it as list value `argumentsSet("mySet")` inside the others.
+Now you can use it as list value `argumentsSet('mySet')` inside the others.
 For this just pass the `$directive` object itself to the list, which then contains only this one element.
 
 #### Example

--- a/src/Generator/Directive/ExpectedArguments.php
+++ b/src/Generator/Directive/ExpectedArguments.php
@@ -21,7 +21,7 @@ namespace IdeHelper\Generator\Directive;
  * expectedArguments(
  *     \MyClass::getFlags(),
  *     0,
- *     argumentsSet("myFileObjectFlags")
+ *     argumentsSet('myFileObjectFlags')
  * );
  */
 class ExpectedArguments extends BaseDirective {

--- a/src/Generator/Directive/ExpectedReturnValues.php
+++ b/src/Generator/Directive/ExpectedReturnValues.php
@@ -17,7 +17,7 @@ namespace IdeHelper\Generator\Directive;
  *
  * expectedReturnValues(
  *     \MyClass::getFlags(),
- *     argumentsSet("myFileObjectFlags")
+ *     argumentsSet('myFileObjectFlags')
  * );
  */
 class ExpectedReturnValues extends BaseDirective {

--- a/src/Generator/Directive/RegisterArgumentsSet.php
+++ b/src/Generator/Directive/RegisterArgumentsSet.php
@@ -78,7 +78,7 @@ TXT;
 	 * @return string
 	 */
 	public function __toString() {
-		return 'argumentsSet("' . $this->set . '")';
+		return 'argumentsSet(\'' . $this->set . '\')';
 	}
 
 }

--- a/src/Generator/Task/DatabaseTableColumnNameTask.php
+++ b/src/Generator/Task/DatabaseTableColumnNameTask.php
@@ -4,12 +4,15 @@ namespace IdeHelper\Generator\Task;
 
 use Cake\Datasource\ConnectionManager;
 use IdeHelper\Generator\Directive\ExpectedArguments;
+use IdeHelper\Generator\Directive\RegisterArgumentsSet;
 use IdeHelper\ValueObject\StringName;
 
 /**
  * This task is useful when using Migrations plugin and creating Migration files.
  */
 class DatabaseTableColumnNameTask extends DatabaseTableTask {
+
+	public const SET_TABLE_NAMES = 'tableNames';
 
 	/**
 	 * @var string[]
@@ -36,8 +39,11 @@ class DatabaseTableColumnNameTask extends DatabaseTableTask {
 		ksort($list);
 
 		$result = [];
+		$registerArgumentsSet = new RegisterArgumentsSet(static::SET_TABLE_NAMES, $list);
+		$result[$registerArgumentsSet->key()] = $registerArgumentsSet;
+
 		foreach ($this->aliases as $alias) {
-			$directive = new ExpectedArguments($alias, 0, $list);
+			$directive = new ExpectedArguments($alias, 0, [$registerArgumentsSet]);
 			$result[$directive->key()] = $directive;
 		}
 

--- a/src/Generator/Task/DatabaseTableColumnTypeTask.php
+++ b/src/Generator/Task/DatabaseTableColumnTypeTask.php
@@ -4,6 +4,7 @@ namespace IdeHelper\Generator\Task;
 
 use Cake\Core\Plugin;
 use IdeHelper\Generator\Directive\ExpectedArguments;
+use IdeHelper\Generator\Directive\RegisterArgumentsSet;
 use IdeHelper\ValueObject\StringName;
 use Migrations\Migrations;
 
@@ -11,6 +12,8 @@ use Migrations\Migrations;
  * This task is useful when using Migrations plugin and creating Migration files.
  */
 class DatabaseTableColumnTypeTask implements TaskInterface {
+
+	public const SET_TABLE_TYPES = 'tableTypes';
 
 	/**
 	 * @var string[]
@@ -63,8 +66,11 @@ class DatabaseTableColumnTypeTask implements TaskInterface {
 		ksort($list);
 
 		$result = [];
+		$registerArgumentsSet = new RegisterArgumentsSet(static::SET_TABLE_TYPES, $list);
+		$result[$registerArgumentsSet->key()] = $registerArgumentsSet;
+
 		foreach ($this->aliases as $alias) {
-			$directive = new ExpectedArguments($alias, 1, $list);
+			$directive = new ExpectedArguments($alias, 1, [$registerArgumentsSet]);
 			$result[$directive->key()] = $directive;
 		}
 

--- a/src/Generator/Task/EnvTask.php
+++ b/src/Generator/Task/EnvTask.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace IdeHelper\Generator\Task;
+
+use IdeHelper\Generator\Directive\ExpectedArguments;
+use IdeHelper\ValueObject\StringName;
+
+class EnvTask extends ModelTask {
+
+	public const METHOD_ENV = 'env()';
+
+	/**
+	 * Keys from Web based request, will be merged with CLI ones.
+	 *
+	 * @var string[]
+	 */
+	protected static $keys = [
+		'HTTP_HOST',
+		'HTTPS',
+		'REMOTE_ADDR',
+		'REMOTE_PORT',
+		'DOCUMENT_ROOT',
+		'DOCUMENT_URI',
+		'PHP_SELF',
+		'CGI_MODE',
+		'SCRIPT_NAME',
+		'HTTP_ACCEPT_LANGUAGE',
+		'HTTP_ACCEPT_ENCODING',
+		'HTTP_ACCEPT',
+		'HTTP_COOKIE',
+		'HTTP_USER_AGENT',
+		'HTTP_CONNECTION',
+		'HOME',
+		'REDIRECT_STATUS',
+		'SERVER_NAME',
+		'SERVER_PORT',
+		'SERVER_PROTOCOL',
+		'GATEWAY_INTERFACE',
+		'REQUEST_SCHEME',
+		'REQUEST_URI',
+		'REQUEST_METHOD',
+		'CONTENT_LENGTH',
+		'CONTENT_TYPE',
+		'QUERY_STRING',
+		'REQUEST_TIME',
+		'SCRIPT_FILENAME',
+	];
+
+	/**
+	 * @return \IdeHelper\Generator\Directive\BaseDirective[]
+	 */
+	public function collect(): array {
+		$result = [];
+
+		$keys = $this->envKeys();
+
+		ksort($keys);
+
+		$method = '\\' . static::METHOD_ENV;
+		$directive = new ExpectedArguments($method, 0, $keys);
+		$result[$directive->key()] = $directive;
+
+		return $result;
+	}
+
+	/**
+	 * @return \IdeHelper\ValueObject\StringName[]
+	 */
+	protected function envKeys(): array {
+		$keys = array_keys($_SERVER);
+		$keys = array_merge($keys, static::$keys);
+		$keys = array_unique($keys);
+
+		$list = [];
+
+		foreach ($keys as $key) {
+			if (strpos($key, '_') === 0) {
+				continue;
+			}
+
+			$list[$key] = StringName::create($key);
+		}
+
+		return $list;
+	}
+
+}

--- a/src/Generator/Task/TableAssociationTask.php
+++ b/src/Generator/Task/TableAssociationTask.php
@@ -8,7 +8,6 @@ use Cake\ORM\Association\HasMany;
 use Cake\ORM\Association\HasOne;
 use Cake\ORM\Table;
 use IdeHelper\Generator\Directive\Override;
-use IdeHelper\Generator\Directive\RegisterArgumentsSet;
 use IdeHelper\ValueObject\ClassName;
 
 class TableAssociationTask extends ModelTask {

--- a/src/Generator/Task/TableAssociationTask.php
+++ b/src/Generator/Task/TableAssociationTask.php
@@ -8,6 +8,7 @@ use Cake\ORM\Association\HasMany;
 use Cake\ORM\Association\HasOne;
 use Cake\ORM\Table;
 use IdeHelper\Generator\Directive\Override;
+use IdeHelper\Generator\Directive\RegisterArgumentsSet;
 use IdeHelper\ValueObject\ClassName;
 
 class TableAssociationTask extends ModelTask {

--- a/src/Generator/Task/TranslationKeyTask.php
+++ b/src/Generator/Task/TranslationKeyTask.php
@@ -5,7 +5,6 @@ namespace IdeHelper\Generator\Task;
 use Cake\I18n\Parser\PoFileParser;
 use Cake\Utility\Inflector;
 use IdeHelper\Generator\Directive\ExpectedArguments;
-use IdeHelper\Generator\Directive\RegisterArgumentsSet;
 use IdeHelper\Utility\App;
 use IdeHelper\Utility\Plugin;
 use IdeHelper\ValueObject\StringName;
@@ -143,12 +142,11 @@ class TranslationKeyTask implements TaskInterface {
 	}
 
 	/**
-	 * @param StringName[] $domains
+	 * @param \IdeHelper\ValueObject\StringName[] $domains
 	 *
-	 * @return StringName[]
+	 * @return \IdeHelper\ValueObject\StringName[]
 	 */
-	protected function completeDomains(array $domains): array
-	{
+	protected function completeDomains(array $domains): array {
 		$plugins = Plugin::all();
 		foreach ($plugins as $plugin) {
 			$pieces = explode('/', $plugin);

--- a/src/Generator/Task/TranslationKeyTask.php
+++ b/src/Generator/Task/TranslationKeyTask.php
@@ -106,6 +106,10 @@ class TranslationKeyTask implements TaskInterface {
 
 		$localePaths = App::path('locales');
 		foreach ($localePaths as $localePath) {
+			if (!is_dir($localePath)) {
+				continue;
+			}
+
 			$Directory = new RecursiveDirectoryIterator($localePath);
 			$Iterator = new RecursiveIteratorIterator($Directory);
 			$Regex = new RegexIterator($Iterator, '/^.+\.po/i', RecursiveRegexIterator::GET_MATCH);

--- a/src/Generator/Task/TranslationKeyTask.php
+++ b/src/Generator/Task/TranslationKeyTask.php
@@ -131,7 +131,8 @@ class TranslationKeyTask implements TaskInterface {
 
 			$plugins = Plugin::all();
 			foreach ($plugins as $plugin) {
-				$localePath = Plugin::path($plugin) . 'resources' . DIRECTORY_SEPARATOR . 'locales' . DIRECTORY_SEPARATOR;;
+				$localePath = Plugin::path($plugin) . 'resources' . DIRECTORY_SEPARATOR . 'locales' . DIRECTORY_SEPARATOR;
+
 				if (!is_dir($localePath)) {
 					continue;
 				}

--- a/src/Generator/Task/TranslationKeyTask.php
+++ b/src/Generator/Task/TranslationKeyTask.php
@@ -149,15 +149,20 @@ class TranslationKeyTask implements TaskInterface {
 	 */
 	protected function completeDomains(array $domains): array
 	{
-		$plugins = Plugin::loaded();
+		$plugins = Plugin::all();
 		foreach ($plugins as $plugin) {
 			$pieces = explode('/', $plugin);
 			foreach ($pieces as $key => $piece) {
 				$pieces[$key] = Inflector::underscore($piece);
 			}
 
-			//TODO: maybe remove unprefixed domain found?
 			$domain = implode('/', $pieces);
+
+			// Issue of https://github.com/cakephp/docs/pull/6585 and for 5.0 to be resolved
+			if (count($pieces) > 1) {
+				$lastPiece = array_pop($pieces);
+				unset($domains[$lastPiece]);
+			}
 
 			$domains[$domain] = StringName::create($domain);
 		}

--- a/src/Generator/Task/TranslationKeyTask.php
+++ b/src/Generator/Task/TranslationKeyTask.php
@@ -1,0 +1,170 @@
+<?php
+
+namespace IdeHelper\Generator\Task;
+
+use Cake\I18n\Parser\PoFileParser;
+use Cake\Utility\Inflector;
+use IdeHelper\Generator\Directive\ExpectedArguments;
+use IdeHelper\Generator\Directive\RegisterArgumentsSet;
+use IdeHelper\Utility\App;
+use IdeHelper\Utility\Plugin;
+use IdeHelper\ValueObject\StringName;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use RecursiveRegexIterator;
+use RegexIterator;
+
+/**
+ * @link https://book.cakephp.org/4/en/core-libraries/global-constants-and-functions.html#global-functions
+ */
+class TranslationKeyTask implements TaskInterface {
+
+	public const SET_TRANSLATION_KEYS = 'translationKeys';
+
+	/**
+	 * function __(string $singular, ...$args): string
+	 */
+	public const METHOD_DEFAULT = '__()';
+
+	/**
+	 * function __d(string $domain, string $msg, ...$args): string
+	 */
+	public const METHOD_DOMAIN = '__d()';
+
+	/**
+	 * @return \IdeHelper\Generator\Directive\BaseDirective[]
+	 */
+	public function collect(): array {
+		$result = [];
+
+		$translationKeys = $this->translationKeys();
+
+		$domains = [];
+		$domainKeys = [];
+		foreach ($translationKeys as $domain => $keys) {
+			if ($domain === 'default') {
+				$method = '\\' . static::METHOD_DEFAULT;
+				$directive = new ExpectedArguments($method, 0, $keys);
+				$result[$directive->key()] = $directive;
+
+				continue;
+			}
+
+			$domains[$domain] = StringName::create($domain);
+			$domainKeys += $keys;
+		}
+
+		if ($domainKeys) {
+			ksort($domainKeys);
+
+			$method = '\\' . static::METHOD_DOMAIN;
+			$directive = new ExpectedArguments($method, 1, $domainKeys);
+			$result[$directive->key()] = $directive;
+		}
+
+		$domains = $this->completeDomains($domains);
+
+		if ($domains) {
+			$method = '\\' . static::METHOD_DOMAIN;
+			$directive = new ExpectedArguments($method, 0, $domains);
+			$result[$directive->key()] = $directive;
+		}
+
+		return $result;
+	}
+
+	/**
+	 * @return \IdeHelper\ValueObject\StringName[][]
+	 */
+	protected function translationKeys(): array {
+		$translationsKeys = $this->parseTranslations();
+
+		foreach ($translationsKeys as $domain => $array) {
+			$array = array_unique($array);
+			$array = array_unique($array);
+
+			$result = [];
+			foreach ($array as $key) {
+				$key = $this->escapeSlashes($key);
+				$result[$key] = StringName::create($key);
+			}
+
+			ksort($result);
+
+			$translationsKeys[$domain] = $result;
+		}
+
+		ksort($translationsKeys);
+
+		return $translationsKeys;
+	}
+
+	/**
+	 * @return string[][]
+	 */
+	protected function parseTranslations(): array {
+		$keys = [];
+
+		$localePaths = App::path('locales');
+		foreach ($localePaths as $localePath) {
+			$Directory = new RecursiveDirectoryIterator($localePath);
+			$Iterator = new RecursiveIteratorIterator($Directory);
+			$Regex = new RegexIterator($Iterator, '/^.+\.po/i', RecursiveRegexIterator::GET_MATCH);
+
+			foreach ($Regex as $files) {
+				foreach ($files as $file) {
+					$domain = pathinfo($file, PATHINFO_FILENAME);
+
+					$result = (new PoFileParser())->parse($file);
+					$domainKeys = array_keys($result);
+
+					if (!isset($keys[$domain])) {
+						$keys[$domain] = [];
+					}
+					$keys[$domain] = array_merge($keys[$domain], $domainKeys);
+				}
+			}
+		}
+
+		return $keys;
+	}
+
+	/**
+	 * @param string $key
+	 *
+	 * @return string
+	 */
+	protected function escapeSlashes(string $key): string {
+		if (version_compare(PHP_VERSION, '7.3') >= 0) {
+			return filter_var($key, FILTER_SANITIZE_ADD_SLASHES);
+		}
+
+		return addcslashes($key, '\'');
+	}
+
+	/**
+	 * @param StringName[] $domains
+	 *
+	 * @return StringName[]
+	 */
+	protected function completeDomains(array $domains): array
+	{
+		$plugins = Plugin::loaded();
+		foreach ($plugins as $plugin) {
+			$pieces = explode('/', $plugin);
+			foreach ($pieces as $key => $piece) {
+				$pieces[$key] = Inflector::underscore($piece);
+			}
+
+			//TODO: maybe remove unprefixed domain found?
+			$domain = implode('/', $pieces);
+
+			$domains[$domain] = StringName::create($domain);
+		}
+
+		ksort($domains);
+
+		return $domains;
+	}
+
+}

--- a/src/Generator/TaskCollection.php
+++ b/src/Generator/TaskCollection.php
@@ -10,6 +10,7 @@ use IdeHelper\Generator\Task\DatabaseTableColumnTypeTask;
 use IdeHelper\Generator\Task\DatabaseTableTask;
 use IdeHelper\Generator\Task\DatabaseTypeTask;
 use IdeHelper\Generator\Task\ElementTask;
+use IdeHelper\Generator\Task\EnvTask;
 use IdeHelper\Generator\Task\HelperTask;
 use IdeHelper\Generator\Task\ModelTask;
 use IdeHelper\Generator\Task\PluginTask;
@@ -17,6 +18,7 @@ use IdeHelper\Generator\Task\RoutePathTask;
 use IdeHelper\Generator\Task\TableAssociationTask;
 use IdeHelper\Generator\Task\TableFinderTask;
 use IdeHelper\Generator\Task\TaskInterface;
+use IdeHelper\Generator\Task\TranslationKeyTask;
 use IdeHelper\Generator\Task\ValidationTask;
 use InvalidArgumentException;
 
@@ -37,9 +39,11 @@ class TaskCollection {
 		PluginTask::class => PluginTask::class,
 		ValidationTask::class => ValidationTask::class,
 		RoutePathTask::class => RoutePathTask::class,
+		EnvTask::class => EnvTask::class,
 		DatabaseTableTask::class => DatabaseTableTask::class,
 		DatabaseTableColumnNameTask::class => DatabaseTableColumnNameTask::class,
 		DatabaseTableColumnTypeTask::class => DatabaseTableColumnTypeTask::class,
+		TranslationKeyTask::class => TranslationKeyTask::class,
 	];
 
 	/**

--- a/tests/TestCase/Generator/Directive/RegisterArgumentsSetTest.php
+++ b/tests/TestCase/Generator/Directive/RegisterArgumentsSetTest.php
@@ -13,11 +13,11 @@ class RegisterArgumentsSetTest extends TestCase {
 	 * @return void
 	 */
 	public function testBuild() {
-		$map = [
+		$list = [
 			'\\Foo\\Bar',
 			'"string"',
 		];
-		$directive = new RegisterArgumentsSet('foo', $map);
+		$directive = new RegisterArgumentsSet('foo', $list);
 
 		$result = $directive->build();
 		$expected = <<<TXT
@@ -35,36 +35,36 @@ TXT;
 	 * @return void
 	 */
 	public function testToString() {
-		$map = [
+		$list = [
 			'\\Foo\\Bar',
 		];
-		$directive = new RegisterArgumentsSet('fooBar', $map);
+		$directive = new RegisterArgumentsSet('fooBar', $list);
 
 		$result = (string)$directive;
-		$this->assertSame('argumentsSet("fooBar")', $result);
+		$this->assertSame('argumentsSet(\'fooBar\')', $result);
 	}
 
 	/**
 	 * @return void
 	 */
 	public function testSetInsideArguments() {
-		$map = [
+		$list = [
 			'\\Foo\\Bar',
 			'"string"',
 		];
-		$argumentsSet = new RegisterArgumentsSet('fooBar', $map);
+		$argumentsSet = new RegisterArgumentsSet('fooBar', $list);
 
-		$map = [
+		$list = [
 			$argumentsSet,
 		];
-		$directive = new ExpectedArguments('\\My\\Class::someMethod()', 1, $map);
+		$directive = new ExpectedArguments('\\My\\Class::someMethod()', 1, $list);
 
 		$result = $directive->build();
 		$expected = <<<TXT
 	expectedArguments(
 		\\My\\Class::someMethod(),
 		1,
-		argumentsSet("fooBar")
+		argumentsSet('fooBar')
 	);
 TXT;
 		$this->assertSame($expected, $result);
@@ -74,22 +74,22 @@ TXT;
 	 * @return void
 	 */
 	public function testArgumentsSetInsideReturnValues() {
-		$map = [
+		$list = [
 			'\\Foo\\Bar',
 			'"string"',
 		];
-		$argumentsSet = new RegisterArgumentsSet('fooBar', $map);
+		$argumentsSet = new RegisterArgumentsSet('fooBar', $list);
 
-		$map = [
+		$list = [
 			$argumentsSet,
 		];
-		$directive = new ExpectedReturnValues('\\My\\Class::someMethod()', $map);
+		$directive = new ExpectedReturnValues('\\My\\Class::someMethod()', $list);
 
 		$result = $directive->build();
 		$expected = <<<TXT
 	expectedReturnValues(
 		\\My\\Class::someMethod(),
-		argumentsSet("fooBar")
+		argumentsSet('fooBar')
 	);
 TXT;
 		$this->assertSame($expected, $result);

--- a/tests/TestCase/Generator/PhpstormGeneratorTest.php
+++ b/tests/TestCase/Generator/PhpstormGeneratorTest.php
@@ -1,12 +1,14 @@
 <?php
 
-namespace IdeHelper\Test\TestCase\Generator\Task;
+namespace IdeHelper\Test\TestCase\Generator;
 
 use Cake\Core\Configure;
 use Cake\Core\Plugin;
 use IdeHelper\Generator\PhpstormGenerator;
 use IdeHelper\Generator\TaskCollection;
+use IdeHelper\Generator\Task\EnvTask;
 use Shim\TestSuite\TestCase;
+use TestApp\Generator\Task\TestEnvTask;
 
 class PhpstormGeneratorTest extends TestCase {
 
@@ -29,7 +31,9 @@ class PhpstormGeneratorTest extends TestCase {
 	public function setUp(): void {
 		parent::setUp();
 
-		$taskCollection = new TaskCollection();
+		$taskCollection = new TaskCollection([
+			EnvTask::class => TestEnvTask::class,
+		]);
 		$this->generator = new PhpstormGenerator($taskCollection);
 
 		$file = TMP . '.meta.php';

--- a/tests/TestCase/Generator/Task/DatabaseTableColumnNameTaskTest.php
+++ b/tests/TestCase/Generator/Task/DatabaseTableColumnNameTaskTest.php
@@ -4,7 +4,6 @@ namespace IdeHelper\Test\TestCase\Generator\Task;
 
 use Cake\TestSuite\TestCase;
 use IdeHelper\Generator\Task\DatabaseTableColumnNameTask;
-use IdeHelper\Generator\Task\DatabaseTableColumnTypeTask;
 
 class DatabaseTableColumnNameTaskTest extends TestCase {
 

--- a/tests/TestCase/Generator/Task/DatabaseTableColumnNameTaskTest.php
+++ b/tests/TestCase/Generator/Task/DatabaseTableColumnNameTaskTest.php
@@ -4,6 +4,7 @@ namespace IdeHelper\Test\TestCase\Generator\Task;
 
 use Cake\TestSuite\TestCase;
 use IdeHelper\Generator\Task\DatabaseTableColumnNameTask;
+use IdeHelper\Generator\Task\DatabaseTableColumnTypeTask;
 
 class DatabaseTableColumnNameTaskTest extends TestCase {
 
@@ -38,7 +39,11 @@ class DatabaseTableColumnNameTaskTest extends TestCase {
 	public function testCollect() {
 		$result = $this->task->collect();
 
-		$this->assertCount(5, $result);
+		$this->assertCount(6, $result);
+
+		/** @var \IdeHelper\Generator\Directive\RegisterArgumentsSet $directive */
+		$directive = array_shift($result);
+		$this->assertSame(DatabaseTableColumnNameTask::SET_TABLE_NAMES, $directive->toArray()['set']);
 
 		/** @var \IdeHelper\Generator\Directive\ExpectedArguments $directive */
 		$directive = array_shift($result);
@@ -50,11 +55,7 @@ class DatabaseTableColumnNameTaskTest extends TestCase {
 		}, $list);
 
 		$expectedList = [
-			'content' => "'content'",
-			'created' => "'created'",
-			'id' => "'id'",
-			'modified' => "'modified'",
-			'name' => "'name'",
+			'argumentsSet(\'tableNames\')',
 		];
 		$this->assertSame($expectedList, $list);
 

--- a/tests/TestCase/Generator/Task/DatabaseTableColumnTypeTaskTest.php
+++ b/tests/TestCase/Generator/Task/DatabaseTableColumnTypeTaskTest.php
@@ -9,7 +9,7 @@ use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\TestCase;
 use IdeHelper\Generator\Directive\ExpectedArguments;
 use IdeHelper\Generator\Task\DatabaseTableColumnTypeTask;
-use IdeHelper\Test\test_app\src\Generator\Task\TestDatabaseTableColumnTypeTask;
+use TestApp\Generator\Task\TestDatabaseTableColumnTypeTask;
 
 class DatabaseTableColumnTypeTaskTest extends TestCase {
 

--- a/tests/TestCase/Generator/Task/DatabaseTableColumnTypeTaskTest.php
+++ b/tests/TestCase/Generator/Task/DatabaseTableColumnTypeTaskTest.php
@@ -7,6 +7,7 @@ use Cake\Database\Driver\Mysql;
 use Cake\Database\Driver\Postgres;
 use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\TestCase;
+use IdeHelper\Generator\Directive\ExpectedArguments;
 use IdeHelper\Generator\Task\DatabaseTableColumnTypeTask;
 use IdeHelper\Test\test_app\src\Generator\Task\TestDatabaseTableColumnTypeTask;
 
@@ -43,13 +44,34 @@ class DatabaseTableColumnTypeTaskTest extends TestCase {
 	public function testCollect() {
 		$result = $this->task->collect();
 
-		$this->assertCount(2, $result);
+		$this->assertCount(3, $result);
+
+		/** @var \IdeHelper\Generator\Directive\RegisterArgumentsSet $directive */
+		$directive = array_shift($result);
+		$this->assertSame(DatabaseTableColumnTypeTask::SET_TABLE_TYPES, $directive->toArray()['set']);
+
+		$list = $directive->toArray()['list'];
+		$list = array_map(function ($className) {
+			return (string)$className;
+		}, $list);
+
+		$expectedList = [
+			'text' => "'text'",
+			'integer' => "'integer'",
+		];
+		foreach ($expectedList as $key => $value) {
+			$this->assertArrayHasKey($key, $list);
+			$this->assertSame($list[$key], $list[$key]);
+		}
 
 		/** @var \IdeHelper\Generator\Directive\ExpectedArguments $directive */
 		$directive = array_shift($result);
+		$this->assertInstanceOf(ExpectedArguments::class, $directive);
 		$this->assertSame('\Migrations\Table::addColumn()', $directive->toArray()['method']);
 
-		$list = $directive->toArray()['list'];
+		$list = array_map(function ($value) {
+			return (string)$value;
+		}, $list);
 
 		$expectedList = [
 			'text' => "'text'",
@@ -69,10 +91,10 @@ class DatabaseTableColumnTypeTaskTest extends TestCase {
 			return (string)$className;
 		}, $list);
 
-		foreach ($expectedList as $key => $value) {
-			$this->assertArrayHasKey($key, $list);
-			$this->assertSame($list[$key], $list[$key]);
-		}
+		$expectedList = [
+			'argumentsSet(\'tableTypes\')',
+		];
+		$this->assertSame($expectedList, $list);
 	}
 
 	/**

--- a/tests/TestCase/Generator/Task/DatabaseTableColumnTypeTaskTest.php
+++ b/tests/TestCase/Generator/Task/DatabaseTableColumnTypeTaskTest.php
@@ -114,7 +114,24 @@ class DatabaseTableColumnTypeTaskTest extends TestCase {
 		$this->task = new TestDatabaseTableColumnTypeTask();
 		$result = $this->task->collect();
 
-		$this->assertCount(2, $result);
+		$this->assertCount(3, $result);
+
+		/** @var \IdeHelper\Generator\Directive\RegisterArgumentsSet $directive */
+		$directive = array_shift($result);
+		$this->assertSame(DatabaseTableColumnTypeTask::SET_TABLE_TYPES, $directive->toArray()['set']);
+
+		$list = $directive->toArray()['list'];
+		$list = array_map(function ($className) {
+			return (string)$className;
+		}, $list);
+		$expectedList = [
+			'text' => "'text'",
+			'integer' => "'integer'",
+		];
+		foreach ($expectedList as $key => $value) {
+			$this->assertArrayHasKey($key, $list);
+			$this->assertSame($list[$key], $list[$key]);
+		}
 
 		/** @var \IdeHelper\Generator\Directive\ExpectedArguments $directive */
 		$directive = array_shift($result);
@@ -126,13 +143,13 @@ class DatabaseTableColumnTypeTaskTest extends TestCase {
 		}, $list);
 
 		$expectedList = [
-			'text' => "'text'",
-			'integer' => "'integer'",
+			'argumentsSet(\'tableTypes\')',
 		];
-		foreach ($expectedList as $key => $value) {
-			$this->assertArrayHasKey($key, $list);
-			$this->assertSame($list[$key], $list[$key]);
-		}
+		$this->assertSame($expectedList, $list);
+
+		/** @var \IdeHelper\Generator\Directive\ExpectedArguments $directive */
+		$directive = array_shift($result);
+		$this->assertSame('\Migrations\Table::changeColumn()', $directive->toArray()['method']);
 
 		Plugin::getCollection()->remove('Migrations');
 		$this->assertFalse(Plugin::isLoaded('Migrations'));

--- a/tests/TestCase/Generator/Task/EnvTaskTest.php
+++ b/tests/TestCase/Generator/Task/EnvTaskTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace IdeHelper\Test\TestCase\Generator\Task;
+
+use IdeHelper\Generator\Task\EnvTask;
+use Shim\TestSuite\TestCase;
+
+class EnvTaskTest extends TestCase {
+
+	/**
+	 * @var \IdeHelper\Generator\Task\EnvTask
+	 */
+	protected $task;
+
+	/**
+	 * @return void
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->task = new EnvTask();
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testCollect() {
+		$result = $this->task->collect();
+
+		$this->assertCount(1, $result);
+
+		/** @var \IdeHelper\Generator\Directive\ExpectedArguments $directive */
+		$directive = array_shift($result);
+		$this->assertSame('\env()', $directive->toArray()['method']);
+
+		$list = $directive->toArray()['list'];
+		$list = array_map(function ($className) {
+			return (string)$className;
+		}, $list);
+
+		$expected = [
+			'HTTP_HOST' => "'HTTP_HOST'",
+			'REMOTE_ADDR' => "'REMOTE_ADDR'",
+		];
+		foreach ($expected as $key => $value) {
+			$this->assertSame($value, $list[$key]);
+		}
+	}
+
+}

--- a/tests/TestCase/Generator/Task/TranslationKeyTaskTest.php
+++ b/tests/TestCase/Generator/Task/TranslationKeyTaskTest.php
@@ -73,12 +73,12 @@ class TranslationKeyTaskTest extends TestCase {
 			return (string)$className;
 		}, $list);
 
+		// 'my_plugin' is now superseeded by 'my_namespace/my_plugin'
 		$expected = [
 			'awesome' => '\'awesome\'',
 			'controllers' => '\'controllers\'',
 			'ide_helper' => '\'ide_helper\'',
 			'my_namespace/my_plugin' => '\'my_namespace/my_plugin\'',
-			'my_plugin' => '\'my_plugin\'',
 			'relations' => '\'relations\'',
 			'shim' => '\'shim\'',
 		];

--- a/tests/TestCase/Generator/Task/TranslationKeyTaskTest.php
+++ b/tests/TestCase/Generator/Task/TranslationKeyTaskTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace IdeHelper\Test\TestCase\Generator\Task;
+
+use Cake\Core\Configure;
+use IdeHelper\Generator\Task\TranslationKeyTask;
+use Shim\TestSuite\TestCase;
+
+class TranslationKeyTaskTest extends TestCase {
+
+	/**
+	 * @var \IdeHelper\Generator\Task\TranslationKeyTask
+	 */
+	protected $task;
+
+	/**
+	 * @return void
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->task = new TranslationKeyTask();
+
+		Configure::write('App.paths.locales', [
+			TEST_ROOT . 'locales' . DS,
+		]);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testCollect() {
+		$result = $this->task->collect();
+
+		$this->assertCount(3, $result);
+
+		/** @var \IdeHelper\Generator\Directive\ExpectedArguments $directive */
+		$directive = array_shift($result);
+		$this->assertSame('\__()', $directive->toArray()['method']);
+
+		$list = $directive->toArray()['list'];
+		$list = array_map(function ($className) {
+			return (string)$className;
+		}, $list);
+
+		$expected = [
+			'A {0} placeholder' => "'A {0} placeholder'",
+			'Some \\\' special case' => '\'Some \\\' special case\'',
+			'my foo and bar' => "'my foo and bar'",
+		];
+		$this->assertSame($expected, $list);
+
+		/** @var \IdeHelper\Generator\Directive\ExpectedArguments $directive */
+		$directive = array_shift($result);
+		$this->assertSame('\__d()', $directive->toArray()['method']);
+
+		$list = $directive->toArray()['list'];
+		$list = array_map(function ($className) {
+			return (string)$className;
+		}, $list);
+
+		$expected = [
+			'A plugin translation' => '\'A plugin translation\'',
+		];
+		$this->assertSame($expected, $list);
+
+		/** @var \IdeHelper\Generator\Directive\ExpectedArguments $directive */
+		$directive = array_shift($result);
+		$this->assertSame('\__d()', $directive->toArray()['method']);
+
+		$list = $directive->toArray()['list'];
+		$list = array_map(function ($className) {
+			return (string)$className;
+		}, $list);
+
+		$expected = [
+			'awesome' => '\'awesome\'',
+			'controllers' => '\'controllers\'',
+			'ide_helper' => '\'ide_helper\'',
+			'my_namespace/my_plugin' => '\'my_namespace/my_plugin\'',
+			'my_plugin' => '\'my_plugin\'',
+			'relations' => '\'relations\'',
+			'shim' => '\'shim\'',
+		];
+		$this->assertSame($expected, $list);
+	}
+
+}

--- a/tests/test_app/locales/de/default.po
+++ b/tests/test_app/locales/de/default.po
@@ -1,0 +1,6 @@
+
+msgid "my foo and bar"
+msgstr "mein foo und bar"
+
+msgid "A {0} placeholder"
+msgstr "Ein {0} Platzhalter"

--- a/tests/test_app/locales/de/my_plugin.po
+++ b/tests/test_app/locales/de/my_plugin.po
@@ -1,0 +1,3 @@
+
+msgid "A plugin translation"
+msgstr "Eine Plugin Übersetzung"

--- a/tests/test_app/locales/en/default.po
+++ b/tests/test_app/locales/en/default.po
@@ -1,0 +1,6 @@
+
+msgid "my foo and bar"
+msgstr ""
+
+msgid "Some ' special case"
+msgstr "Ein ' besonderer Fall"

--- a/tests/test_app/src/Generator/Task/TestDatabaseTableColumnTypeTask.php
+++ b/tests/test_app/src/Generator/Task/TestDatabaseTableColumnTypeTask.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace IdeHelper\Test\test_app\src\Generator\Task;
+namespace TestApp\Generator\Task;
 
 use IdeHelper\Generator\Task\DatabaseTableColumnTypeTask;
 

--- a/tests/test_app/src/Generator/Task/TestEnvTask.php
+++ b/tests/test_app/src/Generator/Task/TestEnvTask.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace TestApp\Generator\Task;
+
+use IdeHelper\Generator\Directive\ExpectedArguments;
+use IdeHelper\Generator\Task\EnvTask;
+use IdeHelper\ValueObject\StringName;
+
+class TestEnvTask extends EnvTask {
+
+	/**
+	 * @return \IdeHelper\ValueObject\StringName[]
+	 */
+	protected function envKeys(): array {
+		$list = parent::envKeys();
+
+		$list = [
+			'HTTP_HOST' => $list['HTTP_HOST'],
+		];
+
+		return $list;
+	}
+
+}

--- a/tests/test_files/meta/phpstorm/.meta.php
+++ b/tests/test_files/meta/phpstorm/.meta.php
@@ -361,6 +361,17 @@ namespace PHPSTORM_META {
 	);
 
 	expectedArguments(
+		\__d(),
+		0,
+		'awesome',
+		'controllers',
+		'ide_helper',
+		'my_namespace/my_plugin',
+		'relations',
+		'shim'
+	);
+
+	expectedArguments(
 		\env(),
 		0,
 		'HTTP_HOST'

--- a/tests/test_files/meta/phpstorm/.meta.php
+++ b/tests/test_files/meta/phpstorm/.meta.php
@@ -321,50 +321,61 @@ namespace PHPSTORM_META {
 	expectedArguments(
 		\Migrations\Table::addColumn(),
 		0,
-		'content',
-		'created',
-		'id',
-		'name'
+		argumentsSet('tableNames')
 	);
 
 	expectedArguments(
 		\Migrations\Table::addColumn(),
 		1,
-		'biginteger',
-		'binary',
-		'binaryuuid',
-		'bit',
-		'blob',
-		'boolean',
-		'char',
-		'date',
-		'datetime',
-		'decimal',
-		'double',
-		'float',
-		'integer',
-		'json',
-		'smallinteger',
-		'string',
-		'text',
-		'time',
-		'timestamp',
-		'uuid',
-		'year'
+		argumentsSet('tableTypes')
 	);
 
 	expectedArguments(
 		\Migrations\Table::changeColumn(),
 		0,
-		'content',
-		'created',
-		'id',
-		'name'
+		argumentsSet('tableNames')
 	);
 
 	expectedArguments(
 		\Migrations\Table::changeColumn(),
 		1,
+		argumentsSet('tableTypes')
+	);
+
+	expectedArguments(
+		\Migrations\Table::hasColumn(),
+		0,
+		argumentsSet('tableNames')
+	);
+
+	expectedArguments(
+		\Migrations\Table::removeColumn(),
+		0,
+		argumentsSet('tableNames')
+	);
+
+	expectedArguments(
+		\Migrations\Table::renameColumn(),
+		0,
+		argumentsSet('tableNames')
+	);
+
+	expectedArguments(
+		\env(),
+		0,
+		'HTTP_HOST'
+	);
+
+	registerArgumentsSet(
+		'tableNames',
+		'content',
+		'created',
+		'id',
+		'name'
+	);
+
+	registerArgumentsSet(
+		'tableTypes',
 		'biginteger',
 		'binary',
 		'binaryuuid',
@@ -386,33 +397,6 @@ namespace PHPSTORM_META {
 		'timestamp',
 		'uuid',
 		'year'
-	);
-
-	expectedArguments(
-		\Migrations\Table::hasColumn(),
-		0,
-		'content',
-		'created',
-		'id',
-		'name'
-	);
-
-	expectedArguments(
-		\Migrations\Table::removeColumn(),
-		0,
-		'content',
-		'created',
-		'id',
-		'name'
-	);
-
-	expectedArguments(
-		\Migrations\Table::renameColumn(),
-		0,
-		'content',
-		'created',
-		'id',
-		'name'
 	);
 
 }


### PR DESCRIPTION
![ide_autocomplete_translations](https://user-images.githubusercontent.com/39854/79483089-11864400-8012-11ea-9ee6-07d852f4a18d.png)


Refs https://github.com/dereuromark/cakephp-ide-helper/issues/182

## TODO

Plugin domains are still a bit wonky
See https://github.com/cakephp/docs/pull/6585 issue