### PR TITLE
Configure collections for templates.

### DIFF
--- a/src/Annotator/TemplateAnnotator.php
+++ b/src/Annotator/TemplateAnnotator.php
@@ -321,7 +321,12 @@ class TemplateAnnotator extends AbstractAnnotator {
 			}
 
 			$resultKey = $matches[1][$key];
-			$result[$resultKey] = AnnotationFactory::createOrFail(VariableAnnotation::TAG, '\\' . $className . '[]|\Cake\Collection\CollectionInterface', '$' . $matches[1][$key]);
+
+			$type = '\\' . $className . '[]';
+			if (!Configure::read('expectArrayCollection')) {
+				$type = '|\Cake\Collection\CollectionInterface';
+			}
+			$result[$resultKey] = AnnotationFactory::createOrFail(VariableAnnotation::TAG, $type, '$' . $matches[1][$key]);
 			// We do not need the singular then
 			$result[$entity] = null;
 		}

--- a/src/Annotator/TemplateAnnotator.php
+++ b/src/Annotator/TemplateAnnotator.php
@@ -324,7 +324,7 @@ class TemplateAnnotator extends AbstractAnnotator {
 
 			$type = '\\' . $className . '[]';
 			if (!Configure::read('expectArrayCollection')) {
-				$type = '|\Cake\Collection\CollectionInterface';
+				$type .= '|\Cake\Collection\CollectionInterface';
 			}
 			$result[$resultKey] = AnnotationFactory::createOrFail(VariableAnnotation::TAG, $type, '$' . $matches[1][$key]);
 			// We do not need the singular then


### PR DESCRIPTION
Right now it always assumes it could be both (as it doesn't see or know the controller code):
```php
<?php
/**
 * @var \App\View\AppView $this
 * @var \App\Model\Entity\User[]|\Cake\Collection\CollectionInterface $users
 */
?>
```
For that the controller code would have to have normal ResultSet query: `->all()` etc (or even Query itself);

But for modern apps it is actually more recommended to close and return the array to the templates:
```php
$users = ...->toArray();
$this->set(compact('users'));
```

Should we add a config here to configure this if the apps adhere to that?
Resulting in
```php
<?php
/**
 * @var \App\View\AppView $this
 * @var \App\Model\Entity\User[] $users
 */
?>
```