### PR TITLE
Add load identifier task

### DIFF
--- a/src/Generator/Task/AuthServiceLoadIdentifierTask.php
+++ b/src/Generator/Task/AuthServiceLoadIdentifierTask.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace IdeHelper\Generator\Task;
+
+use IdeHelper\Generator\Directive\Override;
+
+class AuthServiceLoadIdentifierTask implements TaskInterface {
+
+	/**
+	 * @return array<\IdeHelper\Generator\Directive\BaseDirective>
+	 */
+	public function collect(): array {
+		$method = '\Authentication\AuthenticationService::loadIdentifier(0)';
+
+		$map = [
+			'Authentication.Password' => '\Authentication\Identifier\PasswordIdentifier::class',
+			'Authentication.Token' => '\Authentication\Identifier\TokenIdentifier::class',
+		];
+
+		$directive = new Override($method, $map);
+
+		return [$directive->key() => $directive];
+	}
+
+}

--- a/src/Generator/TaskCollection.php
+++ b/src/Generator/TaskCollection.php
@@ -3,6 +3,7 @@
 namespace IdeHelper\Generator;
 
 use Cake\Core\Configure;
+use IdeHelper\Generator\Task\AuthServiceLoadIdentifierTask;
 use IdeHelper\Generator\Task\BehaviorTask;
 use IdeHelper\Generator\Task\CacheTask;
 use IdeHelper\Generator\Task\CellTask;
@@ -70,6 +71,7 @@ class TaskCollection {
 		ConfigureTask::class => ConfigureTask::class,
 		CellTask::class => CellTask::class,
 		ConsoleHelperTask::class => ConsoleHelperTask::class,
+		AuthServiceLoadIdentifierTask::class => AuthServiceLoadIdentifierTask::class,
 	];
 
 	/**

--- a/tests/TestCase/Generator/Task/AuthServiceLoadIdentifierTaskTest.php
+++ b/tests/TestCase/Generator/Task/AuthServiceLoadIdentifierTaskTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace IdeHelper\Test\TestCase\Generator\Task;
+
+use Cake\TestSuite\TestCase;
+use IdeHelper\Generator\Task\AuthServiceLoadIdentifierTask;
+use Shim\TestSuite\TestTrait;
+
+class AuthServiceLoadIdentifierTaskTest extends TestCase {
+
+	use TestTrait;
+
+	/**
+	 * @var \IdeHelper\Generator\Task\ElementTask
+	 */
+	protected $task;
+
+	/**
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->task = new AuthServiceLoadIdentifierTask();
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testCollect() {
+		$result = $this->task->collect();
+
+		$this->assertCount(1, $result);
+
+		/** @var \IdeHelper\Generator\Directive\Override $directive */
+		$directive = array_shift($result);
+		$this->assertSame('\Authentication\AuthenticationService::loadIdentifier(0)', $directive->toArray()['method']);
+
+		// dd($directive->toArray());
+		$map = $directive->toArray()['map'];
+
+		$map = array_map(function ($className) {
+			return (string)$className;
+		}, $map);
+
+		$expectedMap = [
+			'Authentication.Password' => '\Authentication\Identifier\PasswordIdentifier::class',
+			'Authentication.Token' => '\Authentication\Identifier\TokenIdentifier::class',
+		];
+		$this->assertSame($expectedMap, $map);
+	}
+
+}

--- a/tests/test_files/meta/phpstorm/.meta-44.php
+++ b/tests/test_files/meta/phpstorm/.meta-44.php
@@ -2,6 +2,14 @@
 // @link https://confluence.jetbrains.com/display/PhpStorm/PhpStorm+Advanced+Metadata
 namespace PHPSTORM_META {
 
+	override(
+		\Authentication\AuthenticationService::loadIdentifier(0),
+		map([
+			'Authentication.Password' => \Authentication\Identifier\PasswordIdentifier::class,
+			'Authentication.Token' => \Authentication\Identifier\TokenIdentifier::class,
+		])
+	);
+
 	expectedArguments(
 		\Cake\Cache\Cache::add(),
 		2,


### PR DESCRIPTION
Hi @dereuromark, This is my attempt at a PR to add type hinting to the AuthenticationService::loadIdentifier() method

I think the reason your phpstorm meta file works in VSCode is the PHP Intelephense plugin (bmewburn.vscode-intelephense-client).

I've tried to write a test but I'm not sure it's right. When I run it, it succeeds and then randomly fails.

Also I don't know how to squash these commits into one... still a git newbie.

Hope you can use it despite this.

Thanks for this plugin. Very useful