### PR TITLE
Fix up template var detection.

### DIFF
--- a/src/Annotator/TemplateAnnotator.php
+++ b/src/Annotator/TemplateAnnotator.php
@@ -3,6 +3,7 @@
 namespace IdeHelper\Annotator;
 
 use Bake\View\Helper\DocBlockHelper;
+use Cake\Collection\CollectionInterface;
 use Cake\Core\Configure;
 use Cake\Utility\Inflector;
 use Cake\View\View;
@@ -52,7 +53,7 @@ class TemplateAnnotator extends AbstractAnnotator {
 
 		$needsPhpTag = $phpOpenTagIndex === null || $this->needsPhpTag($file, $phpOpenTagIndex);
 
-		$phpOpenTagIndex = $this->checkforDeclareStatement($file, $phpOpenTagIndex);
+		$phpOpenTagIndex = $this->checkForDeclareStatement($file, $phpOpenTagIndex);
 
 		$docBlockCloseTagIndex = null;
 		if ($needsPhpTag) {
@@ -335,13 +336,13 @@ class TemplateAnnotator extends AbstractAnnotator {
 			$resultKey = $matches[1][$key];
 			$annotation = '\\' . ArrayString::generate($className);
 			if (Configure::read('IdeHelper.templateCollectionObject') !== false) {
-				/** @var string|true $object */
+				/** @var string|bool $object */
 				$object = Configure::read('IdeHelper.templateCollectionObject');
 				if (!$object || $object === true) {
-					$object = '\Cake\Collection\CollectionInterface';
+					$object = '\\' . CollectionInterface::class;
 				}
 
-				$annotation = '\\' . $className . '[]' . '|' . $object;
+				$annotation = ArrayString::generate('\\' . $className, $object);
 			}
 
 			$result[$resultKey] = AnnotationFactory::createOrFail(VariableAnnotation::TAG, $annotation, '$' . $matches[1][$key]);
@@ -518,7 +519,7 @@ class TemplateAnnotator extends AbstractAnnotator {
 	 *
 	 * @return int|null
 	 */
-	protected function checkforDeclareStatement(File $file, ?int $phpOpenTagIndex): ?int {
+	protected function checkForDeclareStatement(File $file, ?int $phpOpenTagIndex): ?int {
 		if ($phpOpenTagIndex === null) {
 			return $phpOpenTagIndex;
 		}

--- a/src/Annotator/Traits/DocBlockTrait.php
+++ b/src/Annotator/Traits/DocBlockTrait.php
@@ -180,7 +180,7 @@ trait DocBlockTrait {
 	 */
 	protected function renderUnionTypes(array $typeNodes): string {
 		return (string)preg_replace(
-			['/ ([|&]) /', '/<\(/', '/\)>/', '/\), /', '/, \(/'],
+			['/ ([\|&]) /', '/<\(/', '/\)>/', '/\), /', '/, \(/'],
 			['${1}', '<', '>', ', ', ', '],
 			implode('|', $typeNodes),
 		);

--- a/src/Annotator/Traits/DocBlockTrait.php
+++ b/src/Annotator/Traits/DocBlockTrait.php
@@ -1,0 +1,213 @@
+<?php
+
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace IdeHelper\Annotator\Traits;
+
+use PHP_CodeSniffer\Files\File;
+use PHPStan\PhpDocParser\Ast\PhpDoc\GenericTagValueNode;
+use PHPStan\PhpDocParser\Ast\PhpDoc\MethodTagValueNode;
+use PHPStan\PhpDocParser\Ast\PhpDoc\ParamTagValueNode;
+use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagValueNode;
+use PHPStan\PhpDocParser\Ast\PhpDoc\ReturnTagValueNode;
+use PHPStan\PhpDocParser\Ast\PhpDoc\ThrowsTagValueNode;
+use PHPStan\PhpDocParser\Ast\PhpDoc\VarTagValueNode;
+use PHPStan\PhpDocParser\Ast\Type\UnionTypeNode;
+use PHPStan\PhpDocParser\Lexer\Lexer;
+use PHPStan\PhpDocParser\Parser\ConstExprParser;
+use PHPStan\PhpDocParser\Parser\PhpDocParser;
+use PHPStan\PhpDocParser\Parser\TokenIterator;
+use PHPStan\PhpDocParser\Parser\TypeParser;
+
+/**
+ * Common functionality around doc block parsing and writing.
+ */
+trait DocBlockTrait
+{
+    /**
+     * @param string $tagName tag name
+     * @param string $tagComment tag comment
+     *
+     * @return \PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagValueNode
+     */
+    protected static function getValueNode(string $tagName, string $tagComment): PhpDocTagValueNode
+    {
+        static $phpDocParser;
+        if (!$phpDocParser) {
+            $constExprParser = new ConstExprParser();
+            $phpDocParser = new PhpDocParser(new TypeParser($constExprParser), $constExprParser);
+        }
+
+        static $phpDocLexer;
+        if (!$phpDocLexer) {
+            $phpDocLexer = new Lexer();
+        }
+
+        return $phpDocParser->parseTagValue(new TokenIterator($phpDocLexer->tokenize($tagComment)), $tagName);
+    }
+
+    /**
+     * @param \PHPStan\PhpDocParser\Ast\PhpDoc\MethodTagValueNode|\PHPStan\PhpDocParser\Ast\PhpDoc\PropertyTagValueNode|\PHPStan\PhpDocParser\Ast\PhpDoc\VarTagValueNode|\PHPStan\PhpDocParser\Ast\PhpDoc\ParamTagValueNode|\PHPStan\PhpDocParser\Ast\PhpDoc\ReturnTagValueNode|\PHPStan\PhpDocParser\Ast\PhpDoc\GenericTagValueNode $valueNode
+     *
+     * @return array<string>
+     */
+    protected function valueNodeParts(PhpDocTagValueNode $valueNode): array
+    {
+        if ($valueNode instanceof MethodTagValueNode) {
+            $types = [$valueNode->returnType];
+        } elseif ($valueNode instanceof GenericTagValueNode) {
+            $types = [$valueNode];
+        } elseif ($valueNode->type instanceof UnionTypeNode) {
+            $types = $valueNode->type->types;
+        } else {
+            $types = [$valueNode->type];
+        }
+
+        $result = [];
+        foreach ($types as $type) {
+            $result[] = (string)$type;
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param array<string> $parts
+     * @param \PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagValueNode $valueNode
+     *
+     * @return string
+     */
+    protected function stringifyValueNode(array $parts, PhpDocTagValueNode $valueNode): string
+    {
+        if ($valueNode instanceof ParamTagValueNode) {
+            return trim(sprintf(
+                '%s %s%s %s',
+                implode('|', $parts),
+                $valueNode->isVariadic ? '...' : '',
+                $valueNode->parameterName,
+                $valueNode->description,
+            ));
+        }
+        if ($valueNode instanceof ReturnTagValueNode) {
+            return trim(sprintf(
+                '%s%s',
+                implode('|', $parts),
+                $valueNode->description,
+            ));
+        }
+        if ($valueNode instanceof MethodTagValueNode) {
+            return trim(sprintf(
+                '%s %s() %s',
+                implode('|', $parts),
+                $valueNode->methodName,
+                $valueNode->description,
+            ));
+        }
+        if ($valueNode instanceof VarTagValueNode) {
+            return trim(sprintf(
+                '%s %s%s',
+                implode('|', $parts),
+                $valueNode->variableName,
+                $valueNode->description,
+            ));
+        }
+        if ($valueNode instanceof ThrowsTagValueNode) {
+            return trim(sprintf(
+                '%s %s',
+                implode('|', $parts),
+                $valueNode->description,
+            ));
+        }
+
+        return trim(implode('|', $parts));
+    }
+
+    /**
+     * Looks for either `@inheritDoc` or `{@inheritDoc}`.
+     * Also allows `@inheritdoc` or `{@inheritdoc}` aliases.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpCsFile
+     * @param int $docBlockStartIndex
+     * @param int $docBlockEndIndex
+     * @param string $needle
+     *
+     * @return bool
+     */
+    protected function hasInheritDoc(File $phpCsFile, $docBlockStartIndex, $docBlockEndIndex, $needle = '@inheritDoc')
+    {
+        $tokens = $phpCsFile->getTokens();
+
+        for ($i = $docBlockStartIndex + 1; $i < $docBlockEndIndex; ++$i) {
+            if (empty($tokens[$i]['content'])) {
+                continue;
+            }
+            $content = $tokens[$i]['content'];
+            $pos = stripos($content, $needle);
+            if ($pos === false) {
+                continue;
+            }
+
+            if ($pos && strpos($needle, '@') === 0 && substr($content, $pos - 1, $pos) === '{') {
+                return false;
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Allow \Foo\Bar[] or array<\Foo\Bar> to pass as array.
+     *
+     * @param array<string> $docBlockTypes
+     * @param string $iterableType
+     *
+     * @return bool
+     */
+    protected function containsTypeArray(array $docBlockTypes, string $iterableType = 'array'): bool
+    {
+        foreach ($docBlockTypes as $docBlockType) {
+            if (strpos($docBlockType, '[]') !== false || strpos($docBlockType, $iterableType . '<') === 0) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Checks for ...<...>.
+     *
+     * @param array<string> $docBlockTypes
+     *
+     * @return bool
+     */
+    protected function containsIterableSyntax(array $docBlockTypes): bool
+    {
+        foreach ($docBlockTypes as $docBlockType) {
+            if (strpos($docBlockType, '<') !== false) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param array<\PHPStan\PhpDocParser\Ast\Type\TypeNode|string> $typeNodes type nodes
+     *
+     * @return string
+     */
+    protected function renderUnionTypes(array $typeNodes): string
+    {
+        return (string)preg_replace(
+            ['/ ([|&]) /', '/<\(/', '/\)>/', '/\), /', '/, \(/'],
+            ['${1}', '<', '>', ', ', ', '],
+            implode('|', $typeNodes),
+        );
+    }
+}

--- a/src/Annotator/Traits/DocBlockTrait.php
+++ b/src/Annotator/Traits/DocBlockTrait.php
@@ -179,11 +179,17 @@ trait DocBlockTrait {
 	 * @return string
 	 */
 	protected function renderUnionTypes(array $typeNodes): string {
-		return (string)preg_replace(
+		$string = (string)preg_replace(
 			['/ ([\|&]) /', '/<\(/', '/\)>/', '/\), /', '/, \(/'],
 			['${1}', '<', '>', ', ', ', '],
 			implode('|', $typeNodes),
 		);
+
+		if (substr($string, 0, 1) === '(' && substr($string, -1, 1) === ')') {
+			$string = substr($string, 1, -1);
+		}
+
+		return $string;
 	}
 
 }

--- a/src/Annotator/Traits/DocBlockTrait.php
+++ b/src/Annotator/Traits/DocBlockTrait.php
@@ -133,7 +133,7 @@ trait DocBlockTrait {
 	 *
 	 * @return bool
 	 */
-	protected function hasInheritDoc(File $phpCsFile, $docBlockStartIndex, $docBlockEndIndex, $needle = '@inheritDoc') {
+	protected function hasInheritDoc(File $phpCsFile, int $docBlockStartIndex, int $docBlockEndIndex, string $needle = '@inheritDoc'): bool {
 		$tokens = $phpCsFile->getTokens();
 
 		for ($i = $docBlockStartIndex + 1; $i < $docBlockEndIndex; ++$i) {
@@ -151,24 +151,6 @@ trait DocBlockTrait {
 			}
 
 			return true;
-		}
-
-		return false;
-	}
-
-	/**
-	 * Allow \Foo\Bar[] or array<\Foo\Bar> to pass as array.
-	 *
-	 * @param array<string> $docBlockTypes
-	 * @param string $iterableType
-	 *
-	 * @return bool
-	 */
-	protected function containsTypeArray(array $docBlockTypes, string $iterableType = 'array'): bool {
-		foreach ($docBlockTypes as $docBlockType) {
-			if (strpos($docBlockType, '[]') !== false || strpos($docBlockType, $iterableType . '<') === 0) {
-				return true;
-			}
 		}
 
 		return false;

--- a/src/Annotator/Traits/DocBlockTrait.php
+++ b/src/Annotator/Traits/DocBlockTrait.php
@@ -25,189 +25,183 @@ use PHPStan\PhpDocParser\Parser\TypeParser;
 /**
  * Common functionality around doc block parsing and writing.
  */
-trait DocBlockTrait
-{
-    /**
-     * @param string $tagName tag name
-     * @param string $tagComment tag comment
-     *
-     * @return \PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagValueNode
-     */
-    protected static function getValueNode(string $tagName, string $tagComment): PhpDocTagValueNode
-    {
-        static $phpDocParser;
-        if (!$phpDocParser) {
-            $constExprParser = new ConstExprParser();
-            $phpDocParser = new PhpDocParser(new TypeParser($constExprParser), $constExprParser);
-        }
+trait DocBlockTrait {
 
-        static $phpDocLexer;
-        if (!$phpDocLexer) {
-            $phpDocLexer = new Lexer();
-        }
+	/**
+	 * @param string $tagName tag name
+	 * @param string $tagComment tag comment
+	 *
+	 * @return \PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagValueNode
+	 */
+	protected static function getValueNode(string $tagName, string $tagComment): PhpDocTagValueNode {
+		static $phpDocParser;
+		if (!$phpDocParser) {
+			$constExprParser = new ConstExprParser();
+			$phpDocParser = new PhpDocParser(new TypeParser($constExprParser), $constExprParser);
+		}
 
-        return $phpDocParser->parseTagValue(new TokenIterator($phpDocLexer->tokenize($tagComment)), $tagName);
-    }
+		static $phpDocLexer;
+		if (!$phpDocLexer) {
+			$phpDocLexer = new Lexer();
+		}
 
-    /**
-     * @param \PHPStan\PhpDocParser\Ast\PhpDoc\MethodTagValueNode|\PHPStan\PhpDocParser\Ast\PhpDoc\PropertyTagValueNode|\PHPStan\PhpDocParser\Ast\PhpDoc\VarTagValueNode|\PHPStan\PhpDocParser\Ast\PhpDoc\ParamTagValueNode|\PHPStan\PhpDocParser\Ast\PhpDoc\ReturnTagValueNode|\PHPStan\PhpDocParser\Ast\PhpDoc\GenericTagValueNode $valueNode
-     *
-     * @return array<string>
-     */
-    protected function valueNodeParts(PhpDocTagValueNode $valueNode): array
-    {
-        if ($valueNode instanceof MethodTagValueNode) {
-            $types = [$valueNode->returnType];
-        } elseif ($valueNode instanceof GenericTagValueNode) {
-            $types = [$valueNode];
-        } elseif ($valueNode->type instanceof UnionTypeNode) {
-            $types = $valueNode->type->types;
-        } else {
-            $types = [$valueNode->type];
-        }
+		return $phpDocParser->parseTagValue(new TokenIterator($phpDocLexer->tokenize($tagComment)), $tagName);
+	}
 
-        $result = [];
-        foreach ($types as $type) {
-            $result[] = (string)$type;
-        }
+	/**
+	 * @param \PHPStan\PhpDocParser\Ast\PhpDoc\MethodTagValueNode|\PHPStan\PhpDocParser\Ast\PhpDoc\PropertyTagValueNode|\PHPStan\PhpDocParser\Ast\PhpDoc\VarTagValueNode|\PHPStan\PhpDocParser\Ast\PhpDoc\ParamTagValueNode|\PHPStan\PhpDocParser\Ast\PhpDoc\ReturnTagValueNode|\PHPStan\PhpDocParser\Ast\PhpDoc\GenericTagValueNode $valueNode
+	 *
+	 * @return array<string>
+	 */
+	protected function valueNodeParts(PhpDocTagValueNode $valueNode): array {
+		if ($valueNode instanceof MethodTagValueNode) {
+			$types = [$valueNode->returnType];
+		} elseif ($valueNode instanceof GenericTagValueNode) {
+			$types = [$valueNode];
+		} elseif ($valueNode->type instanceof UnionTypeNode) {
+			$types = $valueNode->type->types;
+		} else {
+			$types = [$valueNode->type];
+		}
 
-        return $result;
-    }
+		$result = [];
+		foreach ($types as $type) {
+			$result[] = (string)$type;
+		}
 
-    /**
-     * @param array<string> $parts
-     * @param \PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagValueNode $valueNode
-     *
-     * @return string
-     */
-    protected function stringifyValueNode(array $parts, PhpDocTagValueNode $valueNode): string
-    {
-        if ($valueNode instanceof ParamTagValueNode) {
-            return trim(sprintf(
-                '%s %s%s %s',
-                implode('|', $parts),
-                $valueNode->isVariadic ? '...' : '',
-                $valueNode->parameterName,
-                $valueNode->description,
-            ));
-        }
-        if ($valueNode instanceof ReturnTagValueNode) {
-            return trim(sprintf(
-                '%s%s',
-                implode('|', $parts),
-                $valueNode->description,
-            ));
-        }
-        if ($valueNode instanceof MethodTagValueNode) {
-            return trim(sprintf(
-                '%s %s() %s',
-                implode('|', $parts),
-                $valueNode->methodName,
-                $valueNode->description,
-            ));
-        }
-        if ($valueNode instanceof VarTagValueNode) {
-            return trim(sprintf(
-                '%s %s%s',
-                implode('|', $parts),
-                $valueNode->variableName,
-                $valueNode->description,
-            ));
-        }
-        if ($valueNode instanceof ThrowsTagValueNode) {
-            return trim(sprintf(
-                '%s %s',
-                implode('|', $parts),
-                $valueNode->description,
-            ));
-        }
+		return $result;
+	}
 
-        return trim(implode('|', $parts));
-    }
+	/**
+	 * @param array<string> $parts
+	 * @param \PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagValueNode $valueNode
+	 *
+	 * @return string
+	 */
+	protected function stringifyValueNode(array $parts, PhpDocTagValueNode $valueNode): string {
+		if ($valueNode instanceof ParamTagValueNode) {
+			return trim(sprintf(
+				'%s %s%s %s',
+				implode('|', $parts),
+				$valueNode->isVariadic ? '...' : '',
+				$valueNode->parameterName,
+				$valueNode->description,
+			));
+		}
+		if ($valueNode instanceof ReturnTagValueNode) {
+			return trim(sprintf(
+				'%s%s',
+				implode('|', $parts),
+				$valueNode->description,
+			));
+		}
+		if ($valueNode instanceof MethodTagValueNode) {
+			return trim(sprintf(
+				'%s %s() %s',
+				implode('|', $parts),
+				$valueNode->methodName,
+				$valueNode->description,
+			));
+		}
+		if ($valueNode instanceof VarTagValueNode) {
+			return trim(sprintf(
+				'%s %s%s',
+				implode('|', $parts),
+				$valueNode->variableName,
+				$valueNode->description,
+			));
+		}
+		if ($valueNode instanceof ThrowsTagValueNode) {
+			return trim(sprintf(
+				'%s %s',
+				implode('|', $parts),
+				$valueNode->description,
+			));
+		}
 
-    /**
-     * Looks for either `@inheritDoc` or `{@inheritDoc}`.
-     * Also allows `@inheritdoc` or `{@inheritdoc}` aliases.
-     *
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $docBlockStartIndex
-     * @param int $docBlockEndIndex
-     * @param string $needle
-     *
-     * @return bool
-     */
-    protected function hasInheritDoc(File $phpCsFile, $docBlockStartIndex, $docBlockEndIndex, $needle = '@inheritDoc')
-    {
-        $tokens = $phpCsFile->getTokens();
+		return trim(implode('|', $parts));
+	}
 
-        for ($i = $docBlockStartIndex + 1; $i < $docBlockEndIndex; ++$i) {
-            if (empty($tokens[$i]['content'])) {
-                continue;
-            }
-            $content = $tokens[$i]['content'];
-            $pos = stripos($content, $needle);
-            if ($pos === false) {
-                continue;
-            }
+	/**
+	 * Looks for either `@inheritDoc` or `{@inheritDoc}`.
+	 * Also allows `@inheritdoc` or `{@inheritdoc}` aliases.
+	 *
+	 * @param \PHP_CodeSniffer\Files\File $phpCsFile
+	 * @param int $docBlockStartIndex
+	 * @param int $docBlockEndIndex
+	 * @param string $needle
+	 *
+	 * @return bool
+	 */
+	protected function hasInheritDoc(File $phpCsFile, $docBlockStartIndex, $docBlockEndIndex, $needle = '@inheritDoc') {
+		$tokens = $phpCsFile->getTokens();
 
-            if ($pos && strpos($needle, '@') === 0 && substr($content, $pos - 1, $pos) === '{') {
-                return false;
-            }
+		for ($i = $docBlockStartIndex + 1; $i < $docBlockEndIndex; ++$i) {
+			if (empty($tokens[$i]['content'])) {
+				continue;
+			}
+			$content = $tokens[$i]['content'];
+			$pos = stripos($content, $needle);
+			if ($pos === false) {
+				continue;
+			}
 
-            return true;
-        }
+			if ($pos && strpos($needle, '@') === 0 && substr($content, $pos - 1, $pos) === '{') {
+				return false;
+			}
 
-        return false;
-    }
+			return true;
+		}
 
-    /**
-     * Allow \Foo\Bar[] or array<\Foo\Bar> to pass as array.
-     *
-     * @param array<string> $docBlockTypes
-     * @param string $iterableType
-     *
-     * @return bool
-     */
-    protected function containsTypeArray(array $docBlockTypes, string $iterableType = 'array'): bool
-    {
-        foreach ($docBlockTypes as $docBlockType) {
-            if (strpos($docBlockType, '[]') !== false || strpos($docBlockType, $iterableType . '<') === 0) {
-                return true;
-            }
-        }
+		return false;
+	}
 
-        return false;
-    }
+	/**
+	 * Allow \Foo\Bar[] or array<\Foo\Bar> to pass as array.
+	 *
+	 * @param array<string> $docBlockTypes
+	 * @param string $iterableType
+	 *
+	 * @return bool
+	 */
+	protected function containsTypeArray(array $docBlockTypes, string $iterableType = 'array'): bool {
+		foreach ($docBlockTypes as $docBlockType) {
+			if (strpos($docBlockType, '[]') !== false || strpos($docBlockType, $iterableType . '<') === 0) {
+				return true;
+			}
+		}
 
-    /**
-     * Checks for ...<...>.
-     *
-     * @param array<string> $docBlockTypes
-     *
-     * @return bool
-     */
-    protected function containsIterableSyntax(array $docBlockTypes): bool
-    {
-        foreach ($docBlockTypes as $docBlockType) {
-            if (strpos($docBlockType, '<') !== false) {
-                return true;
-            }
-        }
+		return false;
+	}
 
-        return false;
-    }
+	/**
+	 * Checks for ...<...>.
+	 *
+	 * @param array<string> $docBlockTypes
+	 *
+	 * @return bool
+	 */
+	protected function containsIterableSyntax(array $docBlockTypes): bool {
+		foreach ($docBlockTypes as $docBlockType) {
+			if (strpos($docBlockType, '<') !== false) {
+				return true;
+			}
+		}
 
-    /**
-     * @param array<\PHPStan\PhpDocParser\Ast\Type\TypeNode|string> $typeNodes type nodes
-     *
-     * @return string
-     */
-    protected function renderUnionTypes(array $typeNodes): string
-    {
-        return (string)preg_replace(
-            ['/ ([|&]) /', '/<\(/', '/\)>/', '/\), /', '/, \(/'],
-            ['${1}', '<', '>', ', ', ', '],
-            implode('|', $typeNodes),
-        );
-    }
+		return false;
+	}
+
+	/**
+	 * @param array<\PHPStan\PhpDocParser\Ast\Type\TypeNode|string> $typeNodes type nodes
+	 *
+	 * @return string
+	 */
+	protected function renderUnionTypes(array $typeNodes): string {
+		return (string)preg_replace(
+			['/ ([|&]) /', '/<\(/', '/\)>/', '/\), /', '/, \(/'],
+			['${1}', '<', '>', ', ', ', '],
+			implode('|', $typeNodes),
+		);
+	}
+
 }

--- a/tests/TestCase/Annotator/ComponentAnnotatorTest.php
+++ b/tests/TestCase/Annotator/ComponentAnnotatorTest.php
@@ -68,6 +68,8 @@ class ComponentAnnotatorTest extends TestCase {
 	}
 
 	/**
+	 * Note that property always needs $ in front of it: $Prop instead of Prop.
+	 *
 	 * @return void
 	 */
 	public function testAnnotateWithExistingDocBlock() {

--- a/tests/TestCase/Annotator/TemplateAnnotatorTest.php
+++ b/tests/TestCase/Annotator/TemplateAnnotatorTest.php
@@ -214,7 +214,7 @@ class TemplateAnnotatorTest extends TestCase {
 	 *
 	 * @return void
 	 */
-	public function testAnnotateExisting() {
+	public function testAnnotateExistingBasic() {
 		$annotator = $this->_getAnnotatorMock([]);
 
 		$expectedContent = str_replace("\r\n", "\n", file_get_contents(TEST_FILES . 'templates/existing.php'));

--- a/tests/test_app/src/Controller/Component/MyOtherComponent.php
+++ b/tests/test_app/src/Controller/Component/MyOtherComponent.php
@@ -5,7 +5,7 @@ use Cake\Controller\Component;
 
 /**
  * @property \TestApp\Controller\Component\RequestHandlerComponent $RequestHandler
- * @property \Cake\Controller\Component\SecurityComponent Security
+ * @property \Cake\Controller\Component\SecurityComponent $Security
  */
 class MyOtherComponent extends Component {
 

--- a/tests/test_app/templates/Foos/existing.php
+++ b/tests/test_app/templates/Foos/existing.php
@@ -5,9 +5,14 @@
 
 /**
  * @var \TestApp\View\AppView $this
+ * @var array<int, int> $things
  */
 ?>
 <div>
 	<?php foreach ($cars as $car) {} ?>
 	<?php echo h($wheel->id); ?>
+
+	<?php foreach ($things as $keyInt => $valueInt) {
+		echo h($keyInt + $valueInt);
+	} ?>
 </div>

--- a/tests/test_files/Controller/Component/MyOtherComponent.php
+++ b/tests/test_files/Controller/Component/MyOtherComponent.php
@@ -5,7 +5,7 @@ use Cake\Controller\Component;
 
 /**
  * @property \TestApp\Controller\Component\RequestHandlerComponent $RequestHandler
- * @property \Cake\Controller\Component\SecurityComponent Security
+ * @property \Cake\Controller\Component\SecurityComponent $Security
  * @property \Cake\Controller\Component\FlashComponent $Flash
  */
 class MyOtherComponent extends Component {

--- a/tests/test_files/templates/existing.php
+++ b/tests/test_files/templates/existing.php
@@ -5,6 +5,7 @@
 
 /**
  * @var \TestApp\View\AppView $this
+ * @var array<int, int> $things
  * @var \TestApp\Model\Entity\Car[]|\Cake\Collection\CollectionInterface $cars
  * @var \TestApp\Model\Entity\Wheel $wheel
  */
@@ -12,4 +13,8 @@
 <div>
 	<?php foreach ($cars as $car) {} ?>
 	<?php echo h($wheel->id); ?>
+
+	<?php foreach ($things as $keyInt => $valueInt) {
+		echo h($keyInt + $valueInt);
+	} ?>
 </div>


### PR DESCRIPTION
Resolves https://github.com/dereuromark/cakephp-ide-helper/issues/274

It does however seem to break annotations like
```
@property \Awesome\Model\Table\WindowsTable&\Cake\ORM\Association\HasMany $Windows
```
due to the & instead of |

Maybe there is a better way of dealing with it, or adding support for more than just union types?

