### PR TITLE
Cake5: adjust tests to new DocBlockHelper mappings

### DIFF
--- a/tests/TestCase/Annotator/EntityAnnotatorTest.php
+++ b/tests/TestCase/Annotator/EntityAnnotatorTest.php
@@ -77,6 +77,15 @@ class EntityAnnotatorTest extends TestCase {
 				'precision' => null,
 				'fixed' => null,
 			],
+			'offer_date' => [
+				'type' => 'date',
+				'length' => null,
+				'null' => false,
+				'default' => null,
+				'comment' => '',
+				'baseType' => null,
+				'precision' => null,
+			],
 			'created' => [
 				'type' => 'datetime',
 				'length' => null,
@@ -174,7 +183,7 @@ class EntityAnnotatorTest extends TestCase {
 
 		$output = $this->out->output();
 
-		$this->assertTextContains('   -> 3 annotations added, 1 annotation updated.', $output);
+		$this->assertTextContains('   -> 4 annotations added, 1 annotation updated.', $output);
 	}
 
 	/**
@@ -205,7 +214,7 @@ class EntityAnnotatorTest extends TestCase {
 
 		$output = $this->out->output();
 
-		$this->assertTextContains('   -> 6 annotations added', $output);
+		$this->assertTextContains('   -> 7 annotations added', $output);
 	}
 
 	/**
@@ -236,7 +245,7 @@ class EntityAnnotatorTest extends TestCase {
 
 		$output = $this->out->output();
 
-		$this->assertTextContains('   -> 7 annotations added', $output);
+		$this->assertTextContains('   -> 8 annotations added', $output);
 	}
 
 	/**
@@ -267,7 +276,7 @@ class EntityAnnotatorTest extends TestCase {
 
 		$output = $this->out->output();
 
-		$this->assertTextContains('   -> 8 annotations added', $output);
+		$this->assertTextContains('   -> 9 annotations added', $output);
 	}
 
 	/**
@@ -298,7 +307,7 @@ class EntityAnnotatorTest extends TestCase {
 
 		$output = $this->out->output();
 
-		$this->assertTextContains('   -> 8 annotations added', $output);
+		$this->assertTextContains('   -> 9 annotations added', $output);
 	}
 
 	/**
@@ -424,7 +433,7 @@ class EntityAnnotatorTest extends TestCase {
 
 		$output = $this->out->output();
 
-		$this->assertTextContains('   -> 1 annotation updated', $output);
+		$this->assertTextContains('   -> 1 annotation added, 1 annotation updated', $output);
 	}
 
 	/**

--- a/tests/test_files/Model/Entity/Car.php
+++ b/tests/test_files/Model/Entity/Car.php
@@ -9,6 +9,7 @@ use Cake\ORM\Entity;
  * @property int $id
  * @property string $name
  * @property string $content
+ * @property \Cake\I18n\Date $offer_date
  * @property \Cake\I18n\DateTime $created
  * @property \Cake\I18n\DateTime|null $modified
  * @property \TestApp\Model\Entity\Wheel[] $wheels

--- a/tests/test_files/Model/Entity/Constants/Wheel.php
+++ b/tests/test_files/Model/Entity/Constants/Wheel.php
@@ -7,6 +7,7 @@ use Cake\ORM\Entity;
  * @property int $id
  * @property string $name
  * @property string $content
+ * @property \Cake\I18n\Date $offer_date
  * @property \Cake\I18n\DateTime $created
  * @property \Cake\I18n\DateTime|null $modified
  * @property \TestApp\Model\Entity\Wheel[] $wheels
@@ -29,6 +30,7 @@ class Wheel extends Entity {
 	const FIELD_ID = 'id';
 	const FIELD_NAME = 'name';
 	const FIELD_CONTENT = 'content';
+	const FIELD_OFFER_DATE = 'offer_date';
 	const FIELD_CREATED = 'created';
 	const FIELD_MODIFIED = 'modified';
 	const FIELD_WHEELS = 'wheels';

--- a/tests/test_files/Model/Entity/Foo.php
+++ b/tests/test_files/Model/Entity/Foo.php
@@ -8,6 +8,7 @@ use Cake\ORM\Entity;
  * @property \Cake\I18n\DateTime $created
  * @property string $name
  * @property string $content
+ * @property \Cake\I18n\Date $offer_date
  * @property \Cake\I18n\DateTime|null $modified
  */
 class Foo extends Entity {

--- a/tests/test_files/Model/Entity/PHP/Generics.php
+++ b/tests/test_files/Model/Entity/PHP/Generics.php
@@ -10,6 +10,7 @@ use Cake\ORM\Entity;
  * @property \Cake\I18n\DateTime $created
  * @property \Cake\I18n\DateTime|null $modified
  * @property array<\TestApp\Model\Entity\Wheel> $wheels
+ * @property \Cake\I18n\Date $offer_date
  */
 class Generics extends Entity {
 }

--- a/tests/test_files/Model/Entity/PHP7/Virtual.php
+++ b/tests/test_files/Model/Entity/PHP7/Virtual.php
@@ -7,6 +7,7 @@ use Cake\ORM\Entity;
  * @property int $id
  * @property string $name
  * @property string $content
+ * @property \Cake\I18n\Date $offer_date
  * @property \Cake\I18n\DateTime $created
  * @property \Cake\I18n\DateTime|null $modified
  * @property string $virtual_two

--- a/tests/test_files/Model/Entity/Virtual.php
+++ b/tests/test_files/Model/Entity/Virtual.php
@@ -8,6 +8,7 @@ use Cake\ORM\Entity;
  * @property int $id
  * @property string $name
  * @property string $content
+ * @property \Cake\I18n\Date $offer_date
  * @property \Cake\I18n\DateTime $created
  * @property \Cake\I18n\DateTime|null $modified
  * @property mixed $virtual_two

--- a/tests/test_files/Model/Entity/Wheel.php
+++ b/tests/test_files/Model/Entity/Wheel.php
@@ -7,6 +7,7 @@ use Cake\ORM\Entity;
  * @property int $id
  * @property string $name
  * @property string $content
+ * @property \Cake\I18n\Date $offer_date
  * @property \Cake\I18n\DateTime $created
  * @property \Cake\I18n\DateTime|null $modified
  * @property \TestApp\Model\Entity\Wheel[] $wheels


### PR DESCRIPTION
This PR is dependent on https://github.com/cakephp/bake/pull/929 being merged to contain and check the correct mappings being generated for entity classes