### PR TITLE
Add support for multiline annotations

### DIFF
--- a/src/Annotator/AbstractAnnotator.php
+++ b/src/Annotator/AbstractAnnotator.php
@@ -495,6 +495,7 @@ abstract class AbstractAnnotator {
 					$valueNode = static::getValueNode($tokens[$i]['content'], $content);
 					if (!($valueNode instanceof InvalidTagValueNode)) {
 						$multilineFixed = true;
+
 						break;
 					}
 				}

--- a/src/Annotator/AbstractAnnotator.php
+++ b/src/Annotator/AbstractAnnotator.php
@@ -499,7 +499,7 @@ abstract class AbstractAnnotator {
 					}
 				}
 
-				if (!$multilineFixed) {
+				if (!$multilineFixed || $valueNode instanceof InvalidTagValueNode) {
 					continue;
 				}
 			}

--- a/src/Annotator/AbstractAnnotator.php
+++ b/src/Annotator/AbstractAnnotator.php
@@ -480,7 +480,28 @@ abstract class AbstractAnnotator {
 			/** @var \PHPStan\PhpDocParser\Ast\PhpDoc\InvalidTagValueNode|\PHPStan\PhpDocParser\Ast\PhpDoc\ReturnTagValueNode $valueNode */
 			$valueNode = static::getValueNode($tokens[$i]['content'], $content);
 			if ($valueNode instanceof InvalidTagValueNode) {
-				continue;
+				$multilineFixed = false;
+				for ($p = $i + 3; $p < $closeTagIndex; $p++) {
+					if ($tokens[$p]['type'] === 'T_DOC_COMMENT_TAG') {
+						break;
+					}
+
+					if ($tokens[$p]['type'] !== 'T_DOC_COMMENT_STRING') {
+						continue;
+					}
+
+					$content .= $tokens[$p]['content'];
+					/** @var \PHPStan\PhpDocParser\Ast\PhpDoc\InvalidTagValueNode|\PHPStan\PhpDocParser\Ast\PhpDoc\ReturnTagValueNode $valueNode */
+					$valueNode = static::getValueNode($tokens[$i]['content'], $content);
+					if (!($valueNode instanceof InvalidTagValueNode)) {
+						$multilineFixed = true;
+						break;
+					}
+				}
+
+				if (!$multilineFixed) {
+					continue;
+				}
 			}
 
 			$returnTypes = $this->valueNodeParts($valueNode);

--- a/tests/TestCase/Annotator/TemplateAnnotatorTest.php
+++ b/tests/TestCase/Annotator/TemplateAnnotatorTest.php
@@ -439,6 +439,33 @@ class TemplateAnnotatorTest extends TestCase {
 	}
 
 	/**
+	 * Tests that a multiline array is parsed completly.
+	 *
+	 * @return void
+	 */
+	public function testAnnotateWithMultilineArray() {
+		$annotator = $this->_getAnnotatorMock([]);
+
+		$expectedContent = str_replace("\r\n", "\n", file_get_contents(TEST_FILES . 'templates/multiline.php'));
+		$callback = function($value) use ($expectedContent) {
+			$value = str_replace(["\r\n", "\r"], "\n", $value);
+			if ($value !== $expectedContent) {
+				$this->_displayDiff($expectedContent, $value);
+			}
+
+			return $value === $expectedContent;
+		};
+		$annotator->expects($this->once())->method('storeFile')->with($this->anything(), $this->callback($callback));
+
+		$path = TEST_ROOT . 'templates/Foos/multiline.php';
+		$annotator->annotate($path);
+
+		$output = $this->out->output();
+
+		$this->assertTextContains('   -> 1 annotation added.', $output);
+	}
+
+	/**
 	 * @param array $params
 	 * @return \IdeHelper\Annotator\TemplateAnnotator|\PHPUnit\Framework\MockObject\MockObject
 	 */

--- a/tests/test_app/templates/Foos/multiline.php
+++ b/tests/test_app/templates/Foos/multiline.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * @var \TestApp\View\AppView $this
+ * @var array $x
+ * @var array<int> $ints
+ * @var array{
+ * 		a: int,
+ * 		b: string|null
+ * }|null $shaped
+ * @var array{
+ * 		c: array{
+ * 			d: int|string,
+ * 			e: string|null
+ * 		}
+ * } $nested
+ */
+	foreach ($x as $y) {
+		echo $y;
+	}
+	foreach ($foo as $int) {
+		echo $int;
+	}
+?>
+<div>
+	<?php foreach ($ints as $int) {
+		echo $int;
+	} ?>
+	<?php foreach ($shaped as $x) {
+		echo h($x);
+	} ?>
+	<?php foreach ($nested['c'] as $subArray) {
+		echo h($x);
+	} ?>
+</div>

--- a/tests/test_files/templates/multiline.php
+++ b/tests/test_files/templates/multiline.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * @var \TestApp\View\AppView $this
+ * @var array $x
+ * @var array<int> $ints
+ * @var array{
+ * 		a: int,
+ * 		b: string|null
+ * }|null $shaped
+ * @var array{
+ * 		c: array{
+ * 			d: int|string,
+ * 			e: string|null
+ * 		}
+ * } $nested
+ *
+ * @var mixed $foo
+ */
+	foreach ($x as $y) {
+		echo $y;
+	}
+	foreach ($foo as $int) {
+		echo $int;
+	}
+?>
+<div>
+	<?php foreach ($ints as $int) {
+		echo $int;
+	} ?>
+	<?php foreach ($shaped as $x) {
+		echo h($x);
+	} ?>
+	<?php foreach ($nested['c'] as $subArray) {
+		echo h($x);
+	} ?>
+</div>


### PR DESCRIPTION
I have 2 problems that i cannot get rid off

1st one is that after multiline annotation new line is added (when new one is added)

 * } $nested
 *
 * @var mixed $foo
 
 2nd one is that when i debuged generated annotation on end of that function, brackets dont look fine. (d: (int|string,)
 
```
 ROOT\src\Annotator\AbstractAnnotator.php (line 533)
########## DEBUG ##########
object(IdeHelper\Annotation\VariableAnnotation) id:0 {
  [protected] variable => '$nested'
  [protected] description => ''
  [protected] guessed => false
  [protected] type => 'array{c: array{d: (int|string, e: (string|null)}}'
  [protected] index => (int) 51
  [protected] isInUse => true
}
###########################
```

Can you please help me find out why are those error occuring?