### PR TITLE
Cake 5: Fix Segfault and Failing Assertion in PHPStorm Subcommand

### DIFF
--- a/src/Command/GeneratePhpStormMetaCommand.php
+++ b/src/Command/GeneratePhpStormMetaCommand.php
@@ -39,6 +39,8 @@ class GeneratePhpStormMetaCommand extends Command {
 	 * @return int|null|void The exit code or null for success
 	 */
 	public function execute(Arguments $args, ConsoleIo $io) {
+		parent::execute($args, $io);
+
 		$phpstormGenerator = $this->getGenerator();
 		$content = $phpstormGenerator->generate();
 

--- a/src/Command/GeneratePhpStormMetaCommand.php
+++ b/src/Command/GeneratePhpStormMetaCommand.php
@@ -83,7 +83,7 @@ class GeneratePhpStormMetaCommand extends Command {
 
 		$details = 'Generate `/.phpstorm.meta.php/.ide-helper.meta.php` meta file.';
 
-		return parent::getOptionParser()
+		return $parser
 			->setDescription('Meta File Generator for generating better IDE auto-complete/hinting in PhpStorm.' . PHP_EOL . $details);
 	}
 


### PR DESCRIPTION
I just tried out your great plugin with Cake5 and when running the `phpstorm` command, i got a segfault caused by and endless recursion. After fixing that, `$this->io` was not populated correctly.
This small patch fixes those issues.

If this needs further adjustments I'm happy to make them.