### PR TITLE
Model events

### DIFF
--- a/src/CodeCompletion/Task/ModelEventsTask.php
+++ b/src/CodeCompletion/Task/ModelEventsTask.php
@@ -1,0 +1,54 @@
+<?php
+
+
+namespace IdeHelper\CodeCompletion\Task;
+
+use IdeHelper\CodeCompletion\Task\TaskInterface;
+
+class ModelEventsTask implements TaskInterface
+{
+
+    const TYPE_NAMESPACE = 'Cake\ORM';
+
+    /**
+     * @return string
+     */
+    public function type(): string
+    {
+        return static::TYPE_NAMESPACE;
+    }
+
+    /**
+     * @return string
+     */
+    public function create(): string
+    {
+
+        return <<<HERE
+
+        use ArrayObject;
+        use Cake\Datasource\EntityInterface;
+        use Cake\Event\EventInterface;
+        use Cake\Validation\Validator;
+
+        class Table
+        {
+            public function beforeMarshal(EventInterface \$event, ArrayObject \$data, ArrayObject \$options);
+            public function afterMarshal(EventInterface \$event, EntityInterface \$entity, ArrayObject \$data, ArrayObject \$options);
+            public function beforeFind(EventInterface \$event, Query \$query, ArrayObject \$options, \$primary);
+            public function buildValidator(EventInterface \$event, Validator \$validator, \$name);
+            public function buildRules(EventInterface \$event, RulesChecker \$rules);
+            public function beforeRules(EventInterface \$event, EntityInterface \$entity, ArrayObject \$options, \$operation);
+            public function afterRules(EventInterface \$event, EntityInterface \$entity, ArrayObject \$options, \$result, \$operation);
+            public function beforeSave(EventInterface \$event, EntityInterface \$entity, ArrayObject \$options);
+            public function afterSave(EventInterface \$event, EntityInterface \$entity, ArrayObject \$options);
+            public function afterSaveCommit(EventInterface \$event, EntityInterface \$entity, ArrayObject \$options);
+            public function beforeDelete(EventInterface \$event, EntityInterface \$entity, ArrayObject \$options);
+            public function afterDelete(EventInterface \$event, EntityInterface \$entity, ArrayObject \$options);
+            public function afterDeleteCommit(EventInterface \$event, EntityInterface \$entity, ArrayObject \$options);
+        }
+
+        
+        HERE;
+    }
+}

--- a/src/CodeCompletion/Task/ModelEventsTask.php
+++ b/src/CodeCompletion/Task/ModelEventsTask.php
@@ -1,30 +1,26 @@
 <?php
 
-
 namespace IdeHelper\CodeCompletion\Task;
 
