### PR TITLE
Add FormHelper autocomplete.

### DIFF
--- a/docs/Generator.md
+++ b/docs/Generator.md
@@ -18,6 +18,7 @@ PhpStorm TOC
   * [Elements](#elements)
   * [Layouts](#layouts)
   * [Cache](#cache)
+  * [FormHelper](#formhelper)
   * [Validation](#validation)
     + [Validator::requirePresence()](#validator--requirepresence--)
   * [Request params](#request-params)
@@ -160,6 +161,9 @@ With this generator PhpStorm can auto-complete this, including all elements for 
 
 #### Cache
 `Cache::write()`, `Cache::read()` and other methods are now auto-completed for the cache engine(s) available.
+
+#### FormHelper
+`$this->Form->control()` is now auto-completed for the model fields available.
 
 #### Validation
 

--- a/src/Generator/Task/ConnectionTask.php
+++ b/src/Generator/Task/ConnectionTask.php
@@ -6,7 +6,7 @@ use Cake\Datasource\ConnectionManager;
 use IdeHelper\Generator\Directive\ExpectedArguments;
 use IdeHelper\ValueObject\StringName;
 
-class ConnectionTask extends ModelTask {
+class ConnectionTask implements TaskInterface {
 
 	protected const METHOD_GET = '\\' . ConnectionManager::class . '::get()';
 

--- a/src/Generator/Task/ElementTask.php
+++ b/src/Generator/Task/ElementTask.php
@@ -12,7 +12,7 @@ use RecursiveIteratorIterator;
 use RecursiveRegexIterator;
 use RegexIterator;
 
-class ElementTask extends ModelTask {
+class ElementTask implements TaskInterface {
 
 	public const CLASS_VIEW = View::class;
 

--- a/src/Generator/Task/EnvTask.php
+++ b/src/Generator/Task/EnvTask.php
@@ -5,7 +5,7 @@ namespace IdeHelper\Generator\Task;
 use IdeHelper\Generator\Directive\ExpectedArguments;
 use IdeHelper\ValueObject\StringName;
 
-class EnvTask extends ModelTask {
+class EnvTask implements TaskInterface {
 
 	protected const METHOD_ENV = '\\' . 'env()';
 

--- a/src/Generator/Task/FormHelperTask.php
+++ b/src/Generator/Task/FormHelperTask.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace IdeHelper\Generator\Task;
+
+use Cake\ORM\TableRegistry;
+use Cake\View\Helper\FormHelper;
+use IdeHelper\Generator\Directive\ExpectedArguments;
+use IdeHelper\Utility\App;
+use IdeHelper\ValueObject\StringName;
+use ReflectionClass;
+use Throwable;
+
+class FormHelperTask extends ModelTask {
+
+	public const CLASS_FORM_HELPER = FormHelper::class;
+
+	/**
+	 * @return \IdeHelper\Generator\Directive\BaseDirective[]
+	 */
+	public function collect(): array {
+		$result = [];
+
+		$list = $this->collectFieldNames();
+
+		ksort($list);
+
+		$method = '\\' . static::CLASS_FORM_HELPER . '::control()';
+		$directive = new ExpectedArguments($method, 0, $list);
+		$result[$directive->key()] = $directive;
+
+		return $result;
+	}
+
+	/**
+	 * @return string[]
+	 */
+	protected function collectFieldNames(): array {
+		$models = $this->collectModels();
+
+		$allFields = [];
+		foreach ($models as $model => $className) {
+			$tableClass = App::className($model, 'Model/Table', 'Table');
+
+			$tableReflection = new ReflectionClass($tableClass);
+			if (!$tableReflection->isInstantiable()) {
+				continue;
+			}
+
+			try {
+				$modelObject = TableRegistry::getTableLocator()->get($model);
+				$fields = $modelObject->getSchema()->columns();
+
+			} catch (Throwable $exception) {
+				continue;
+			}
+
+			$allFields = array_merge($allFields, $fields);
+		}
+
+		$allFields = array_unique($allFields);
+
+		$list = [];
+		foreach ($allFields as $field) {
+			$list[$field] = StringName::create($field);
+		}
+
+		return $list;
+	}
+
+}

--- a/src/Generator/Task/LayoutTask.php
+++ b/src/Generator/Task/LayoutTask.php
@@ -11,7 +11,7 @@ use IdeHelper\ValueObject\StringName;
 use RecursiveRegexIterator;
 use RegexIterator;
 
-class LayoutTask extends ModelTask {
+class LayoutTask implements TaskInterface {
 
 	public const CLASS_VIEW_BUILDER = ViewBuilder::class;
 

--- a/src/Generator/Task/ValidationTask.php
+++ b/src/Generator/Task/ValidationTask.php
@@ -7,7 +7,7 @@ use IdeHelper\Generator\Directive\ExpectedArguments;
 use IdeHelper\Generator\Directive\RegisterArgumentsSet;
 use IdeHelper\ValueObject\StringName;
 
-class ValidationTask extends ModelTask {
+class ValidationTask implements TaskInterface {
 
 	public const SET_VALIDATION_WHEN = 'validationWhen';
 

--- a/src/Generator/TaskCollection.php
+++ b/src/Generator/TaskCollection.php
@@ -15,6 +15,7 @@ use IdeHelper\Generator\Task\DatabaseTypeTask;
 use IdeHelper\Generator\Task\ElementTask;
 use IdeHelper\Generator\Task\EnvTask;
 use IdeHelper\Generator\Task\FixtureTask;
+use IdeHelper\Generator\Task\FormHelperTask;
 use IdeHelper\Generator\Task\HelperTask;
 use IdeHelper\Generator\Task\LayoutTask;
 use IdeHelper\Generator\Task\MailerTask;
@@ -55,6 +56,7 @@ class TaskCollection {
 		EnvTask::class => EnvTask::class,
 		ConsoleTask::class => ConsoleTask::class,
 		ConnectionTask::class => ConnectionTask::class,
+		FormHelperTask::class => FormHelperTask::class,
 		DatabaseTableTask::class => DatabaseTableTask::class,
 		DatabaseTableColumnNameTask::class => DatabaseTableColumnNameTask::class,
 		DatabaseTableColumnTypeTask::class => DatabaseTableColumnTypeTask::class,

--- a/tests/TestCase/Generator/Task/FormHelperTaskTest.php
+++ b/tests/TestCase/Generator/Task/FormHelperTaskTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace IdeHelper\Test\TestCase\Generator\Task;
+
+use Cake\TestSuite\TestCase;
+use IdeHelper\Generator\Directive\ExpectedArguments;
+use IdeHelper\Generator\Task\FormHelperTask;
+
+class FormHelperTaskTest extends TestCase {
+
+	/**
+	 * @var string[]
+	 */
+	protected $fixtures = [
+		'plugin.IdeHelper.Cars',
+		'plugin.IdeHelper.Wheels',
+	];
+
+	/**
+	 * @var \IdeHelper\Generator\Task\FormHelperTask
+	 */
+	protected $task;
+
+	/**
+	 * @return void
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->getTableLocator()->get('Cars');
+		$this->getTableLocator()->get('Wheels');
+
+		$this->task = new FormHelperTask();
+	}
+
+	/**
+	 * @return void
+	 */
+	public function tearDown(): void {
+		parent::tearDown();
+
+		unset($this->task);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testCollect() {
+		$result = $this->task->collect();
+
+		$this->assertCount(1, $result);
+
+		/** @var \IdeHelper\Generator\Directive\ExpectedArguments $directive */
+		$directive = array_shift($result);
+		$this->assertInstanceOf(ExpectedArguments::class, $directive);
+
+		$list = $directive->toArray()['list'];
+		$list = array_map(function ($className) {
+			return (string)$className;
+		}, $list);
+
+		$expectedList = [
+			'content' => "'content'",
+			'created' => "'created'",
+			'id' => "'id'",
+			'modified' => "'modified'",
+			'name' => "'name'",
+			'user_id' => "'user_id'",
+		];
+		$this->assertSame($expectedList, $list);
+	}
+
+}

--- a/tests/test_files/meta/phpstorm/.meta.php
+++ b/tests/test_files/meta/phpstorm/.meta.php
@@ -491,6 +491,17 @@ namespace PHPSTORM_META {
 	);
 
 	expectedArguments(
+		\Cake\View\Helper\FormHelper::control(),
+		0,
+		'content',
+		'created',
+		'id',
+		'modified',
+		'name',
+		'user_id'
+	);
+
+	expectedArguments(
 		\Cake\View\Helper\HtmlHelper::linkFromPath(),
 		1,
 		argumentsSet('routePaths')


### PR DESCRIPTION
![idehelper_formhelper](https://user-images.githubusercontent.com/39854/93250020-76e18b00-f792-11ea-93a8-291e09cfea41.png)

OK, maybe I should have picked a few better (longer) example field names for the screenshot^^

On top we could add the following as well:

- relation.field_name (e.g. from related data like `$this->Form->control('event.location')`
