### PR TITLE
Update AbstractAnnotator.php new Differ(null) not supported

### DIFF
--- a/src/Annotator/AbstractAnnotator.php
+++ b/src/Annotator/AbstractAnnotator.php
@@ -26,6 +26,7 @@ use PHPStan\PhpDocParser\Ast\PhpDoc\InvalidTagValueNode;
 use ReflectionClass;
 use RuntimeException;
 use SebastianBergmann\Diff\Differ;
+use SebastianBergmann\Diff\Output\DiffOnlyOutputBuilder;
 
 $composerVendorDir = getcwd() . DS . 'vendor';
 $codesnifferDir = 'squizlabs' . DS . 'php_codesniffer';
@@ -144,7 +145,7 @@ abstract class AbstractAnnotator {
 	 * @return void
 	 */
 	protected function displayDiff(string $oldContent, string $newContent): void {
-		$differ = new Differ(null);
+		$differ = new Differ(new DiffOnlyOutputBuilder());
 		$array = $differ->diffToArray($oldContent, $newContent);
 
 		$begin = null;


### PR DESCRIPTION
null in new Differ(null) not supported -> replace by any Implementation of DiffOutputBuilderInterface (like DiffOnlyOutputBuilder)
solves issues with bin/cake annotate models for example if anything changed
I am using PHP 8.2