### PR TITLE
Fix up new model annotations as generics

### DIFF
--- a/config/app.example.php
+++ b/config/app.example.php
@@ -20,7 +20,7 @@ return [
 		'arrayAsGenerics' => false, // Enable to have modern generics syntax (recommended) in doc blocks
 		// Set to false to disable
 		'objectAsGenerics' => false, // Enable to have modern generics syntax (recommended) in doc blocks
-		'assocsAsGeneric' => false, // Enable to have modern generics syntax (NOT recommended yet) in doc blocks
+		'assocsAsGenerics' => false, // Enable to have modern generics syntax (NOT recommended yet) in doc blocks
 		// Set to false to disable, or string if you have a custom FQCN to be used
 		'templateCollectionObject' => true,
 		// Set to false to disable, defaults to mixed if enabled, you can also pass callable for logic

--- a/config/app.example.php
+++ b/config/app.example.php
@@ -20,7 +20,7 @@ return [
 		'arrayAsGenerics' => false, // Enable to have modern generics syntax (recommended) in doc blocks
 		// Set to false to disable
 		'objectAsGenerics' => false, // Enable to have modern generics syntax (recommended) in doc blocks
-		'assocsAsGeneric' => false,  // Enable to have modern generics syntax (NOT recommended yet) in doc blocks
+		'assocsAsGeneric' => false, // Enable to have modern generics syntax (NOT recommended yet) in doc blocks
 		// Set to false to disable, or string if you have a custom FQCN to be used
 		'templateCollectionObject' => true,
 		// Set to false to disable, defaults to mixed if enabled, you can also pass callable for logic

--- a/config/app.example.php
+++ b/config/app.example.php
@@ -20,6 +20,7 @@ return [
 		'arrayAsGenerics' => false, // Enable to have modern generics syntax (recommended) in doc blocks
 		// Set to false to disable
 		'objectAsGenerics' => false, // Enable to have modern generics syntax (recommended) in doc blocks
+		'assocsAsGeneric' => false,  // Enable to have modern generics syntax (NOT recommended yet) in doc blocks
 		// Set to false to disable, or string if you have a custom FQCN to be used
 		'templateCollectionObject' => true,
 		// Set to false to disable, defaults to mixed if enabled, you can also pass callable for logic

--- a/docs/Annotations.md
+++ b/docs/Annotations.md
@@ -86,8 +86,8 @@ A LocationsTable class would then get the following doc block annotations added 
  * @method \Cake\Datasource\ResultSetInterface<\App\Model\Entity\Location>|false deleteMany(iterable $entities, $options = [])
  * @method \Cake\Datasource\ResultSetInterface<\App\Model\Entity\Location> deleteManyOrFail(iterable $entities, $options = [])
  *
- * @property \App\Model\Table\ImagesTable&\Cake\ORM\Association\HasMany $Images
- * @property \App\Model\Table\UsersTable&\Cake\ORM\Association\BelongsTo $Users
+ * @property \Cake\ORM\Association\HasMany<\App\Model\Table\ImagesTable> $Images
+ * @property \Cake\ORM\Association\BelongsTo<\App\Model\Table\UsersTable> $Users
  *
  * @mixin \Cake\ORM\Behavior\TimestampBehavior
 ```

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -11,6 +11,7 @@ parameters:
 	bootstrapFiles:
 		- tests/bootstrap.php
 		- tests/shim.php
+	checkGenericClassInNonGenericObjectType: false
 	ignoreErrors:
 		- '#Unsafe usage of new static\(\).+#'
 		- '#Parameter \#1 \$object of function get_class expects object, object\|string given.#'

--- a/src/Annotator/ModelAnnotator.php
+++ b/src/Annotator/ModelAnnotator.php
@@ -137,7 +137,7 @@ class ModelAnnotator extends AbstractAnnotator {
 		$annotations = [];
 		foreach ($associations as $type => $assocs) {
 			foreach ($assocs as $name => $className) {
-				$annotations[] = "@property \\{$className}&\\{$type} \${$name}";
+				$annotations[] = "@property \\{$type}<\\{$className}> \${$name}";
 			}
 		}
 

--- a/src/Annotator/ModelAnnotator.php
+++ b/src/Annotator/ModelAnnotator.php
@@ -137,7 +137,7 @@ class ModelAnnotator extends AbstractAnnotator {
 		$annotations = [];
 		foreach ($associations as $type => $assocs) {
 			foreach ($assocs as $name => $className) {
-				if (Configure::read('IdeHelper.assocsAsGeneric') === true) {
+				if (Configure::read('IdeHelper.assocsAsGenerics') === true) {
 					$annotations[] = "@property \\{$type}<\\{$className}> \${$name}";
 				} else {
 					$annotations[] = "@property \\{$className}&\\{$type} \${$name}";

--- a/src/Annotator/ModelAnnotator.php
+++ b/src/Annotator/ModelAnnotator.php
@@ -137,7 +137,11 @@ class ModelAnnotator extends AbstractAnnotator {
 		$annotations = [];
 		foreach ($associations as $type => $assocs) {
 			foreach ($assocs as $name => $className) {
-				$annotations[] = "@property \\{$type}<\\{$className}> \${$name}";
+				if (Configure::read('IdeHelper.assocsAsGeneric') === true) {
+					$annotations[] = "@property \\{$type}<\\{$className}> \${$name}";
+				} else {
+					$annotations[] = "@property \\{$className}&\\{$type} \${$name}";
+				}
 			}
 		}
 

--- a/tests/TestCase/Annotator/ModelAnnotatorTest.php
+++ b/tests/TestCase/Annotator/ModelAnnotatorTest.php
@@ -10,7 +10,6 @@ use Cake\TestSuite\TestCase;
 use IdeHelper\Annotator\AbstractAnnotator;
 use IdeHelper\Annotator\ModelAnnotator;
 use IdeHelper\Console\Io;
-use Phinx\Config\Config;
 use Shim\TestSuite\ConsoleOutput;
 use TestApp\Model\Table\FoosTable;
 

--- a/tests/TestCase/Annotator/ModelAnnotatorTest.php
+++ b/tests/TestCase/Annotator/ModelAnnotatorTest.php
@@ -98,6 +98,8 @@ class ModelAnnotatorTest extends TestCase {
 	 * @return void
 	 */
 	public function tearDown(): void {
+		parent::tearDown();
+
 		Configure::delete('IdeHelper.assocsAsGeneric');
 	}
 

--- a/tests/TestCase/Annotator/ModelAnnotatorTest.php
+++ b/tests/TestCase/Annotator/ModelAnnotatorTest.php
@@ -43,7 +43,7 @@ class ModelAnnotatorTest extends TestCase {
 		$consoleIo = new ConsoleIo($this->out, $this->err);
 		$this->io = new Io($consoleIo);
 
-		Configure::write('IdeHelper.assocsAsGeneric', true);
+		Configure::write('IdeHelper.assocsAsGenerics', true);
 
 		$x = TableRegistry::getTableLocator()->get('IdeHelper.Foos', ['className' => FoosTable::class]);
 		$columns = [
@@ -99,7 +99,7 @@ class ModelAnnotatorTest extends TestCase {
 	public function tearDown(): void {
 		parent::tearDown();
 
-		Configure::delete('IdeHelper.assocsAsGeneric');
+		Configure::delete('IdeHelper.assocsAsGenerics');
 	}
 
 	/**

--- a/tests/TestCase/Annotator/ModelAnnotatorTest.php
+++ b/tests/TestCase/Annotator/ModelAnnotatorTest.php
@@ -3,12 +3,14 @@
 namespace IdeHelper\Test\TestCase\Annotator;
 
 use Cake\Console\ConsoleIo;
+use Cake\Core\Configure;
 use Cake\Database\Schema\TableSchema;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 use IdeHelper\Annotator\AbstractAnnotator;
 use IdeHelper\Annotator\ModelAnnotator;
 use IdeHelper\Console\Io;
+use Phinx\Config\Config;
 use Shim\TestSuite\ConsoleOutput;
 use TestApp\Model\Table\FoosTable;
 
@@ -41,6 +43,8 @@ class ModelAnnotatorTest extends TestCase {
 		$this->err = new ConsoleOutput();
 		$consoleIo = new ConsoleIo($this->out, $this->err);
 		$this->io = new Io($consoleIo);
+
+		Configure::write('IdeHelper.assocsAsGeneric', true);
 
 		$x = TableRegistry::getTableLocator()->get('IdeHelper.Foos', ['className' => FoosTable::class]);
 		$columns = [
@@ -88,6 +92,13 @@ class ModelAnnotatorTest extends TestCase {
 		$schema = new TableSchema('Foos', $columns);
 		$x->setSchema($schema);
 		TableRegistry::getTableLocator()->set('Foos', $x);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function tearDown(): void {
+		Configure::delete('IdeHelper.assocsAsGeneric');
 	}
 
 	/**

--- a/tests/TestCase/Command/AnnotateCommandTest.php
+++ b/tests/TestCase/Command/AnnotateCommandTest.php
@@ -37,7 +37,7 @@ class AnnotateCommandTest extends TestCase {
 	public function tearDown(): void {
 		parent::tearDown();
 
-		Configure::delete('IdeHelper.assocsAsGeneric');
+		Configure::delete('IdeHelper.assocsAsGenerics');
 	}
 
 	/**

--- a/tests/TestCase/Command/AnnotateCommandTest.php
+++ b/tests/TestCase/Command/AnnotateCommandTest.php
@@ -3,6 +3,7 @@
 namespace IdeHelper\Test\TestCase\Command;
 
 use Cake\Console\TestSuite\ConsoleIntegrationTestTrait;
+use Cake\Core\Configure;
 use Cake\TestSuite\TestCase;
 use IdeHelper\Command\AnnotateCommand;
 
@@ -26,6 +27,17 @@ class AnnotateCommandTest extends TestCase {
 		if (!is_dir(LOGS)) {
 			mkdir(LOGS, 0770, true);
 		}
+
+		Configure::write('IdeHelper.assocsAsGeneric', true);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function tearDown(): void {
+		parent::tearDown();
+
+		Configure::delete('IdeHelper.assocsAsGeneric');
 	}
 
 	/**

--- a/tests/TestCase/Command/AnnotateCommandTest.php
+++ b/tests/TestCase/Command/AnnotateCommandTest.php
@@ -28,7 +28,7 @@ class AnnotateCommandTest extends TestCase {
 			mkdir(LOGS, 0770, true);
 		}
 
-		Configure::write('IdeHelper.assocsAsGeneric', true);
+		Configure::write('IdeHelper.assocsAsGenerics', true);
 	}
 
 	/**
@@ -134,7 +134,7 @@ class AnnotateCommandTest extends TestCase {
 	 */
 	public function testAllCiModeNoChanges() {
 		$this->exec('annotate all -d -v --ci -p Awesome');
-		$this->assertExitSuccess();
+		$this->assertExitSuccess($this->_out->output());
 	}
 
 	/**
@@ -143,7 +143,7 @@ class AnnotateCommandTest extends TestCase {
 	public function testAllCiModeChanges() {
 		$this->exec('annotate all -d -v --ci');
 
-		$this->assertExitCode(AnnotateCommand::CODE_CHANGES);
+		$this->assertExitCode(AnnotateCommand::CODE_CHANGES, $this->_out->output());
 	}
 
 	/**
@@ -166,11 +166,11 @@ class AnnotateCommandTest extends TestCase {
 	 * @param string $subcommand The subcommand to be tested
 	 * @return void
 	 */
-	public function testIndividualSubcommandCiModeNoChanges($subcommand) {
+	public function testIndividualSubcommandCiModeNoChanges(string $subcommand): void {
 		$this->skipIf($subcommand === 'view', 'View does not support the plugin parameter');
 
 		$this->exec('annotate ' . $subcommand . ' -d -v --ci -p Awesome');
-		$this->assertExitSuccess();
+		$this->assertExitSuccess($this->_out->output());
 	}
 
 	/**
@@ -179,10 +179,10 @@ class AnnotateCommandTest extends TestCase {
 	 * @param string $subcommand The subcommand to be tested
 	 * @return void
 	 */
-	public function testIndividualSubcommandCiModeChanges($subcommand) {
+	public function testIndividualSubcommandCiModeChanges(string $subcommand): void {
 		$this->exec('annotate ' . $subcommand . ' -d -v --ci');
 
-		$this->assertExitCode(AnnotateCommand::CODE_CHANGES);
+		$this->assertExitCode(AnnotateCommand::CODE_CHANGES, $this->_out->output());
 	}
 
 }

--- a/tests/test_app/plugins/Awesome/src/Model/Table/HousesTable.php
+++ b/tests/test_app/plugins/Awesome/src/Model/Table/HousesTable.php
@@ -4,7 +4,7 @@ namespace Awesome\Model\Table;
 use Cake\ORM\Table;
 
 /**
- * @property \Awesome\Model\Table\WindowsTable&\Cake\ORM\Association\HasMany $Windows
+ * @property \Cake\ORM\Association\HasMany<\Awesome\Model\Table\WindowsTable> $Windows
  */
 class HousesTable extends Table {
 

--- a/tests/test_app/plugins/Awesome/src/Model/Table/WindowsTable.php
+++ b/tests/test_app/plugins/Awesome/src/Model/Table/WindowsTable.php
@@ -4,7 +4,7 @@ namespace Awesome\Model\Table;
 use Cake\ORM\Table;
 
 /**
- * @property \Awesome\Model\Table\HousesTable&\Cake\ORM\Association\BelongsTo $Houses
+ * @property \Cake\ORM\Association\BelongsTo<\Awesome\Model\Table\HousesTable> $Houses
  */
 class WindowsTable extends Table {
 

--- a/tests/test_app/src/Model/Table/SkipSomeTable.php
+++ b/tests/test_app/src/Model/Table/SkipSomeTable.php
@@ -4,8 +4,8 @@ namespace TestApp\Model\Table;
 use Cake\ORM\Table;
 
 /**
- * @property \TestApp\Model\Table\CarsTable|\Cake\ORM\Association\BelongsTo $Cars
- * @property \TestApp\Model\Table\CarsTable|\Cake\ORM\Association\BelongsTo $CarsAwesome
+ * @property \Cake\ORM\Association\BelongsTo<\TestApp\Model\Table\CarsTable> $Cars
+ * @property \Cake\ORM\Association\BelongsTo<\TestApp\Model\Table\CarsTable> $CarsAwesome
  */
 class SkipSomeTable extends Table {
 

--- a/tests/test_app/src/Model/Table/WheelsExtraTable.php
+++ b/tests/test_app/src/Model/Table/WheelsExtraTable.php
@@ -4,7 +4,7 @@ namespace TestApp\Model\Table;
 use Cake\ORM\Table;
 
 /**
- * @property \TestApp\Model\Table\CarsOldTable&\Cake\ORM\Association\BelongsTo $Cars
+ * @property \Cake\ORM\Association\BelongsTo<\TestApp\Model\Table\CarsOldTable> $Cars
  */
 class WheelsExtraTable extends Table {
 

--- a/tests/test_files/Model/Table/BarBarsAbstractTable.php
+++ b/tests/test_files/Model/Table/BarBarsAbstractTable.php
@@ -2,9 +2,9 @@
 namespace TestApp\Model\Table;
 
 /**
- * @property \TestApp\Model\Table\FoosTable&\Cake\ORM\Association\BelongsTo $Foos
- * @property \Awesome\Model\Table\HousesTable&\Cake\ORM\Association\BelongsToMany $Houses
- * @property \Awesome\Model\Table\WindowsTable&\Cake\ORM\Association\HasMany $Windows
+ * @property \Cake\ORM\Association\BelongsTo<\TestApp\Model\Table\FoosTable> $Foos
+ * @property \Cake\ORM\Association\BelongsToMany<\Awesome\Model\Table\HousesTable> $Houses
+ * @property \Cake\ORM\Association\HasMany<\Awesome\Model\Table\WindowsTable> $Windows
  *
  * @method \TestApp\Model\Entity\BarBarsAbstract newEmptyEntity()
  * @method \TestApp\Model\Entity\BarBarsAbstract newEntity(array $data, array $options = [])

--- a/tests/test_files/Model/Table/BarBarsTable.php
+++ b/tests/test_files/Model/Table/BarBarsTable.php
@@ -4,9 +4,9 @@ namespace TestApp\Model\Table;
 use Cake\ORM\Table;
 
 /**
- * @property \TestApp\Model\Table\FoosTable&\Cake\ORM\Association\BelongsTo $Foos
- * @property \Awesome\Model\Table\HousesTable&\Cake\ORM\Association\BelongsToMany $Houses
- * @property \Awesome\Model\Table\WindowsTable&\Cake\ORM\Association\HasMany $Windows
+ * @property \Cake\ORM\Association\BelongsTo<\TestApp\Model\Table\FoosTable> $Foos
+ * @property \Cake\ORM\Association\BelongsToMany<\Awesome\Model\Table\HousesTable> $Houses
+ * @property \Cake\ORM\Association\HasMany<\Awesome\Model\Table\WindowsTable> $Windows
  *
  * @method \TestApp\Model\Entity\BarBar newEmptyEntity()
  * @method \TestApp\Model\Entity\BarBar newEntity(array $data, array $options = [])

--- a/tests/test_files/Model/Table/SkipSomeTable.php
+++ b/tests/test_files/Model/Table/SkipSomeTable.php
@@ -4,8 +4,8 @@ namespace TestApp\Model\Table;
 use Cake\ORM\Table;
 
 /**
- * @property \TestApp\Model\Table\CarsTable|\Cake\ORM\Association\BelongsTo $Cars
- * @property \TestApp\Model\Table\CarsTable|\Cake\ORM\Association\BelongsTo $CarsAwesome
+ * @property \Cake\ORM\Association\BelongsTo<\TestApp\Model\Table\CarsTable> $Cars
+ * @property \Cake\ORM\Association\BelongsTo<\TestApp\Model\Table\CarsTable> $CarsAwesome
  */
 class SkipSomeTable extends Table {
 

--- a/tests/test_files/Model/Table/WheelsExtraTable.php
+++ b/tests/test_files/Model/Table/WheelsExtraTable.php
@@ -4,7 +4,7 @@ namespace TestApp\Model\Table;
 use Cake\ORM\Table;
 
 /**
- * @property \TestApp\Model\Table\CarsTable&\Cake\ORM\Association\BelongsTo $Cars
+ * @property \Cake\ORM\Association\BelongsTo<\TestApp\Model\Table\CarsTable> $Cars
  */
 class WheelsExtraTable extends Table {
 

--- a/tests/test_files/Model/Table/WheelsTable.php
+++ b/tests/test_files/Model/Table/WheelsTable.php
@@ -5,7 +5,7 @@ use Cake\ORM\Table;
 
 /**
  * @method \TestApp\Model\Entity\Wheel newEntity(array $data, array $options = [])
- * @property \TestApp\Model\Table\CarsTable&\Cake\ORM\Association\BelongsTo $Cars
+ * @property \Cake\ORM\Association\BelongsTo<\TestApp\Model\Table\CarsTable> $Cars
  * @method \TestApp\Model\Entity\Wheel newEmptyEntity()
  * @method \TestApp\Model\Entity\Wheel[] newEntities(array $data, array $options = [])
  * @method \TestApp\Model\Entity\Wheel get(mixed $primaryKey, array|string $finder = 'all', \Psr\SimpleCache\CacheInterface|string|null $cache = null, \Closure|string|null $cacheKey = null, mixed ...$args)


### PR DESCRIPTION
Follow https://github.com/cakephp/cakephp/pull/17451

BUT
as discusses in https://github.com/CakeDC/cakephp-phpstan/issues/20#issuecomment-1828908282 this is not sth that should be enabled by default as it seems to currently kill (PHPStorm) IDE autocomplete.

We definitly need a feature flag to switch it on as opt-in:

    IdeHelper.assocsAsGeneric