### PR TITLE
Update ModelTask.php

### DIFF
--- a/src/Generator/Task/ModelTask.php
+++ b/src/Generator/Task/ModelTask.php
@@ -3,6 +3,7 @@
 namespace IdeHelper\Generator\Task;
 
 use Cake\Filesystem\Folder;
+use Cake\ORM\Table;
 use IdeHelper\Generator\Directive\Override;
 use IdeHelper\Utility\App;
 use IdeHelper\Utility\AppPath;
@@ -112,7 +113,7 @@ class ModelTask implements TaskInterface {
 			}
 
 			$reflectionClass = new ReflectionClass($className);
-			if (!$reflectionClass->isInstantiable() || !$reflectionClass->isSubclassOf(\Cake\ORM\Table::class)) {
+			if (!$reflectionClass->isInstantiable() || !$reflectionClass->isSubclassOf(Table::class)) {
 				continue;
 			}
 

--- a/src/Generator/Task/ModelTask.php
+++ b/src/Generator/Task/ModelTask.php
@@ -112,7 +112,7 @@ class ModelTask implements TaskInterface {
 			}
 
 			$reflectionClass = new ReflectionClass($className);
-			if (!$reflectionClass->isInstantiable()) {
+			if (!$reflectionClass->isInstantiable() || !$reflectionClass->isSubclassOf(\Cake\ORM\Table::class)) {
 				continue;
 			}
 


### PR DESCRIPTION
It's possible to have files ending in "Table" in the App\Model\Table namespace without them actually extending the CakePHP ORM Table class.
We have several of these files in our codebase (legacy code) and trying to generate the metadata file results in errors like:

`Error: [Error] Call to undefined method App\Model\Table\SomeTable::getSchema() in...`

This proposed change checks that the class extends the `\Cake\ORM\Table` class which should make sure `getSchema()` is defined.