### PR TITLE
Also add 2nd arg

### DIFF
--- a/src/Generator/Task/DatabaseTableColumnNameTask.php
+++ b/src/Generator/Task/DatabaseTableColumnNameTask.php
@@ -47,6 +47,9 @@ class DatabaseTableColumnNameTask extends DatabaseTableTask {
 			$result[$directive->key()] = $directive;
 		}
 
+		$directive = new ExpectedArguments('\Migrations\Table::renameColumn()', 1, [$registerArgumentsSet]);
+		$result[$directive->key()] = $directive;
+
 		return $result;
 	}
 

--- a/tests/TestCase/Generator/Task/DatabaseTableColumnNameTaskTest.php
+++ b/tests/TestCase/Generator/Task/DatabaseTableColumnNameTaskTest.php
@@ -47,7 +47,7 @@ class DatabaseTableColumnNameTaskTest extends TestCase {
 	public function testCollect() {
 		$result = $this->task->collect();
 
-		$this->assertCount(6, $result);
+		$this->assertCount(7, $result);
 
 		/** @var \IdeHelper\Generator\Directive\RegisterArgumentsSet $directive */
 		$directive = array_shift($result);

--- a/tests/test_files/meta/phpstorm/.meta.php
+++ b/tests/test_files/meta/phpstorm/.meta.php
@@ -632,6 +632,12 @@ namespace PHPSTORM_META {
 	);
 
 	expectedArguments(
+		\Migrations\Table::renameColumn(),
+		1,
+		argumentsSet('columnNames')
+	);
+
+	expectedArguments(
 		\Phinx\Seed\AbstractSeed::table(),
 		0,
 		argumentsSet('tableNames')


### PR DESCRIPTION
This is supposed to also add some autocomplete on y of

    ->renameColumn('x', 'y')

Not quite as useful as the first, but still

One problem remaining though:

addColumn and changeColumn work fine, rename and remove do not for some reason
What am I missing?

OK, this has the same inheritance problem as 
https://github.com/dereuromark/cakephp-ide-helper/pull/212 and the other one...
I will still merge it now and hope one day it will be solved in PHPStorm...