### PR TITLE
Update DatabaseTypeTask.php to use TypeFactory

### DIFF
--- a/src/Generator/Task/DatabaseTypeTask.php
+++ b/src/Generator/Task/DatabaseTypeTask.php
@@ -2,7 +2,6 @@
 
 namespace IdeHelper\Generator\Task;
 
-use Cake\Database\Type;
 use Cake\Database\TypeFactory;
 use IdeHelper\Generator\Directive\ExpectedArguments;
 use IdeHelper\Generator\Directive\Override;
@@ -55,7 +54,7 @@ class DatabaseTypeTask implements TaskInterface {
 		$types = [];
 
 		try {
-			$allTypes = Type::buildAll();
+			$allTypes = TypeFactory::buildAll();
 		} catch (Throwable $exception) {
 			return $types;
 		}


### PR DESCRIPTION
This was updated on the 2.x branch, but I noticed a deprecation warning tonight on the 1.x branch after updating to CakePHP 4.5.0.