### PR TITLE
Add Entity autocomplete.

### DIFF
--- a/docs/Generator.md
+++ b/docs/Generator.md
@@ -8,6 +8,7 @@ PhpStorm TOC
 - [Available tasks](#available-tasks)
   * [Plugins](#plugins)
   * [Models](#models)
+  * [Entities](#entities)
   * [TableAssociations](#tableassociations)
   * [TableFinders](#tablefinders)
   * [Behaviors](#behaviors)
@@ -88,6 +89,15 @@ $users->doSomething();
 It now knows the concrete object of `$users` and can autocomplete the method call right away.
 
 You will not be able to quickly select from a list of input options, however.
+
+#### Entities
+The following is now auto-completed, for example:
+```php
+$user->setDirty('field_name');
+$user->setError('field_name');
+$user->getOriginal('field_name');
+...
+```
 
 #### TableAssociations
 The following is now auto-completed, for example:

--- a/src/Generator/Task/EntityTask.php
+++ b/src/Generator/Task/EntityTask.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace IdeHelper\Generator\Task;
+
+use IdeHelper\Generator\Directive\ExpectedArguments;
+use IdeHelper\Generator\Directive\RegisterArgumentsSet;
+use IdeHelper\ValueObject\StringName;
+
+class EntityTask extends ModelTask {
+
+	public const SET_ENTITY_FIELDS = 'entityFields';
+
+	/**
+	 * @var int[] array<string, int>
+	 */
+	public static $methods = [
+		'has' => 0,
+		'get' => 0,
+		'hasValue' => 0,
+		'isEmpty' => 0,
+		'isDirty' => 0,
+		'getOriginal' => 0,
+		'setDirty' => 0,
+		'setError' => 0,
+		'getError' => 0,
+		'getInvalidField' => 0,
+	];
+
+	/**
+	 * @return \IdeHelper\Generator\Directive\BaseDirective[]
+	 */
+	public function collect(): array {
+		$fields = $this->getEntityFields();
+
+		$result = [];
+		foreach ($fields as $entityClass => $entityFields) {
+			$registerArgumentsSet = new RegisterArgumentsSet(static::SET_ENTITY_FIELDS . ':' . $entityClass, $entityFields);
+			$result[$registerArgumentsSet->key()] = $registerArgumentsSet;
+
+			foreach (static::$methods as $method => $position) {
+				$entityMethod = '\\' . $entityClass . '::' . $method . '()';
+				$directive = new ExpectedArguments($entityMethod, $position, [$registerArgumentsSet]);
+				$result[$directive->key()] = $directive;
+			}
+		}
+
+		return $result;
+	}
+
+	/**
+	 * @return string[][]
+	 */
+	protected function getEntityFields(): array {
+		$modelFields = [];
+
+		$models = $this->collectModels();
+		foreach ($models as $model => $className) {
+			$fields = [];
+			try {
+				/** @var \Cake\ORM\Table $tableObject */
+				$tableObject = new $className();
+				$fields = $tableObject->getSchema()->columns();
+			} catch (\Exception $exception) {
+				// Do nothing
+			}
+
+			if (!$fields) {
+				continue;
+			}
+
+			$entityClass = $tableObject->getEntityClass();
+
+			$list = [];
+			foreach ($fields as $field) {
+				$list[$field] = StringName::create($field);
+			}
+
+			ksort($list);
+
+			$modelFields[$entityClass] = $list;
+		}
+
+		return $modelFields;
+	}
+
+}

--- a/src/Generator/Task/EntityTask.php
+++ b/src/Generator/Task/EntityTask.php
@@ -62,13 +62,14 @@ class EntityTask extends ModelTask {
 				$fields = $tableObject->getSchema()->columns();
 			} catch (\Exception $exception) {
 				// Do nothing
+				$tableObject = null;
 			}
 
 			if (!$fields) {
 				continue;
 			}
 
-			$entityClass = $tableObject->getEntityClass();
+			$entityClass = $tableObject ? $tableObject->getEntityClass() : null;
 
 			$list = [];
 			foreach ($fields as $field) {

--- a/src/Generator/TaskCollection.php
+++ b/src/Generator/TaskCollection.php
@@ -14,6 +14,7 @@ use IdeHelper\Generator\Task\DatabaseTableColumnTypeTask;
 use IdeHelper\Generator\Task\DatabaseTableTask;
 use IdeHelper\Generator\Task\DatabaseTypeTask;
 use IdeHelper\Generator\Task\ElementTask;
+use IdeHelper\Generator\Task\EntityTask;
 use IdeHelper\Generator\Task\EnvTask;
 use IdeHelper\Generator\Task\FixtureTask;
 use IdeHelper\Generator\Task\FormHelperTask;
@@ -61,6 +62,7 @@ class TaskCollection {
 		DatabaseTableTask::class => DatabaseTableTask::class,
 		DatabaseTableColumnNameTask::class => DatabaseTableColumnNameTask::class,
 		DatabaseTableColumnTypeTask::class => DatabaseTableColumnTypeTask::class,
+		EntityTask::class => EntityTask::class,
 		FixtureTask::class => FixtureTask::class,
 		TranslationKeyTask::class => TranslationKeyTask::class,
 		ConfigureTask::class => ConfigureTask::class,

--- a/tests/TestCase/Generator/PhpstormGeneratorTest.php
+++ b/tests/TestCase/Generator/PhpstormGeneratorTest.php
@@ -52,9 +52,7 @@ class PhpstormGeneratorTest extends TestCase {
 		Configure::write('IdeHelper.skipDatabaseTables', ['/^(?!wheels)/']);
 
 		$result = $this->generator->generate();
-		if ($this->isDebug()) {
-			file_put_contents(TMP . '.meta.php', $result);
-		}
+		file_put_contents(TMP . '.meta.php', $result);
 
 		$file = Plugin::path('IdeHelper') . 'tests' . DS . 'test_files' . DS . 'meta' . DS . 'phpstorm' . DS . '.meta.php';
 		$expected = file_get_contents($file);

--- a/tests/TestCase/Generator/Task/EntityTaskTest.php
+++ b/tests/TestCase/Generator/Task/EntityTaskTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace IdeHelper\Test\TestCase\Generator\Task;
+
+use Cake\TestSuite\TestCase;
+use IdeHelper\Generator\Directive\ExpectedArguments;
+use IdeHelper\Generator\Directive\RegisterArgumentsSet;
+use IdeHelper\Generator\Task\EntityTask;
+
+class EntityTaskTest extends TestCase {
+
+	/**
+	 * @var string[]
+	 */
+	protected $fixtures = [
+		'plugin.IdeHelper.Cars',
+		'plugin.IdeHelper.Wheels',
+	];
+
+	/**
+	 * @var \IdeHelper\Generator\Task\EntityTask
+	 */
+	protected $task;
+
+	/**
+	 * @return void
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->task = new EntityTask();
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testCollect() {
+		$result = $this->task->collect();
+
+		$this->assertCount(66, $result);
+
+		/** @var \IdeHelper\Generator\Directive\RegisterArgumentsSet $directive */
+		$directive = array_shift($result);
+		$this->assertInstanceOf(RegisterArgumentsSet::class, $directive);
+		$this->assertStringContainsString(EntityTask::SET_ENTITY_FIELDS, $directive->toArray()['set']);
+
+		$list = $directive->toArray()['list'];
+		$list = array_map(function ($className) {
+			return (string)$className;
+		}, $list);
+
+		$expected = [
+			'content' => "'content'",
+			'created' => "'created'",
+			'id' => "'id'",
+			'modified' => "'modified'",
+			'name' => "'name'",
+		];
+		$this->assertSame($expected, $list);
+
+		$directive = array_shift($result);
+		$this->assertInstanceOf(ExpectedArguments::class, $directive);
+	}
+
+}

--- a/tests/TestCase/Generator/Task/EntityTaskTest.php
+++ b/tests/TestCase/Generator/Task/EntityTaskTest.php
@@ -37,7 +37,7 @@ class EntityTaskTest extends TestCase {
 	public function testCollect() {
 		$result = $this->task->collect();
 
-		$this->assertCount(66, $result);
+		$this->assertCount(88, $result);
 
 		/** @var \IdeHelper\Generator\Directive\RegisterArgumentsSet $directive */
 		$directive = array_shift($result);
@@ -53,7 +53,6 @@ class EntityTaskTest extends TestCase {
 			'content' => "'content'",
 			'created' => "'created'",
 			'id' => "'id'",
-			'modified' => "'modified'",
 			'name' => "'name'",
 		];
 		$this->assertSame($expected, $list);

--- a/tests/TestCase/Shell/PhpstormShellTest.php
+++ b/tests/TestCase/Shell/PhpstormShellTest.php
@@ -43,6 +43,8 @@ class PhpstormShellTest extends TestCase {
 		}
 		if (file_exists(TMP . 'phpstorm' . DS . '.meta.php')) {
 			unlink(TMP . 'phpstorm' . DS . '.meta.php');
+		}
+		if (is_dir(TMP . 'phpstorm')) {
 			rmdir(TMP . 'phpstorm');
 		}
 

--- a/tests/test_files/meta/phpstorm/.meta.php
+++ b/tests/test_files/meta/phpstorm/.meta.php
@@ -939,6 +939,126 @@ namespace PHPSTORM_META {
 	);
 
 	expectedArguments(
+		\TestApp\Model\Entity\BarBar::get(),
+		0,
+		argumentsSet('entityFields:TestApp\Model\Entity\BarBar')
+	);
+
+	expectedArguments(
+		\TestApp\Model\Entity\BarBar::getError(),
+		0,
+		argumentsSet('entityFields:TestApp\Model\Entity\BarBar')
+	);
+
+	expectedArguments(
+		\TestApp\Model\Entity\BarBar::getInvalidField(),
+		0,
+		argumentsSet('entityFields:TestApp\Model\Entity\BarBar')
+	);
+
+	expectedArguments(
+		\TestApp\Model\Entity\BarBar::getOriginal(),
+		0,
+		argumentsSet('entityFields:TestApp\Model\Entity\BarBar')
+	);
+
+	expectedArguments(
+		\TestApp\Model\Entity\BarBar::has(),
+		0,
+		argumentsSet('entityFields:TestApp\Model\Entity\BarBar')
+	);
+
+	expectedArguments(
+		\TestApp\Model\Entity\BarBar::hasValue(),
+		0,
+		argumentsSet('entityFields:TestApp\Model\Entity\BarBar')
+	);
+
+	expectedArguments(
+		\TestApp\Model\Entity\BarBar::isDirty(),
+		0,
+		argumentsSet('entityFields:TestApp\Model\Entity\BarBar')
+	);
+
+	expectedArguments(
+		\TestApp\Model\Entity\BarBar::isEmpty(),
+		0,
+		argumentsSet('entityFields:TestApp\Model\Entity\BarBar')
+	);
+
+	expectedArguments(
+		\TestApp\Model\Entity\BarBar::setDirty(),
+		0,
+		argumentsSet('entityFields:TestApp\Model\Entity\BarBar')
+	);
+
+	expectedArguments(
+		\TestApp\Model\Entity\BarBar::setError(),
+		0,
+		argumentsSet('entityFields:TestApp\Model\Entity\BarBar')
+	);
+
+	expectedArguments(
+		\TestApp\Model\Entity\BarBarsAbstract::get(),
+		0,
+		argumentsSet('entityFields:TestApp\Model\Entity\BarBarsAbstract')
+	);
+
+	expectedArguments(
+		\TestApp\Model\Entity\BarBarsAbstract::getError(),
+		0,
+		argumentsSet('entityFields:TestApp\Model\Entity\BarBarsAbstract')
+	);
+
+	expectedArguments(
+		\TestApp\Model\Entity\BarBarsAbstract::getInvalidField(),
+		0,
+		argumentsSet('entityFields:TestApp\Model\Entity\BarBarsAbstract')
+	);
+
+	expectedArguments(
+		\TestApp\Model\Entity\BarBarsAbstract::getOriginal(),
+		0,
+		argumentsSet('entityFields:TestApp\Model\Entity\BarBarsAbstract')
+	);
+
+	expectedArguments(
+		\TestApp\Model\Entity\BarBarsAbstract::has(),
+		0,
+		argumentsSet('entityFields:TestApp\Model\Entity\BarBarsAbstract')
+	);
+
+	expectedArguments(
+		\TestApp\Model\Entity\BarBarsAbstract::hasValue(),
+		0,
+		argumentsSet('entityFields:TestApp\Model\Entity\BarBarsAbstract')
+	);
+
+	expectedArguments(
+		\TestApp\Model\Entity\BarBarsAbstract::isDirty(),
+		0,
+		argumentsSet('entityFields:TestApp\Model\Entity\BarBarsAbstract')
+	);
+
+	expectedArguments(
+		\TestApp\Model\Entity\BarBarsAbstract::isEmpty(),
+		0,
+		argumentsSet('entityFields:TestApp\Model\Entity\BarBarsAbstract')
+	);
+
+	expectedArguments(
+		\TestApp\Model\Entity\BarBarsAbstract::setDirty(),
+		0,
+		argumentsSet('entityFields:TestApp\Model\Entity\BarBarsAbstract')
+	);
+
+	expectedArguments(
+		\TestApp\Model\Entity\BarBarsAbstract::setError(),
+		0,
+		argumentsSet('entityFields:TestApp\Model\Entity\BarBarsAbstract')
+	);
+
+	expectedArguments(
 		\TestApp\Model\Entity\Car::get(),
 		0,
 		argumentsSet('entityFields:TestApp\Model\Entity\Car')
@@ -1163,6 +1283,22 @@ namespace PHPSTORM_META {
 
 	registerArgumentsSet(
 		'entityFields:Relations\Model\Entity\User',
+		'id',
+		'name'
+	);
+
+	registerArgumentsSet(
+		'entityFields:TestApp\Model\Entity\BarBar',
+		'content',
+		'created',
+		'id',
+		'name'
+	);
+
+	registerArgumentsSet(
+		'entityFields:TestApp\Model\Entity\BarBarsAbstract',
+		'content',
+		'created',
 		'id',
 		'name'
 	);

--- a/tests/test_files/meta/phpstorm/.meta.php
+++ b/tests/test_files/meta/phpstorm/.meta.php
@@ -265,6 +265,66 @@ namespace PHPSTORM_META {
 		])
 	);
 
+	expectedArguments(
+		\Cake\ORM\Entity::get(),
+		0,
+		argumentsSet('entityFields:Cake\ORM\Entity')
+	);
+
+	expectedArguments(
+		\Cake\ORM\Entity::getError(),
+		0,
+		argumentsSet('entityFields:Cake\ORM\Entity')
+	);
+
+	expectedArguments(
+		\Cake\ORM\Entity::getInvalidField(),
+		0,
+		argumentsSet('entityFields:Cake\ORM\Entity')
+	);
+
+	expectedArguments(
+		\Cake\ORM\Entity::getOriginal(),
+		0,
+		argumentsSet('entityFields:Cake\ORM\Entity')
+	);
+
+	expectedArguments(
+		\Cake\ORM\Entity::has(),
+		0,
+		argumentsSet('entityFields:Cake\ORM\Entity')
+	);
+
+	expectedArguments(
+		\Cake\ORM\Entity::hasValue(),
+		0,
+		argumentsSet('entityFields:Cake\ORM\Entity')
+	);
+
+	expectedArguments(
+		\Cake\ORM\Entity::isDirty(),
+		0,
+		argumentsSet('entityFields:Cake\ORM\Entity')
+	);
+
+	expectedArguments(
+		\Cake\ORM\Entity::isEmpty(),
+		0,
+		argumentsSet('entityFields:Cake\ORM\Entity')
+	);
+
+	expectedArguments(
+		\Cake\ORM\Entity::setDirty(),
+		0,
+		argumentsSet('entityFields:Cake\ORM\Entity')
+	);
+
+	expectedArguments(
+		\Cake\ORM\Entity::setError(),
+		0,
+		argumentsSet('entityFields:Cake\ORM\Entity')
+	);
+
 	override(
 		\Cake\ORM\Locator\LocatorInterface::get(0),
 		map([
@@ -686,6 +746,306 @@ namespace PHPSTORM_META {
 	);
 
 	expectedArguments(
+		\Relations\Model\Entity\Bar::get(),
+		0,
+		argumentsSet('entityFields:Relations\Model\Entity\Bar')
+	);
+
+	expectedArguments(
+		\Relations\Model\Entity\Bar::getError(),
+		0,
+		argumentsSet('entityFields:Relations\Model\Entity\Bar')
+	);
+
+	expectedArguments(
+		\Relations\Model\Entity\Bar::getInvalidField(),
+		0,
+		argumentsSet('entityFields:Relations\Model\Entity\Bar')
+	);
+
+	expectedArguments(
+		\Relations\Model\Entity\Bar::getOriginal(),
+		0,
+		argumentsSet('entityFields:Relations\Model\Entity\Bar')
+	);
+
+	expectedArguments(
+		\Relations\Model\Entity\Bar::has(),
+		0,
+		argumentsSet('entityFields:Relations\Model\Entity\Bar')
+	);
+
+	expectedArguments(
+		\Relations\Model\Entity\Bar::hasValue(),
+		0,
+		argumentsSet('entityFields:Relations\Model\Entity\Bar')
+	);
+
+	expectedArguments(
+		\Relations\Model\Entity\Bar::isDirty(),
+		0,
+		argumentsSet('entityFields:Relations\Model\Entity\Bar')
+	);
+
+	expectedArguments(
+		\Relations\Model\Entity\Bar::isEmpty(),
+		0,
+		argumentsSet('entityFields:Relations\Model\Entity\Bar')
+	);
+
+	expectedArguments(
+		\Relations\Model\Entity\Bar::setDirty(),
+		0,
+		argumentsSet('entityFields:Relations\Model\Entity\Bar')
+	);
+
+	expectedArguments(
+		\Relations\Model\Entity\Bar::setError(),
+		0,
+		argumentsSet('entityFields:Relations\Model\Entity\Bar')
+	);
+
+	expectedArguments(
+		\Relations\Model\Entity\Foo::get(),
+		0,
+		argumentsSet('entityFields:Relations\Model\Entity\Foo')
+	);
+
+	expectedArguments(
+		\Relations\Model\Entity\Foo::getError(),
+		0,
+		argumentsSet('entityFields:Relations\Model\Entity\Foo')
+	);
+
+	expectedArguments(
+		\Relations\Model\Entity\Foo::getInvalidField(),
+		0,
+		argumentsSet('entityFields:Relations\Model\Entity\Foo')
+	);
+
+	expectedArguments(
+		\Relations\Model\Entity\Foo::getOriginal(),
+		0,
+		argumentsSet('entityFields:Relations\Model\Entity\Foo')
+	);
+
+	expectedArguments(
+		\Relations\Model\Entity\Foo::has(),
+		0,
+		argumentsSet('entityFields:Relations\Model\Entity\Foo')
+	);
+
+	expectedArguments(
+		\Relations\Model\Entity\Foo::hasValue(),
+		0,
+		argumentsSet('entityFields:Relations\Model\Entity\Foo')
+	);
+
+	expectedArguments(
+		\Relations\Model\Entity\Foo::isDirty(),
+		0,
+		argumentsSet('entityFields:Relations\Model\Entity\Foo')
+	);
+
+	expectedArguments(
+		\Relations\Model\Entity\Foo::isEmpty(),
+		0,
+		argumentsSet('entityFields:Relations\Model\Entity\Foo')
+	);
+
+	expectedArguments(
+		\Relations\Model\Entity\Foo::setDirty(),
+		0,
+		argumentsSet('entityFields:Relations\Model\Entity\Foo')
+	);
+
+	expectedArguments(
+		\Relations\Model\Entity\Foo::setError(),
+		0,
+		argumentsSet('entityFields:Relations\Model\Entity\Foo')
+	);
+
+	expectedArguments(
+		\Relations\Model\Entity\User::get(),
+		0,
+		argumentsSet('entityFields:Relations\Model\Entity\User')
+	);
+
+	expectedArguments(
+		\Relations\Model\Entity\User::getError(),
+		0,
+		argumentsSet('entityFields:Relations\Model\Entity\User')
+	);
+
+	expectedArguments(
+		\Relations\Model\Entity\User::getInvalidField(),
+		0,
+		argumentsSet('entityFields:Relations\Model\Entity\User')
+	);
+
+	expectedArguments(
+		\Relations\Model\Entity\User::getOriginal(),
+		0,
+		argumentsSet('entityFields:Relations\Model\Entity\User')
+	);
+
+	expectedArguments(
+		\Relations\Model\Entity\User::has(),
+		0,
+		argumentsSet('entityFields:Relations\Model\Entity\User')
+	);
+
+	expectedArguments(
+		\Relations\Model\Entity\User::hasValue(),
+		0,
+		argumentsSet('entityFields:Relations\Model\Entity\User')
+	);
+
+	expectedArguments(
+		\Relations\Model\Entity\User::isDirty(),
+		0,
+		argumentsSet('entityFields:Relations\Model\Entity\User')
+	);
+
+	expectedArguments(
+		\Relations\Model\Entity\User::isEmpty(),
+		0,
+		argumentsSet('entityFields:Relations\Model\Entity\User')
+	);
+
+	expectedArguments(
+		\Relations\Model\Entity\User::setDirty(),
+		0,
+		argumentsSet('entityFields:Relations\Model\Entity\User')
+	);
+
+	expectedArguments(
+		\Relations\Model\Entity\User::setError(),
+		0,
+		argumentsSet('entityFields:Relations\Model\Entity\User')
+	);
+
+	expectedArguments(
+		\TestApp\Model\Entity\Car::get(),
+		0,
+		argumentsSet('entityFields:TestApp\Model\Entity\Car')
+	);
+
+	expectedArguments(
+		\TestApp\Model\Entity\Car::getError(),
+		0,
+		argumentsSet('entityFields:TestApp\Model\Entity\Car')
+	);
+
+	expectedArguments(
+		\TestApp\Model\Entity\Car::getInvalidField(),
+		0,
+		argumentsSet('entityFields:TestApp\Model\Entity\Car')
+	);
+
+	expectedArguments(
+		\TestApp\Model\Entity\Car::getOriginal(),
+		0,
+		argumentsSet('entityFields:TestApp\Model\Entity\Car')
+	);
+
+	expectedArguments(
+		\TestApp\Model\Entity\Car::has(),
+		0,
+		argumentsSet('entityFields:TestApp\Model\Entity\Car')
+	);
+
+	expectedArguments(
+		\TestApp\Model\Entity\Car::hasValue(),
+		0,
+		argumentsSet('entityFields:TestApp\Model\Entity\Car')
+	);
+
+	expectedArguments(
+		\TestApp\Model\Entity\Car::isDirty(),
+		0,
+		argumentsSet('entityFields:TestApp\Model\Entity\Car')
+	);
+
+	expectedArguments(
+		\TestApp\Model\Entity\Car::isEmpty(),
+		0,
+		argumentsSet('entityFields:TestApp\Model\Entity\Car')
+	);
+
+	expectedArguments(
+		\TestApp\Model\Entity\Car::setDirty(),
+		0,
+		argumentsSet('entityFields:TestApp\Model\Entity\Car')
+	);
+
+	expectedArguments(
+		\TestApp\Model\Entity\Car::setError(),
+		0,
+		argumentsSet('entityFields:TestApp\Model\Entity\Car')
+	);
+
+	expectedArguments(
+		\TestApp\Model\Entity\Wheel::get(),
+		0,
+		argumentsSet('entityFields:TestApp\Model\Entity\Wheel')
+	);
+
+	expectedArguments(
+		\TestApp\Model\Entity\Wheel::getError(),
+		0,
+		argumentsSet('entityFields:TestApp\Model\Entity\Wheel')
+	);
+
+	expectedArguments(
+		\TestApp\Model\Entity\Wheel::getInvalidField(),
+		0,
+		argumentsSet('entityFields:TestApp\Model\Entity\Wheel')
+	);
+
+	expectedArguments(
+		\TestApp\Model\Entity\Wheel::getOriginal(),
+		0,
+		argumentsSet('entityFields:TestApp\Model\Entity\Wheel')
+	);
+
+	expectedArguments(
+		\TestApp\Model\Entity\Wheel::has(),
+		0,
+		argumentsSet('entityFields:TestApp\Model\Entity\Wheel')
+	);
+
+	expectedArguments(
+		\TestApp\Model\Entity\Wheel::hasValue(),
+		0,
+		argumentsSet('entityFields:TestApp\Model\Entity\Wheel')
+	);
+
+	expectedArguments(
+		\TestApp\Model\Entity\Wheel::isDirty(),
+		0,
+		argumentsSet('entityFields:TestApp\Model\Entity\Wheel')
+	);
+
+	expectedArguments(
+		\TestApp\Model\Entity\Wheel::isEmpty(),
+		0,
+		argumentsSet('entityFields:TestApp\Model\Entity\Wheel')
+	);
+
+	expectedArguments(
+		\TestApp\Model\Entity\Wheel::setDirty(),
+		0,
+		argumentsSet('entityFields:TestApp\Model\Entity\Wheel')
+	);
+
+	expectedArguments(
+		\TestApp\Model\Entity\Wheel::setError(),
+		0,
+		argumentsSet('entityFields:TestApp\Model\Entity\Wheel')
+	);
+
+	expectedArguments(
 		\__d(),
 		0,
 		'awesome',
@@ -764,6 +1124,51 @@ namespace PHPSTORM_META {
 		'plugins.Cake/TwigView',
 		'plugins.Migrations',
 		'plugins.Shim'
+	);
+
+	registerArgumentsSet(
+		'entityFields:Cake\ORM\Entity',
+		'content',
+		'created',
+		'id',
+		'name'
+	);
+
+	registerArgumentsSet(
+		'entityFields:Relations\Model\Entity\Bar',
+		'id',
+		'name',
+		'user_id'
+	);
+
+	registerArgumentsSet(
+		'entityFields:Relations\Model\Entity\Foo',
+		'id',
+		'name',
+		'user_id'
+	);
+
+	registerArgumentsSet(
+		'entityFields:Relations\Model\Entity\User',
+		'id',
+		'name'
+	);
+
+	registerArgumentsSet(
+		'entityFields:TestApp\Model\Entity\Car',
+		'content',
+		'created',
+		'id',
+		'modified',
+		'name'
+	);
+
+	registerArgumentsSet(
+		'entityFields:TestApp\Model\Entity\Wheel',
+		'content',
+		'created',
+		'id',
+		'name'
 	);
 
 	registerArgumentsSet(


### PR DESCRIPTION
Unfortunately, this doesnt work yet, PhpStorm doesnt understand trait methods.
All those methods are on the EntityTrait, so using them from the Entity wouldn't autocomplete.

Pending
- [x] https://youtrack.jetbrains.com/issue/WI-52799 => phpstorm 2020.3.1 release.