### PR TITLE
Cleanup output.

### DIFF
--- a/src/Annotator/AbstractAnnotator.php
+++ b/src/Annotator/AbstractAnnotator.php
@@ -176,12 +176,12 @@ abstract class AbstractAnnotator {
 
 			if ($row[1] === 1) {
 				$char = '+';
-				$this->_io->info('   | ' . $char . $output, 1, ConsoleIo::VERBOSE);
+				$this->_io->info('   | ' . $char . $output);
 			} elseif ($row[1] === 2) {
 				$char = '-';
-				$this->_io->out('<warning>' . '   | ' . $char . $output . '</warning>', 1, ConsoleIo::VERBOSE);
+				$this->_io->out('<warning>' . '   | ' . $char . $output . '</warning>');
 			} else {
-				$this->_io->out('   | ' . $char . $output, 1, ConsoleIo::VERBOSE);
+				$this->_io->out('   | ' . $char . $output);
 			}
 		}
 	}
@@ -247,6 +247,10 @@ abstract class AbstractAnnotator {
 			$this->reportSkipped();
 
 			return false;
+		}
+
+		if (!$this->getConfig('verbose')) {
+			$this->_io->out('-> ' . str_replace(ROOT . DS, '', $path));
 		}
 
 		$this->displayDiff($content, $newContent);

--- a/src/Annotator/AbstractAnnotator.php
+++ b/src/Annotator/AbstractAnnotator.php
@@ -3,7 +3,6 @@
 namespace IdeHelper\Annotator;
 
 use Bake\View\Helper\DocBlockHelper;
-use Cake\Console\ConsoleIo;
 use Cake\Core\Configure;
 use Cake\Core\InstanceConfigTrait;
 use Cake\View\View;