-use IdeHelper\CodeCompletion\Task\TaskInterface;
+class ModelEventsTask implements TaskInterface {
 
-class ModelEventsTask implements TaskInterface
-{
+	/**
+	 * @var string
+	 */
+	public const TYPE_NAMESPACE = 'Cake\ORM';
 
-    const TYPE_NAMESPACE = 'Cake\ORM';
+	/**
+	 * @return string
+	 */
+	public function type(): string {
+		return static::TYPE_NAMESPACE;
+	}
 
-    /**
-     * @return string
-     */
-    public function type(): string
-    {
-        return static::TYPE_NAMESPACE;
-    }
-
-    /**
-     * @return string
-     */
-    public function create(): string
-    {
-
-        return <<<HERE
+	/**
+	 * @return string
+	 */
+	public function create(): string {
+		return <<<HERE
 
         use ArrayObject;
         use Cake\Datasource\EntityInterface;
@@ -50,5 +46,6 @@ class ModelEventsTask implements TaskInterface
 
         
         HERE;
-    }
+	}
+
 }

--- a/src/CodeCompletion/TaskCollection.php
+++ b/src/CodeCompletion/TaskCollection.php
@@ -8,8 +8,7 @@ use IdeHelper\CodeCompletion\Task\ModelEventsTask;
 use IdeHelper\CodeCompletion\Task\TaskInterface;
 use InvalidArgumentException;
 
-class TaskCollection
-{
+class TaskCollection {
 
 	/**
 	 * @phpstan-var array<class-string<\IdeHelper\CodeCompletion\Task\TaskInterface>, class-string<\IdeHelper\CodeCompletion\Task\TaskInterface>>
@@ -18,7 +17,7 @@ class TaskCollection
 	 */
 	protected $defaultTasks = [
 		BehaviorTask::class => BehaviorTask::class,
-		ModelEventsTask::class => ModelEventsTask::class
+		ModelEventsTask::class => ModelEventsTask::class,
 	];
 
 	/**
@@ -29,8 +28,7 @@ class TaskCollection
 	/**
 	 * @param array<string|\IdeHelper\Generator\Task\TaskInterface> $tasks
 	 */
-	public function __construct(array $tasks = [])
-	{
+	public function __construct(array $tasks = []) {
 		$defaultTasks = (array)Configure::read('IdeHelper.codeCompletionTasks') + $this->defaultTasks;
 		$tasks += $defaultTasks;
 
@@ -50,8 +48,7 @@ class TaskCollection
 	 * @throws \InvalidArgumentException
 	 * @return $this
 	 */
-	protected function add($task)
-	{
+	protected function add($task) {
 		if (is_string($task)) {
 			$task = new $task();
 		}
@@ -71,16 +68,14 @@ class TaskCollection
 	/**
 	 * @return array<\IdeHelper\CodeCompletion\Task\TaskInterface>
 	 */
-	public function tasks(): array
-	{
+	public function tasks(): array {
 		return $this->tasks;
 	}
 
 	/**
 	 * @return array<string, array<string>>
 	 */
-	public function getMap(): array
-	{
+	public function getMap(): array {
 		$map = [];
 		foreach ($this->tasks as $task) {
 			$snippet = $task->create();
@@ -95,4 +90,5 @@ class TaskCollection
 
 		return $map;
 	}
+
 }

--- a/src/CodeCompletion/TaskCollection.php
+++ b/src/CodeCompletion/TaskCollection.php
@@ -4,10 +4,12 @@ namespace IdeHelper\CodeCompletion;
 
 use Cake\Core\Configure;
 use IdeHelper\CodeCompletion\Task\BehaviorTask;
+use IdeHelper\CodeCompletion\Task\ModelEventsTask;
 use IdeHelper\CodeCompletion\Task\TaskInterface;
 use InvalidArgumentException;
 
-class TaskCollection {
+class TaskCollection
+{
 
 	/**
 	 * @phpstan-var array<class-string<\IdeHelper\CodeCompletion\Task\TaskInterface>, class-string<\IdeHelper\CodeCompletion\Task\TaskInterface>>
@@ -16,6 +18,7 @@ class TaskCollection {
 	 */
 	protected $defaultTasks = [
 		BehaviorTask::class => BehaviorTask::class,
+		ModelEventsTask::class => ModelEventsTask::class
 	];
 
 	/**
@@ -26,7 +29,8 @@ class TaskCollection {
 	/**
 	 * @param array<string|\IdeHelper\Generator\Task\TaskInterface> $tasks
 	 */
-	public function __construct(array $tasks = []) {
+	public function __construct(array $tasks = [])
+	{
 		$defaultTasks = (array)Configure::read('IdeHelper.codeCompletionTasks') + $this->defaultTasks;
 		$tasks += $defaultTasks;
 
@@ -46,7 +50,8 @@ class TaskCollection {
 	 * @throws \InvalidArgumentException
 	 * @return $this
 	 */
-	protected function add($task) {
+	protected function add($task)
+	{
 		if (is_string($task)) {
 			$task = new $task();
 		}
@@ -66,14 +71,16 @@ class TaskCollection {
 	/**
 	 * @return array<\IdeHelper\CodeCompletion\Task\TaskInterface>
 	 */
-	public function tasks(): array {
+	public function tasks(): array
+	{
 		return $this->tasks;
 	}
 
 	/**
 	 * @return array<string, array<string>>
 	 */
-	public function getMap(): array {
+	public function getMap(): array
+	{
 		$map = [];
 		foreach ($this->tasks as $task) {
 			$snippet = $task->create();
@@ -88,5 +95,4 @@ class TaskCollection {
 
 		return $map;
 	}
-
 }

--- a/tests/TestCase/CodeCompletion/CodeCompletionGeneratorTest.php
+++ b/tests/TestCase/CodeCompletion/CodeCompletionGeneratorTest.php
@@ -37,11 +37,12 @@ class CodeCompletionGeneratorTest extends TestCase {
 		$expected = [
 			'Cake\ORM',
 		];
-
+	
 		$this->assertSame($expected, $result);
 		$this->assertFileExists(TMP . 'CodeCompletionCakeORM.php');
 
 		$result = file_get_contents(TMP . 'CodeCompletionCakeORM.php');
+	
 		$expected = <<<TXT
 <?php
 namespace Cake\ORM;
@@ -66,6 +67,29 @@ abstract class BehaviorRegistry extends \Cake\Core\ObjectRegistry {
 	public \$Nullable;
 
 }
+
+use ArrayObject;
+use Cake\Datasource\EntityInterface;
+use Cake\Event\EventInterface;
+use Cake\Validation\Validator;
+
+class Table
+{
+    public function beforeMarshal(EventInterface \$event, ArrayObject \$data, ArrayObject \$options);
+    public function afterMarshal(EventInterface \$event, EntityInterface \$entity, ArrayObject \$data, ArrayObject \$options);
+    public function beforeFind(EventInterface \$event, Query \$query, ArrayObject \$options, \$primary);
+    public function buildValidator(EventInterface \$event, Validator \$validator, \$name);
+    public function buildRules(EventInterface \$event, RulesChecker \$rules);
+    public function beforeRules(EventInterface \$event, EntityInterface \$entity, ArrayObject \$options, \$operation);
+    public function afterRules(EventInterface \$event, EntityInterface \$entity, ArrayObject \$options, \$result, \$operation);
+    public function beforeSave(EventInterface \$event, EntityInterface \$entity, ArrayObject \$options);
+    public function afterSave(EventInterface \$event, EntityInterface \$entity, ArrayObject \$options);
+    public function afterSaveCommit(EventInterface \$event, EntityInterface \$entity, ArrayObject \$options);
+    public function beforeDelete(EventInterface \$event, EntityInterface \$entity, ArrayObject \$options);
+    public function afterDelete(EventInterface \$event, EntityInterface \$entity, ArrayObject \$options);
+    public function afterDeleteCommit(EventInterface \$event, EntityInterface \$entity, ArrayObject \$options);
+}
+
 
 TXT;
 

--- a/tests/TestCase/CodeCompletion/CodeCompletionGeneratorTest.php
+++ b/tests/TestCase/CodeCompletion/CodeCompletionGeneratorTest.php
@@ -37,12 +37,12 @@ class CodeCompletionGeneratorTest extends TestCase {
 		$expected = [
 			'Cake\ORM',
 		];
-	
+
 		$this->assertSame($expected, $result);
 		$this->assertFileExists(TMP . 'CodeCompletionCakeORM.php');
 
 		$result = file_get_contents(TMP . 'CodeCompletionCakeORM.php');
-	
+
 		$expected = <<<TXT
 <?php
 namespace Cake\ORM;

--- a/tests/TestCase/CodeCompletion/Task/ModelEventsTaskTest.php
+++ b/tests/TestCase/CodeCompletion/Task/ModelEventsTaskTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace IdeHelper\Test\TestCase\CodeCompletion\Task;
+
+use Cake\TestSuite\TestCase;
+use IdeHelper\CodeCompletion\Task\ModelEventsTask;
+
+class ModelEventsTaskTest extends TestCase {
+
+	/**
+	 * @var \IdeHelper\CodeCompletion\Task\ModelEventsTask
+	 */
+	protected $task;
+
+	/**
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->task = new ModelEventsTask();
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testCollect() {
+		$result = $this->task->create();
+
+		$expected = <<<HERE
+
+        use ArrayObject;
+        use Cake\Datasource\EntityInterface;
+        use Cake\Event\EventInterface;
+        use Cake\Validation\Validator;
+
+        class Table
+        {
+            public function beforeMarshal(EventInterface \$event, ArrayObject \$data, ArrayObject \$options);
+            public function afterMarshal(EventInterface \$event, EntityInterface \$entity, ArrayObject \$data, ArrayObject \$options);
+            public function beforeFind(EventInterface \$event, Query \$query, ArrayObject \$options, \$primary);
+            public function buildValidator(EventInterface \$event, Validator \$validator, \$name);
+            public function buildRules(EventInterface \$event, RulesChecker \$rules);
+            public function beforeRules(EventInterface \$event, EntityInterface \$entity, ArrayObject \$options, \$operation);
+            public function afterRules(EventInterface \$event, EntityInterface \$entity, ArrayObject \$options, \$result, \$operation);
+            public function beforeSave(EventInterface \$event, EntityInterface \$entity, ArrayObject \$options);
+            public function afterSave(EventInterface \$event, EntityInterface \$entity, ArrayObject \$options);
+            public function afterSaveCommit(EventInterface \$event, EntityInterface \$entity, ArrayObject \$options);
+            public function beforeDelete(EventInterface \$event, EntityInterface \$entity, ArrayObject \$options);
+            public function afterDelete(EventInterface \$event, EntityInterface \$entity, ArrayObject \$options);
+            public function afterDeleteCommit(EventInterface \$event, EntityInterface \$entity, ArrayObject \$options);
+        }
+
+        
+        HERE;
+		
+		$this->assertTextEquals($expected, $result);
+	}
+
+}

--- a/tests/TestCase/CodeCompletion/Task/ModelEventsTaskTest.php
+++ b/tests/TestCase/CodeCompletion/Task/ModelEventsTaskTest.php
@@ -26,7 +26,7 @@ class ModelEventsTaskTest extends TestCase {
 	 */
 	public function testCollect() {
 		$result = $this->task->create();
-    
+
 		$expected = <<<HERE
 
         use ArrayObject;

--- a/tests/TestCase/CodeCompletion/Task/ModelEventsTaskTest.php
+++ b/tests/TestCase/CodeCompletion/Task/ModelEventsTaskTest.php
@@ -26,7 +26,7 @@ class ModelEventsTaskTest extends TestCase {
 	 */
 	public function testCollect() {
 		$result = $this->task->create();
-
+    
 		$expected = <<<HERE
 
         use ArrayObject;
@@ -53,7 +53,7 @@ class ModelEventsTaskTest extends TestCase {
 
         
         HERE;
-		
+
 		$this->assertTextEquals($expected, $result);
 	}
 


### PR DESCRIPTION
Hi @dereuromark,

I found that when I was trying to autocomplete the callback function definitions for the Model.*  events in a Table class that they wouldn't complete (I use VSCode).

Is this PR a correct way to get that working? Not sure if it will cause problems with PHPStorm or if it is implemented correctly.

Version: Cake 4.4.5 
PHP: 8.1.10

