### PR TITLE
Cake5: fix IlluminateCommand

### DIFF
--- a/src/Command/IlluminateCommand.php
+++ b/src/Command/IlluminateCommand.php
@@ -30,6 +30,7 @@ class IlluminateCommand extends Command {
 	 * @return int The exit code or null for success
 	 */
 	public function execute(Arguments $args, ConsoleIo $io): int {
+		parent::execute($args, $io);
 		$path = $args->getArgument('path');
 		if (!$path) {
 			$path = ($args->getOption('plugin') ? 'src' : APP_DIR) . DS;
@@ -124,9 +125,7 @@ class IlluminateCommand extends Command {
 	 * @return array<string>
 	 */
 	protected function getTaskList(): array {
-		assert($this->args !== null, 'Args not set');
-
-		$taskCollection = new TaskCollection($this->io(), $this->args->getOptions());
+		$taskCollection = new TaskCollection($this->io(), []);
 
 		return $taskCollection->taskNames();
 	}
@@ -135,9 +134,9 @@ class IlluminateCommand extends Command {
 	 * @return \IdeHelper\Console\Io
 	 */
 	protected function io(): Io {
-		assert($this->io !== null, 'IO not set');
+		$io = $this->io ?? new ConsoleIo();
 
-		return new Io($this->io);
+		return new Io($io);
 	}
 
 }

--- a/tests/TestCase/Command/IlluminateCommandTest.php
+++ b/tests/TestCase/Command/IlluminateCommandTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace IdeHelper\Test\TestCase\Command;
+
+use Cake\Console\TestSuite\ConsoleIntegrationTestTrait;
+use Cake\TestSuite\TestCase;
+
+class IlluminateCommandTest extends TestCase {
+
+	use ConsoleIntegrationTestTrait;
+
+	/**
+	 * @return void
+	 */
+	public function testIlluminateDryRun() {
+		$this->exec('illuminator -d -v');
+
+		$this->assertExitSuccess();
+		$this->assertOutputContains('# /src/Illuminator/Illuminator.php');
+	}
+
+}


### PR DESCRIPTION
Previously it seems that the Shell had access to the options/arguments before they were built.

But now `io` and `$args` are only available in the execute method so there is no real way to pass down the arguments to the TaskCollection while they are built.