### PR TITLE
Support FQN in belongsToMany through option

### DIFF
--- a/src/Annotator/ModelAnnotator.php
+++ b/src/Annotator/ModelAnnotator.php
@@ -364,9 +364,7 @@ class ModelAnnotator extends AbstractAnnotator {
 			$this->_cache[$parentClass] = $parentBehaviors = $this->extractBehaviors($map);
 		}
 
-		$result = array_diff_key($behaviors, $parentBehaviors);
-
-		return $result;
+		return array_diff_key($behaviors, $parentBehaviors);
 	}
 
 	/**

--- a/src/Annotator/ModelAnnotator.php
+++ b/src/Annotator/ModelAnnotator.php
@@ -281,7 +281,6 @@ class ModelAnnotator extends AbstractAnnotator {
 			$className = App::className($through, 'Model/Table', 'Table') ?: static::CLASS_TABLE;
 			[, $throughName] = pluginSplit($through);
 			if (strpos($throughName, '\\') !== false) {
-				/** @psalm-suppress PossiblyFalseOperand */
 				$throughName = substr($throughName, strrpos($throughName, '\\') + 1, -5);
 			}
 			$type = HasMany::class;

--- a/src/Annotator/ModelAnnotator.php
+++ b/src/Annotator/ModelAnnotator.php
@@ -233,7 +233,7 @@ class ModelAnnotator extends AbstractAnnotator {
 	 * @return array<string>
 	 */
 	protected function parseLoadedBehaviors(string $content): array {
-		preg_match_all('/\$this-\>addBehavior\(\'([a-z.\/]+)\'/i', $content, $matches);
+		preg_match_all('/\$this->addBehavior\(\'([a-z.\/]+)\'/i', $content, $matches);
 		if (empty($matches[1])) {
 			return [];
 		}

--- a/src/Annotator/ModelAnnotator.php
+++ b/src/Annotator/ModelAnnotator.php
@@ -280,6 +280,10 @@ class ModelAnnotator extends AbstractAnnotator {
 
 			$className = App::className($through, 'Model/Table', 'Table') ?: static::CLASS_TABLE;
 			[, $throughName] = pluginSplit($through);
+			if (strpos($throughName, '\\') !== false) {
+				/** @psalm-suppress PossiblyFalseOperand */
+				$throughName = substr($throughName, strrpos($throughName, '\\') + 1, -5);
+			}
 			$type = HasMany::class;
 			if (isset($associations[$type][$throughName])) {
 				continue;


### PR DESCRIPTION
Support FQN in `belongsToMany` `through` option:

`$this->belongsToMany('CustomerPersons', ['className' => PersonsTable::class, 'through' => CompaniesCustomersTable::class]);`

CakePhp supports FQNs here, but IDE Helper generates wrong property name in the annotation