### PR TITLE
Add better IDE autocomplete for event method stubs

### DIFF
--- a/config/app.example.php
+++ b/config/app.example.php
@@ -52,5 +52,6 @@ return [
 		],
 		// If a custom directory should be used, defaults to TMP otherwise
 		'codeCompletionPath' => null,
+		'codeCompletionReturnType' => null, // Auto-detect based on controller/component, set to true/false to force one mode.
 	],
 ];

--- a/src/CodeCompletion/Task/ControllerEventsTask.php
+++ b/src/CodeCompletion/Task/ControllerEventsTask.php
@@ -2,6 +2,8 @@
 
 namespace IdeHelper\CodeCompletion\Task;
 
+use Cake\Core\Configure;
+
 class ControllerEventsTask implements TaskInterface {
 
 	/**
@@ -20,26 +22,11 @@ class ControllerEventsTask implements TaskInterface {
 	 * @return string
 	 */
 	public function create(): string {
-		$events = <<<'TXT'
-		public function startup(EventInterface $event) {
-			return null;
-		}
-		public function beforeFilter(EventInterface $event) {
-			return null;
-		}
-		public function beforeRender(EventInterface $event) {
-			return null;
-		}
-		public function afterFilter(EventInterface $event) {
-			return null;
-		}
-		public function shutdown(EventInterface $event) {
-			return null;
-		}
-		public function beforeRedirect(EventInterface $event, $url, Response $response) {
-			return null;
-		}
-TXT;
+		/** @var bool|null $returnType */
+		$returnType = Configure::read('IdeHelper.codeCompletionReturnType');
+
+		$controllerEvents = $this->events($returnType ?? false);
+		$componentEvents = $this->events($returnType ?? true);
 
 		return <<<CODE
 
@@ -48,15 +35,60 @@ use Cake\Http\Response;
 
 if (false) {
 	class Controller {
-$events
+$controllerEvents
 	}
 
 	class Component {
-$events
+$componentEvents
 	}
 }
 
 CODE;
+	}
+
+	/**
+	 * @param bool $returnType
+	 *
+	 * @return string
+	 */
+	protected function events(bool $returnType): string {
+		$type = null;
+		$docBlock = null;
+		if ($returnType) {
+			$type = ': ' . '\Cake\Http\Response|null';
+		} else {
+			$docBlock = <<<TXT
+        /**
+         * @param \Cake\Event\EventInterface \$event
+         *
+         * @return \Cake\Http\Response|null|void
+         */
+TXT;
+			$docBlock = trim($docBlock) . PHP_EOL . str_repeat("\t", 2);
+		}
+
+		$events = <<<TXT
+		{$docBlock}public function startup(EventInterface \$event)$type {
+			return null;
+		}
+		{$docBlock}public function beforeFilter(EventInterface \$event)$type {
+			return null;
+		}
+		{$docBlock}public function beforeRender(EventInterface \$event)$type {
+			return null;
+		}
+		{$docBlock}public function afterFilter(EventInterface \$event)$type {
+			return null;
+		}
+		{$docBlock}public function shutdown(EventInterface \$event)$type {
+			return null;
+		}
+		{$docBlock}public function beforeRedirect(EventInterface \$event, \$url, Response \$response)$type {
+			return null;
+		}
+TXT;
+
+		return $events;
 	}
 
 }

--- a/tests/TestCase/CodeCompletion/Task/ControllerEventsTaskTest.php
+++ b/tests/TestCase/CodeCompletion/Task/ControllerEventsTaskTest.php
@@ -31,43 +31,73 @@ use Cake\Http\Response;
 
 if (false) {
 	class Controller {
+		/**
+         * @param \Cake\Event\EventInterface $event
+         *
+         * @return \Cake\Http\Response|null|void
+         */
 		public function startup(EventInterface $event) {
 			return null;
 		}
+		/**
+         * @param \Cake\Event\EventInterface $event
+         *
+         * @return \Cake\Http\Response|null|void
+         */
 		public function beforeFilter(EventInterface $event) {
 			return null;
 		}
+		/**
+         * @param \Cake\Event\EventInterface $event
+         *
+         * @return \Cake\Http\Response|null|void
+         */
 		public function beforeRender(EventInterface $event) {
 			return null;
 		}
+		/**
+         * @param \Cake\Event\EventInterface $event
+         *
+         * @return \Cake\Http\Response|null|void
+         */
 		public function afterFilter(EventInterface $event) {
 			return null;
 		}
+		/**
+         * @param \Cake\Event\EventInterface $event
+         *
+         * @return \Cake\Http\Response|null|void
+         */
 		public function shutdown(EventInterface $event) {
 			return null;
 		}
+		/**
+         * @param \Cake\Event\EventInterface $event
+         *
+         * @return \Cake\Http\Response|null|void
+         */
 		public function beforeRedirect(EventInterface $event, $url, Response $response) {
 			return null;
 		}
 	}
 
 	class Component {
-		public function startup(EventInterface $event) {
+		public function startup(EventInterface $event): \Cake\Http\Response|null {
 			return null;
 		}
-		public function beforeFilter(EventInterface $event) {
+		public function beforeFilter(EventInterface $event): \Cake\Http\Response|null {
 			return null;
 		}
-		public function beforeRender(EventInterface $event) {
+		public function beforeRender(EventInterface $event): \Cake\Http\Response|null {
 			return null;
 		}
-		public function afterFilter(EventInterface $event) {
+		public function afterFilter(EventInterface $event): \Cake\Http\Response|null {
 			return null;
 		}
-		public function shutdown(EventInterface $event) {
+		public function shutdown(EventInterface $event): \Cake\Http\Response|null {
 			return null;
 		}
-		public function beforeRedirect(EventInterface $event, $url, Response $response) {
+		public function beforeRedirect(EventInterface $event, $url, Response $response): \Cake\Http\Response|null {
 			return null;
 		}
 	}


### PR DESCRIPTION
Reverts https://github.com/dereuromark/cakephp-ide-helper/pull/308 with the option to either enable or disable types in favor of docblocks.

Components have return types by default as there is no controller code interferring
Components have docblocks by default unless told otherwise, as here the parent code can cause the issues described in the linked PR