### PR TITLE
Update PhpstormGenerator.php

### DIFF
--- a/src/Generator/PhpstormGenerator.php
+++ b/src/Generator/PhpstormGenerator.php
@@ -33,7 +33,9 @@ class PhpstormGenerator implements GeneratorInterface {
 	protected function build(array $map) {
 		$overrides = [];
 		foreach ($map as $directive) {
-			$overrides[] = $directive->build();
+            if (is_object($directive) && method_exists($directive, "build")) {
+			    $overrides[] = $directive->build();
+            }
 		}
 		$overrides = implode(PHP_EOL . PHP_EOL, $overrides);
 


### PR DESCRIPTION
One '$directive' was an array - maybe you fixed it in a later version for CakePHP 4. 
With this quick fix, the script might skip some models, but it runs through at least.