### PR TITLE
Update DiffHelperTrait.php new Differ(null) not supported

### DIFF
--- a/tests/TestCase/Annotator/DiffHelperTrait.php
+++ b/tests/TestCase/Annotator/DiffHelperTrait.php
@@ -3,6 +3,7 @@
 namespace IdeHelper\Test\TestCase\Annotator;
 
 use SebastianBergmann\Diff\Differ;
+use SebastianBergmann\Diff\Output\DiffOnlyOutputBuilder;
 
 trait DiffHelperTrait {
 
@@ -15,7 +16,7 @@ trait DiffHelperTrait {
 	 * @return void
 	 */
 	protected function _displayDiff($expected, $actual) {
-		$differ = new Differ(null);
+		$differ = new Differ(new DiffOnlyOutputBuilder());
 		$array = $differ->diffToArray($expected, $actual);
 
 		$begin = null;


### PR DESCRIPTION
like in #302
null in new Differ(null) not supported -> replace by any Implementation of DiffOutputBuilderInterface (like DiffOnlyOutputBuilder) I am using PHP 8.2