--- a/src/Command/Annotate/CallbacksCommand.php
+++ b/src/Command/Annotate/CallbacksCommand.php
@@ -60,7 +60,7 @@ class CallbacksCommand extends AnnotateCommand {
 	 * @return void
 	 */
 	protected function _callbacks(string $folder) {
-		$this->io->out(str_replace(ROOT, '', $folder), 1, ConsoleIo::VERBOSE);
+		$this->io->out(str_replace(ROOT . DS, '', $folder), 1, ConsoleIo::VERBOSE);
 
 		$folderContent = glob($folder . '*') ?: [];
 		foreach ($folderContent as $path) {

--- a/src/Command/Annotate/ClassesCommand.php
+++ b/src/Command/Annotate/ClassesCommand.php
@@ -84,7 +84,7 @@ class ClassesCommand extends AnnotateCommand {
 	 * @return void
 	 */
 	protected function _classes(string $folder) {
-		$this->io->out(str_replace(ROOT, '', $folder), 1, ConsoleIo::VERBOSE);
+		$this->io->out(str_replace(ROOT . DS, '', $folder), 1, ConsoleIo::VERBOSE);
 
 		$folderContent = glob($folder . '*') ?: [];
 		foreach ($folderContent as $path) {

--- a/src/Command/Annotate/CommandsCommand.php
+++ b/src/Command/Annotate/CommandsCommand.php
@@ -45,7 +45,7 @@ class CommandsCommand extends AnnotateCommand {
 	 * @return void
 	 */
 	protected function _commands(string $folder) {
-		$this->io->out(str_replace(ROOT, '', $folder), 1, ConsoleIo::VERBOSE);
+		$this->io->out(str_replace(ROOT . DS, '', $folder), 1, ConsoleIo::VERBOSE);
 
 		$folderContent = glob($folder . '*') ?: [];
 		foreach ($folderContent as $path) {

--- a/src/Command/Annotate/ComponentsCommand.php
+++ b/src/Command/Annotate/ComponentsCommand.php
@@ -44,7 +44,7 @@ class ComponentsCommand extends AnnotateCommand {
 	 * @return void
 	 */
 	protected function _components(string $folder) {
-		$this->io->out(str_replace(ROOT, '', $folder), 1, ConsoleIo::VERBOSE);
+		$this->io->out(str_replace(ROOT . DS, '', $folder), 1, ConsoleIo::VERBOSE);
 
 		$folderContent = glob($folder . '*') ?: [];
 		foreach ($folderContent as $path) {

--- a/src/Command/Annotate/ControllersCommand.php
+++ b/src/Command/Annotate/ControllersCommand.php
@@ -46,7 +46,7 @@ class ControllersCommand extends AnnotateCommand {
 	 * @return void
 	 */
 	protected function _controllers(string $folder) {
-		$this->io->out(str_replace(ROOT, '', $folder), 1, ConsoleIo::VERBOSE);
+		$this->io->out(str_replace(ROOT . DS, '', $folder), 1, ConsoleIo::VERBOSE);
 
 		$folderContent = glob($folder . '*') ?: [];
 		foreach ($folderContent as $path) {

--- a/src/Command/Annotate/HelpersCommand.php
+++ b/src/Command/Annotate/HelpersCommand.php
@@ -44,7 +44,7 @@ class HelpersCommand extends AnnotateCommand {
 	 * @return void
 	 */
 	protected function _helpers($folder) {
-		$this->io->out(str_replace(ROOT, '', $folder), 1, ConsoleIo::VERBOSE);
+		$this->io->out(str_replace(ROOT . DS, '', $folder), 1, ConsoleIo::VERBOSE);
 
 		$folderContent = glob($folder . '*') ?: [];
 		foreach ($folderContent as $path) {

--- a/src/Command/Annotate/ModelsCommand.php
+++ b/src/Command/Annotate/ModelsCommand.php
@@ -44,7 +44,7 @@ class ModelsCommand extends AnnotateCommand {
 	 * @return void
 	 */
 	protected function _models(string $folder) {
-		$this->io->out(str_replace(ROOT, '', $folder), 1, ConsoleIo::VERBOSE);
+		$this->io->out(str_replace(ROOT . DS, '', $folder), 1, ConsoleIo::VERBOSE);
 
 		$folderContent = glob($folder . '*') ?: [];
 		foreach ($folderContent as $path) {

--- a/src/Command/Annotate/TemplatesCommand.php
+++ b/src/Command/Annotate/TemplatesCommand.php
@@ -45,7 +45,7 @@ class TemplatesCommand extends AnnotateCommand {
 	 * @return void
 	 */
 	protected function _templates($folder) {
-		$this->io->out(str_replace(ROOT, '', $folder), 1, ConsoleIo::VERBOSE);
+		$this->io->out(str_replace(ROOT . DS, '', $folder), 1, ConsoleIo::VERBOSE);
 
 		$folderContent = glob($folder . '*') ?: [];
 		foreach ($folderContent as $path) {
@@ -63,7 +63,7 @@ class TemplatesCommand extends AnnotateCommand {
 					}
 
 					if ($this->args->getOption('verbose')) {
-						$this->io->warning(sprintf('Skipped template folder `%s`', str_replace(ROOT, '', $subFolder)));
+						$this->io->warning(sprintf('Skipped template folder `%s`', str_replace(ROOT . DS, '', $subFolder)));
 					}
 
 					break;

--- a/src/Command/Annotate/ViewCommand.php
+++ b/src/Command/Annotate/ViewCommand.php
@@ -39,7 +39,7 @@ class ViewCommand extends AnnotateCommand {
 		}
 
 		$folder = pathinfo($file, PATHINFO_DIRNAME);
-		$io->out(str_replace(ROOT, '', $folder));
+		$io->out(str_replace(ROOT . DS, '', $folder));
 		$io->out(' -> ' . pathinfo($file, PATHINFO_BASENAME));
 
 		$annotator = $this->getAnnotator(ViewAnnotator::class);

--- a/tests/TestCase/Annotator/CallbackAnnotatorTask/VirtualFieldCallbackAnnotatorTaskTest.php
+++ b/tests/TestCase/Annotator/CallbackAnnotatorTask/VirtualFieldCallbackAnnotatorTaskTest.php
@@ -74,7 +74,7 @@ class VirtualFieldCallbackAnnotatorTaskTest extends TestCase {
 		$this->assertSame(3, $count, 'Count is ' . $count);
 
 		$output = $this->out->output();
-		$this->assertSame('', $output);
+		$this->assertTextContains('@see \TestApp\Model\Entity\Foo::$something', $output);
 	}
 
 	/**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the display of file and folder paths in console output by removing the root directory prefix along with the trailing directory separator, resulting in cleaner and more accurate relative paths.
  * In non-verbose mode, the relative file path is now shown before displaying diffs and storing files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->