### PR TITLE
Remove return type for Controller events

### DIFF
--- a/src/CodeCompletion/Task/ControllerEventsTask.php
+++ b/src/CodeCompletion/Task/ControllerEventsTask.php
@@ -21,19 +21,19 @@ class ControllerEventsTask implements TaskInterface {
 	 */
 	public function create(): string {
 		$events = <<<'TXT'
-		public function startup(EventInterface $event): ?Response {
+		public function startup(EventInterface $event) {
 			return null;
 		}
-		public function beforeFilter(EventInterface $event): ?Response {
+		public function beforeFilter(EventInterface $event) {
 			return null;
 		}
-		public function beforeRender(EventInterface $event): ?Response {
+		public function beforeRender(EventInterface $event) {
 			return null;
 		}
-		public function afterFilter(EventInterface $event): ?Response {
+		public function afterFilter(EventInterface $event) {
 			return null;
 		}
-		public function shutdown(EventInterface $event): ?Response {
+		public function shutdown(EventInterface $event) {
 			return null;
 		}
 		public function beforeRedirect(EventInterface $event, $url, Response $response) {

--- a/tests/TestCase/CodeCompletion/Task/ControllerEventsTaskTest.php
+++ b/tests/TestCase/CodeCompletion/Task/ControllerEventsTaskTest.php
@@ -34,19 +34,19 @@ use Cake\Http\Response;
 
 if (false) {
 	abstract class Controller {
-		public function startup(EventInterface $event): ?Response {
+		public function startup(EventInterface $event) {
 			return null;
 		}
-		public function beforeFilter(EventInterface $event): ?Response {
+		public function beforeFilter(EventInterface $event) {
 			return null;
 		}
-		public function beforeRender(EventInterface $event): ?Response {
+		public function beforeRender(EventInterface $event) {
 			return null;
 		}
-		public function afterFilter(EventInterface $event): ?Response {
+		public function afterFilter(EventInterface $event) {
 			return null;
 		}
-		public function shutdown(EventInterface $event): ?Response {
+		public function shutdown(EventInterface $event) {
 			return null;
 		}
 		public function beforeRedirect(EventInterface $event, $url, Response $response) {
@@ -55,19 +55,19 @@ if (false) {
 	}
 
 	abstract class Component {
-		public function startup(EventInterface $event): ?Response {
+		public function startup(EventInterface $event) {
 			return null;
 		}
-		public function beforeFilter(EventInterface $event): ?Response {
+		public function beforeFilter(EventInterface $event) {
 			return null;
 		}
-		public function beforeRender(EventInterface $event): ?Response {
+		public function beforeRender(EventInterface $event) {
 			return null;
 		}
-		public function afterFilter(EventInterface $event): ?Response {
+		public function afterFilter(EventInterface $event) {
 			return null;
 		}
-		public function shutdown(EventInterface $event): ?Response {
+		public function shutdown(EventInterface $event) {
 			return null;
 		}
 		public function beforeRedirect(EventInterface $event, $url, Response $response) {


### PR DESCRIPTION
Hello. I was about to open an issue since I'm not 100% confident on this but I thought a PR may be convenient.
**Cake 4.4.14 @ PHP 8.2.7**

https://github.com/dereuromark/cakephp-ide-helper/blob/f5289db4ddf6633ab71e870b07c9abcbfe94abca/src/CodeCompletion/Task/ControllerEventsTask.php#L22

The Generator adds `?Response` but that means that events should return `null | Response` while the actual Controller Events can return `void`.

So if I add `?Response` to my code, the "not compatible with method" error disappears but then I got a new error because my event is returning nothing (void) and is expected to return `null | Response`

I tried to do `null | Response | void` but [The void type can never be part of a union](https://wiki.php.net/rfc/union_types_v2#void_type)


I'm not an expert so... Is the best here to not state return type (as Cake does) or is just me doing something wrong?

![image](https://github.com/dereuromark/cakephp-ide-helper/assets/10481749/92fb071e-9fd6-42e9-9f09-e55616c07385)
