### PR TITLE
Add components unload() autocomplete.

### DIFF
--- a/docs/Generator.md
+++ b/docs/Generator.md
@@ -118,7 +118,8 @@ $this->removeBehavior('Slugged'); // Note the alias without plugin prefix
 #### Components
 The following is now auto-completed, for example:
 ```php
-$this->loadComponent('Security');
+$this->loadComponent('My.Useful');
+$this->components()->unload('Useful'); // Note the alias without plugin prefix
 ```
 
 #### Helpers

--- a/tests/TestCase/Generator/Task/ComponentTaskTest.php
+++ b/tests/TestCase/Generator/Task/ComponentTaskTest.php
@@ -27,7 +27,7 @@ class ComponentTaskTest extends TestCase {
 	public function testCollect() {
 		$result = $this->task->collect();
 
-		$this->assertCount(1, $result);
+		$this->assertCount(2, $result);
 
 		/** @var \IdeHelper\Generator\Directive\Override $directive */
 		$directive = array_shift($result);

--- a/tests/test_files/meta/phpstorm/.meta.php
+++ b/tests/test_files/meta/phpstorm/.meta.php
@@ -70,6 +70,19 @@ namespace PHPSTORM_META {
 
 	exitPoint(\Cake\Console\ConsoleIo::abort());
 
+	expectedArguments(
+		\Cake\Controller\ComponentRegistry::unload(),
+		0,
+		'Auth',
+		'Flash',
+		'FormProtection',
+		'My',
+		'MyOther',
+		'Paginator',
+		'RequestHandler',
+		'Security'
+	);
+
 	override(
 		\Cake\Controller\Controller::loadComponent(0),
 		map([


### PR DESCRIPTION
This seems to be also blocked by
- [x] https://youtrack.jetbrains.com/issue/WI-52799 => phpstorm 2020.3.1 release.

And setting it on the ObjectRegistry is not specific enough...