### PR TITLE
Adjust to skip URLs in link annotations.

### DIFF
--- a/src/Annotation/LinkAnnotation.php
+++ b/src/Annotation/LinkAnnotation.php
@@ -23,6 +23,10 @@ class LinkAnnotation extends AbstractAnnotation {
 
 		parent::__construct($type, $index);
 
+		if (preg_match('/^(http|https):/', $type)) {
+			$this->isInUse = true;
+		}
+
 		$this->description = $description;
 	}
 

--- a/tests/test_app/src/View/AppView.php
+++ b/tests/test_app/src/View/AppView.php
@@ -3,5 +3,8 @@ namespace TestApp\View;
 
 use Cake\View\View;
 
+/**
+ * @link https://book.cakephp.org/5/en/views.html#the-app-view
+ */
 class AppView extends View {
 }

--- a/tests/test_files/View/AppView.php
+++ b/tests/test_files/View/AppView.php
@@ -4,6 +4,7 @@ namespace TestApp\View;
 use Cake\View\View;
 
 /**
+ * @link https://book.cakephp.org/5/en/views.html#the-app-view
  * @property \TestApp\View\Helper\HtmlHelper $Html
  * @property \TestApp\View\Helper\MyHelper $My
  * @property \Shim\View\Helper\ConfigureHelper $Configure


### PR DESCRIPTION
So -r doesnt remove them as unneeded.
Not everyone is using `@see` here

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of link annotations to better detect and mark HTTP/HTTPS links as in use.

* **Documentation**
  * Added and updated PHPDoc link annotations for improved reference and clarity in class documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->