### PR TITLE
Incorrect types for ModelEventsTask.php

### DIFF
--- a/src/CodeCompletion/Task/ModelEventsTask.php
+++ b/src/CodeCompletion/Task/ModelEventsTask.php
@@ -22,8 +22,8 @@ class ModelEventsTask implements TaskInterface {
 	public function create(): string {
 		$events = <<<'TXT'
 		public function beforeMarshal(EventInterface $event, ArrayObject $data, ArrayObject $options): void {}
-		public function afterMarshal(EventInterface $event, EntityInterface $entity, ArrayObject $data, ArrayObject $options): void {}
-		public function beforeFind(EventInterface $event, Query $query, ArrayObject $options, bool $primary): void {}
+		public function afterMarshal(EventInterface $event, EntityInterface $entity, ArrayObject $options): void {}
+		public function beforeFind(EventInterface $event, SelectQuery $query, ArrayObject $options, boolean $primary): void {}
 		public function buildValidator(EventInterface $event, Validator $validator, string $name): void {}
 		public function buildRules(RulesChecker $rules): RulesChecker { return $rules; }
 		public function beforeRules(EventInterface $event, EntityInterface $entity, ArrayObject $options, string $operation): void {}
@@ -39,7 +39,7 @@ TXT;
 		return <<<CODE
 
 use ArrayObject;
-use Cake\Database\Query;
+use Cake\Database\Query\SelectQuery;
 use Cake\Datasource\EntityInterface;
 use Cake\Event\EventInterface;
 use Cake\Validation\Validator;

--- a/src/CodeCompletion/Task/ModelEventsTask.php
+++ b/src/CodeCompletion/Task/ModelEventsTask.php
@@ -42,8 +42,8 @@ use ArrayObject;
 use Cake\Database\Query\SelectQuery;
 use Cake\Datasource\EntityInterface;
 use Cake\Event\EventInterface;
-use Cake\Validation\Validator;
 use Cake\ORM\RulesChecker;
+use Cake\Validation\Validator;
 
 if (false) {
 	class Table {

--- a/src/CodeCompletion/Task/ModelEventsTask.php
+++ b/src/CodeCompletion/Task/ModelEventsTask.php
@@ -23,11 +23,11 @@ class ModelEventsTask implements TaskInterface {
 		$events = <<<'TXT'
 		public function beforeMarshal(EventInterface $event, ArrayObject $data, ArrayObject $options): void {}
 		public function afterMarshal(EventInterface $event, EntityInterface $entity, ArrayObject $data, ArrayObject $options): void {}
-		public function beforeFind(EventInterface $event, Query $query, ArrayObject $options, $primary): void {}
-		public function buildValidator(EventInterface $event, Validator $validator, $name): void {}
+		public function beforeFind(EventInterface $event, Query $query, ArrayObject $options, bool $primary): void {}
+		public function buildValidator(EventInterface $event, Validator $validator, string $name): void {}
 		public function buildRules(RulesChecker $rules): RulesChecker { return $rules; }
-		public function beforeRules(EventInterface $event, EntityInterface $entity, ArrayObject $options, $operation): void {}
-		public function afterRules(EventInterface $event, EntityInterface $entity, ArrayObject $options, $result, $operation): void {}
+		public function beforeRules(EventInterface $event, EntityInterface $entity, ArrayObject $options, string $operation): void {}
+		public function afterRules(EventInterface $event, EntityInterface $entity, ArrayObject $options, bool $result, string $operation): void {}
 		public function beforeSave(EventInterface $event, EntityInterface $entity, ArrayObject $options): void {}
 		public function afterSave(EventInterface $event, EntityInterface $entity, ArrayObject $options): void {}
 		public function afterSaveCommit(EventInterface $event, EntityInterface $entity, ArrayObject $options): void {}
@@ -39,9 +39,11 @@ TXT;
 		return <<<CODE
 
 use ArrayObject;
+use Cake\Database\Query;
 use Cake\Datasource\EntityInterface;
 use Cake\Event\EventInterface;
 use Cake\Validation\Validator;
+use Cake\ORM\RulesChecker;
 
 if (false) {
 	class Table {

--- a/src/CodeCompletion/Task/ModelEventsTask.php
+++ b/src/CodeCompletion/Task/ModelEventsTask.php
@@ -39,9 +39,9 @@ TXT;
 		return <<<CODE
 
 use ArrayObject;
-use Cake\Database\Query\SelectQuery;
 use Cake\Datasource\EntityInterface;
 use Cake\Event\EventInterface;
+use Cake\ORM\Query\SelectQuery;
 use Cake\ORM\RulesChecker;
 use Cake\Validation\Validator;
 

--- a/src/CodeCompletion/Task/ModelEventsTask.php
+++ b/src/CodeCompletion/Task/ModelEventsTask.php
@@ -23,7 +23,7 @@ class ModelEventsTask implements TaskInterface {
 		$events = <<<'TXT'
 		public function beforeMarshal(EventInterface $event, ArrayObject $data, ArrayObject $options): void {}
 		public function afterMarshal(EventInterface $event, EntityInterface $entity, ArrayObject $options): void {}
-		public function beforeFind(EventInterface $event, SelectQuery $query, ArrayObject $options, boolean $primary): void {}
+		public function beforeFind(EventInterface $event, SelectQuery $query, ArrayObject $options, bool $primary): void {}
 		public function buildValidator(EventInterface $event, Validator $validator, string $name): void {}
 		public function buildRules(RulesChecker $rules): RulesChecker { return $rules; }
 		public function beforeRules(EventInterface $event, EntityInterface $entity, ArrayObject $options, string $operation): void {}

--- a/tests/TestCase/CodeCompletion/CodeCompletionGeneratorTest.php
+++ b/tests/TestCase/CodeCompletion/CodeCompletionGeneratorTest.php
@@ -68,19 +68,21 @@ abstract class BehaviorRegistry extends \Cake\Core\ObjectRegistry {
 }
 
 use ArrayObject;
+use Cake\Database\Query;
 use Cake\Datasource\EntityInterface;
 use Cake\Event\EventInterface;
 use Cake\Validation\Validator;
+use Cake\ORM\RulesChecker;
 
 if (false) {
 	class Table {
 		public function beforeMarshal(EventInterface $event, ArrayObject $data, ArrayObject $options): void {}
 		public function afterMarshal(EventInterface $event, EntityInterface $entity, ArrayObject $data, ArrayObject $options): void {}
-		public function beforeFind(EventInterface $event, Query $query, ArrayObject $options, $primary): void {}
-		public function buildValidator(EventInterface $event, Validator $validator, $name): void {}
+		public function beforeFind(EventInterface $event, Query $query, ArrayObject $options, bool $primary): void {}
+		public function buildValidator(EventInterface $event, Validator $validator, string $name): void {}
 		public function buildRules(RulesChecker $rules): RulesChecker { return $rules; }
-		public function beforeRules(EventInterface $event, EntityInterface $entity, ArrayObject $options, $operation): void {}
-		public function afterRules(EventInterface $event, EntityInterface $entity, ArrayObject $options, $result, $operation): void {}
+		public function beforeRules(EventInterface $event, EntityInterface $entity, ArrayObject $options, string $operation): void {}
+		public function afterRules(EventInterface $event, EntityInterface $entity, ArrayObject $options, bool $result, string $operation): void {}
 		public function beforeSave(EventInterface $event, EntityInterface $entity, ArrayObject $options): void {}
 		public function afterSave(EventInterface $event, EntityInterface $entity, ArrayObject $options): void {}
 		public function afterSaveCommit(EventInterface $event, EntityInterface $entity, ArrayObject $options): void {}
@@ -92,11 +94,11 @@ if (false) {
 	class Behavior {
 		public function beforeMarshal(EventInterface $event, ArrayObject $data, ArrayObject $options): void {}
 		public function afterMarshal(EventInterface $event, EntityInterface $entity, ArrayObject $data, ArrayObject $options): void {}
-		public function beforeFind(EventInterface $event, Query $query, ArrayObject $options, $primary): void {}
-		public function buildValidator(EventInterface $event, Validator $validator, $name): void {}
+		public function beforeFind(EventInterface $event, Query $query, ArrayObject $options, bool $primary): void {}
+		public function buildValidator(EventInterface $event, Validator $validator, string $name): void {}
 		public function buildRules(RulesChecker $rules): RulesChecker { return $rules; }
-		public function beforeRules(EventInterface $event, EntityInterface $entity, ArrayObject $options, $operation): void {}
-		public function afterRules(EventInterface $event, EntityInterface $entity, ArrayObject $options, $result, $operation): void {}
+		public function beforeRules(EventInterface $event, EntityInterface $entity, ArrayObject $options, string $operation): void {}
+		public function afterRules(EventInterface $event, EntityInterface $entity, ArrayObject $options, bool $result, string $operation): void {}
 		public function beforeSave(EventInterface $event, EntityInterface $entity, ArrayObject $options): void {}
 		public function afterSave(EventInterface $event, EntityInterface $entity, ArrayObject $options): void {}
 		public function afterSaveCommit(EventInterface $event, EntityInterface $entity, ArrayObject $options): void {}

--- a/tests/TestCase/CodeCompletion/CodeCompletionGeneratorTest.php
+++ b/tests/TestCase/CodeCompletion/CodeCompletionGeneratorTest.php
@@ -71,8 +71,8 @@ use ArrayObject;
 use Cake\Database\Query\SelectQuery;
 use Cake\Datasource\EntityInterface;
 use Cake\Event\EventInterface;
-use Cake\Validation\Validator;
 use Cake\ORM\RulesChecker;
+use Cake\Validation\Validator;
 
 if (false) {
 	class Table {

--- a/tests/TestCase/CodeCompletion/CodeCompletionGeneratorTest.php
+++ b/tests/TestCase/CodeCompletion/CodeCompletionGeneratorTest.php
@@ -78,7 +78,7 @@ if (false) {
 	class Table {
 		public function beforeMarshal(EventInterface $event, ArrayObject $data, ArrayObject $options): void {}
 		public function afterMarshal(EventInterface $event, EntityInterface $entity, ArrayObject $options): void {}
-		public function beforeFind(EventInterface $event, SelectQuery $query, ArrayObject $options, boolean $primary): void {}
+		public function beforeFind(EventInterface $event, SelectQuery $query, ArrayObject $options, bool $primary): void {}
 		public function buildValidator(EventInterface $event, Validator $validator, string $name): void {}
 		public function buildRules(RulesChecker $rules): RulesChecker { return $rules; }
 		public function beforeRules(EventInterface $event, EntityInterface $entity, ArrayObject $options, string $operation): void {}
@@ -94,7 +94,7 @@ if (false) {
 	class Behavior {
 		public function beforeMarshal(EventInterface $event, ArrayObject $data, ArrayObject $options): void {}
 		public function afterMarshal(EventInterface $event, EntityInterface $entity, ArrayObject $options): void {}
-		public function beforeFind(EventInterface $event, SelectQuery $query, ArrayObject $options, boolean $primary): void {}
+		public function beforeFind(EventInterface $event, SelectQuery $query, ArrayObject $options, bool $primary): void {}
 		public function buildValidator(EventInterface $event, Validator $validator, string $name): void {}
 		public function buildRules(RulesChecker $rules): RulesChecker { return $rules; }
 		public function beforeRules(EventInterface $event, EntityInterface $entity, ArrayObject $options, string $operation): void {}

--- a/tests/TestCase/CodeCompletion/CodeCompletionGeneratorTest.php
+++ b/tests/TestCase/CodeCompletion/CodeCompletionGeneratorTest.php
@@ -68,9 +68,9 @@ abstract class BehaviorRegistry extends \Cake\Core\ObjectRegistry {
 }
 
 use ArrayObject;
-use Cake\Database\Query\SelectQuery;
 use Cake\Datasource\EntityInterface;
 use Cake\Event\EventInterface;
+use Cake\ORM\Query\SelectQuery;
 use Cake\ORM\RulesChecker;
 use Cake\Validation\Validator;
 

--- a/tests/TestCase/CodeCompletion/CodeCompletionGeneratorTest.php
+++ b/tests/TestCase/CodeCompletion/CodeCompletionGeneratorTest.php
@@ -68,7 +68,7 @@ abstract class BehaviorRegistry extends \Cake\Core\ObjectRegistry {
 }
 
 use ArrayObject;
-use Cake\Database\Query;
+use Cake\Database\Query\SelectQuery;
 use Cake\Datasource\EntityInterface;
 use Cake\Event\EventInterface;
 use Cake\Validation\Validator;
@@ -77,8 +77,8 @@ use Cake\ORM\RulesChecker;
 if (false) {
 	class Table {
 		public function beforeMarshal(EventInterface $event, ArrayObject $data, ArrayObject $options): void {}
-		public function afterMarshal(EventInterface $event, EntityInterface $entity, ArrayObject $data, ArrayObject $options): void {}
-		public function beforeFind(EventInterface $event, Query $query, ArrayObject $options, bool $primary): void {}
+		public function afterMarshal(EventInterface $event, EntityInterface $entity, ArrayObject $options): void {}
+		public function beforeFind(EventInterface $event, SelectQuery $query, ArrayObject $options, boolean $primary): void {}
 		public function buildValidator(EventInterface $event, Validator $validator, string $name): void {}
 		public function buildRules(RulesChecker $rules): RulesChecker { return $rules; }
 		public function beforeRules(EventInterface $event, EntityInterface $entity, ArrayObject $options, string $operation): void {}
@@ -93,8 +93,8 @@ if (false) {
 
 	class Behavior {
 		public function beforeMarshal(EventInterface $event, ArrayObject $data, ArrayObject $options): void {}
-		public function afterMarshal(EventInterface $event, EntityInterface $entity, ArrayObject $data, ArrayObject $options): void {}
-		public function beforeFind(EventInterface $event, Query $query, ArrayObject $options, bool $primary): void {}
+		public function afterMarshal(EventInterface $event, EntityInterface $entity, ArrayObject $options): void {}
+		public function beforeFind(EventInterface $event, SelectQuery $query, ArrayObject $options, boolean $primary): void {}
 		public function buildValidator(EventInterface $event, Validator $validator, string $name): void {}
 		public function buildRules(RulesChecker $rules): RulesChecker { return $rules; }
 		public function beforeRules(EventInterface $event, EntityInterface $entity, ArrayObject $options, string $operation): void {}

--- a/tests/TestCase/CodeCompletion/Task/ModelEventsTaskTest.php
+++ b/tests/TestCase/CodeCompletion/Task/ModelEventsTaskTest.php
@@ -37,7 +37,7 @@ if (false) {
 	class Table {
 		public function beforeMarshal(EventInterface $event, ArrayObject $data, ArrayObject $options): void {}
 		public function afterMarshal(EventInterface $event, EntityInterface $entity, ArrayObject $options): void {}
-		public function beforeFind(EventInterface $event, SelectQuery $query, ArrayObject $options, boolean $primary): void {}
+		public function beforeFind(EventInterface $event, SelectQuery $query, ArrayObject $options, bool $primary): void {}
 		public function buildValidator(EventInterface $event, Validator $validator, string $name): void {}
 		public function buildRules(RulesChecker $rules): RulesChecker { return $rules; }
 		public function beforeRules(EventInterface $event, EntityInterface $entity, ArrayObject $options, string $operation): void {}
@@ -53,7 +53,7 @@ if (false) {
 	class Behavior {
 		public function beforeMarshal(EventInterface $event, ArrayObject $data, ArrayObject $options): void {}
 		public function afterMarshal(EventInterface $event, EntityInterface $entity, ArrayObject $options): void {}
-		public function beforeFind(EventInterface $event, SelectQuery $query, ArrayObject $options, boolean $primary): void {}
+		public function beforeFind(EventInterface $event, SelectQuery $query, ArrayObject $options, bool $primary): void {}
 		public function buildValidator(EventInterface $event, Validator $validator, string $name): void {}
 		public function buildRules(RulesChecker $rules): RulesChecker { return $rules; }
 		public function beforeRules(EventInterface $event, EntityInterface $entity, ArrayObject $options, string $operation): void {}

--- a/tests/TestCase/CodeCompletion/Task/ModelEventsTaskTest.php
+++ b/tests/TestCase/CodeCompletion/Task/ModelEventsTaskTest.php
@@ -27,9 +27,9 @@ class ModelEventsTaskTest extends TestCase {
 		$expected = <<<'TXT'
 
 use ArrayObject;
-use Cake\Database\Query\SelectQuery;
 use Cake\Datasource\EntityInterface;
 use Cake\Event\EventInterface;
+use Cake\ORM\Query\SelectQuery;
 use Cake\ORM\RulesChecker;
 use Cake\Validation\Validator;
 

--- a/tests/TestCase/CodeCompletion/Task/ModelEventsTaskTest.php
+++ b/tests/TestCase/CodeCompletion/Task/ModelEventsTaskTest.php
@@ -27,7 +27,7 @@ class ModelEventsTaskTest extends TestCase {
 		$expected = <<<'TXT'
 
 use ArrayObject;
-use Cake\Database\Query;
+use Cake\Database\Query\SelectQuery;
 use Cake\Datasource\EntityInterface;
 use Cake\Event\EventInterface;
 use Cake\Validation\Validator;
@@ -36,8 +36,8 @@ use Cake\ORM\RulesChecker;
 if (false) {
 	class Table {
 		public function beforeMarshal(EventInterface $event, ArrayObject $data, ArrayObject $options): void {}
-		public function afterMarshal(EventInterface $event, EntityInterface $entity, ArrayObject $data, ArrayObject $options): void {}
-		public function beforeFind(EventInterface $event, Query $query, ArrayObject $options, bool $primary): void {}
+		public function afterMarshal(EventInterface $event, EntityInterface $entity, ArrayObject $options): void {}
+		public function beforeFind(EventInterface $event, SelectQuery $query, ArrayObject $options, boolean $primary): void {}
 		public function buildValidator(EventInterface $event, Validator $validator, string $name): void {}
 		public function buildRules(RulesChecker $rules): RulesChecker { return $rules; }
 		public function beforeRules(EventInterface $event, EntityInterface $entity, ArrayObject $options, string $operation): void {}
@@ -52,8 +52,8 @@ if (false) {
 
 	class Behavior {
 		public function beforeMarshal(EventInterface $event, ArrayObject $data, ArrayObject $options): void {}
-		public function afterMarshal(EventInterface $event, EntityInterface $entity, ArrayObject $data, ArrayObject $options): void {}
-		public function beforeFind(EventInterface $event, Query $query, ArrayObject $options, bool $primary): void {}
+		public function afterMarshal(EventInterface $event, EntityInterface $entity, ArrayObject $options): void {}
+		public function beforeFind(EventInterface $event, SelectQuery $query, ArrayObject $options, boolean $primary): void {}
 		public function buildValidator(EventInterface $event, Validator $validator, string $name): void {}
 		public function buildRules(RulesChecker $rules): RulesChecker { return $rules; }
 		public function beforeRules(EventInterface $event, EntityInterface $entity, ArrayObject $options, string $operation): void {}

--- a/tests/TestCase/CodeCompletion/Task/ModelEventsTaskTest.php
+++ b/tests/TestCase/CodeCompletion/Task/ModelEventsTaskTest.php
@@ -27,19 +27,21 @@ class ModelEventsTaskTest extends TestCase {
 		$expected = <<<'TXT'
 
 use ArrayObject;
+use Cake\Database\Query;
 use Cake\Datasource\EntityInterface;
 use Cake\Event\EventInterface;
 use Cake\Validation\Validator;
+use Cake\ORM\RulesChecker;
 
 if (false) {
 	class Table {
 		public function beforeMarshal(EventInterface $event, ArrayObject $data, ArrayObject $options): void {}
 		public function afterMarshal(EventInterface $event, EntityInterface $entity, ArrayObject $data, ArrayObject $options): void {}
-		public function beforeFind(EventInterface $event, Query $query, ArrayObject $options, $primary): void {}
-		public function buildValidator(EventInterface $event, Validator $validator, $name): void {}
+		public function beforeFind(EventInterface $event, Query $query, ArrayObject $options, bool $primary): void {}
+		public function buildValidator(EventInterface $event, Validator $validator, string $name): void {}
 		public function buildRules(RulesChecker $rules): RulesChecker { return $rules; }
-		public function beforeRules(EventInterface $event, EntityInterface $entity, ArrayObject $options, $operation): void {}
-		public function afterRules(EventInterface $event, EntityInterface $entity, ArrayObject $options, $result, $operation): void {}
+		public function beforeRules(EventInterface $event, EntityInterface $entity, ArrayObject $options, string $operation): void {}
+		public function afterRules(EventInterface $event, EntityInterface $entity, ArrayObject $options, bool $result, string $operation): void {}
 		public function beforeSave(EventInterface $event, EntityInterface $entity, ArrayObject $options): void {}
 		public function afterSave(EventInterface $event, EntityInterface $entity, ArrayObject $options): void {}
 		public function afterSaveCommit(EventInterface $event, EntityInterface $entity, ArrayObject $options): void {}
@@ -51,11 +53,11 @@ if (false) {
 	class Behavior {
 		public function beforeMarshal(EventInterface $event, ArrayObject $data, ArrayObject $options): void {}
 		public function afterMarshal(EventInterface $event, EntityInterface $entity, ArrayObject $data, ArrayObject $options): void {}
-		public function beforeFind(EventInterface $event, Query $query, ArrayObject $options, $primary): void {}
-		public function buildValidator(EventInterface $event, Validator $validator, $name): void {}
+		public function beforeFind(EventInterface $event, Query $query, ArrayObject $options, bool $primary): void {}
+		public function buildValidator(EventInterface $event, Validator $validator, string $name): void {}
 		public function buildRules(RulesChecker $rules): RulesChecker { return $rules; }
-		public function beforeRules(EventInterface $event, EntityInterface $entity, ArrayObject $options, $operation): void {}
-		public function afterRules(EventInterface $event, EntityInterface $entity, ArrayObject $options, $result, $operation): void {}
+		public function beforeRules(EventInterface $event, EntityInterface $entity, ArrayObject $options, string $operation): void {}
+		public function afterRules(EventInterface $event, EntityInterface $entity, ArrayObject $options, bool $result, string $operation): void {}
 		public function beforeSave(EventInterface $event, EntityInterface $entity, ArrayObject $options): void {}
 		public function afterSave(EventInterface $event, EntityInterface $entity, ArrayObject $options): void {}
 		public function afterSaveCommit(EventInterface $event, EntityInterface $entity, ArrayObject $options): void {}

--- a/tests/TestCase/CodeCompletion/Task/ModelEventsTaskTest.php
+++ b/tests/TestCase/CodeCompletion/Task/ModelEventsTaskTest.php
@@ -30,8 +30,8 @@ use ArrayObject;
 use Cake\Database\Query\SelectQuery;
 use Cake\Datasource\EntityInterface;
 use Cake\Event\EventInterface;
-use Cake\Validation\Validator;
 use Cake\ORM\RulesChecker;
+use Cake\Validation\Validator;
 
 if (false) {
 	class Table {


### PR DESCRIPTION
Signature of Model Events is outdated for CakePHP 5.

New signatures taken from https://github.com/cakephp/cakephp/blob/5.0.0/src/ORM/Table.php#L141-L153
