### PR TITLE
Allow adding defaultTable for non existing models in controllers.

### DIFF
--- a/src/Illuminator/Task/ControllerDefaultTableTask.php
+++ b/src/Illuminator/Task/ControllerDefaultTableTask.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace IdeHelper\Illuminator\Task;
+
+use Cake\Core\Configure;
+use IdeHelper\Annotator\Traits\DocBlockTrait;
+use IdeHelper\Annotator\Traits\FileTrait;
+use PHP_CodeSniffer\Files\File;
+
+/**
+ * Adds $defaultTable = '' property to controllers that don't have a corresponding table class.
+ */
+class ControllerDefaultTableTask extends AbstractTask {
+
+	use FileTrait;
+	use DocBlockTrait;
+
+	/**
+	 * @param string $path
+	 * @return bool
+	 */
+	public function shouldRun(string $path): bool {
+		$className = pathinfo($path, PATHINFO_FILENAME);
+		if (!str_ends_with($className, 'Controller')) {
+			return false;
+		}
+
+		if ($className === 'AppController' || preg_match('#[a-z0-9]AppController$#', $className)) {
+			return false;
+		}
+
+		if (!str_contains($path, DS . 'Controller' . DS)) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * @param string $content
+	 * @param string $path Path to file.
+	 * @return string
+	 */
+	public function run(string $content, string $path): string {
+		if (preg_match('/\bprotected \?string \$defaultTable\b/', $content)) {
+			return $content;
+		}
+
+		$className = pathinfo($path, PATHINFO_FILENAME);
+		$namespace = $this->extractNamespace($content);
+		if (!$namespace) {
+			return $content;
+		}
+
+		$baseNamespace = $this->detectPluginFromNamespace($namespace);
+
+		$modelName = substr($className, 0, -10);
+		$modelClassName = str_replace('/', '\\', $baseNamespace) . '\\Model\\Table\\' . $modelName . 'Table';
+
+		if (class_exists($modelClassName)) {
+			return $content;
+		}
+
+		$file = $this->getFile('', $content);
+		$classIndex = $file->findNext(T_CLASS, 0);
+		if (!$classIndex) {
+			return $content;
+		}
+
+		return $this->addDefaultTableProperty($file, $classIndex, $content);
+	}
+
+	/**
+	 * @param \PHP_CodeSniffer\Files\File $file
+	 * @param int $classIndex
+	 * @param string $content
+	 * @return string
+	 */
+	protected function addDefaultTableProperty(File $file, int $classIndex, string $content): string {
+		$tokens = $file->getTokens();
+
+		$openBraceIndex = $tokens[$classIndex]['scope_opener'];
+		$closeBraceIndex = $tokens[$classIndex]['scope_closer'];
+		if (!$openBraceIndex || !$closeBraceIndex) {
+			return $content;
+		}
+
+		$indentation = Configure::read('IdeHelper.illuminatorIndentation') ?? "\t";
+
+		$fixer = $this->getFixer($file);
+
+		$property = PHP_EOL . PHP_EOL . $indentation . 'protected ?string $defaultTable = \'\';';
+
+		$fixer->addContent($openBraceIndex, $property);
+
+		return $fixer->getContents();
+	}
+
+	/**
+	 * @param \PHP_CodeSniffer\Files\File $file
+	 * @param int $index
+	 * @return string
+	 */
+	protected function detectIndentation(File $file, int $index): string {
+		$tokens = $file->getTokens();
+
+		$line = $tokens[$index]['line'];
+		$firstOfLine = $index;
+		while ($firstOfLine - 1 >= 0 && $tokens[$firstOfLine - 1]['line'] === $line) {
+			$firstOfLine--;
+		}
+
+		$whitespace = '';
+		for ($i = $firstOfLine; $i < $index; $i++) {
+			if ($tokens[$i]['code'] === T_WHITESPACE) {
+				$whitespace .= $tokens[$i]['content'];
+			}
+		}
+
+		return $whitespace;
+	}
+
+	/**
+	 * @param string $content
+	 * @return string|null
+	 */
+	protected function extractNamespace(string $content): ?string {
+		if (preg_match('/^namespace\s+([^;]+);/m', $content, $matches)) {
+			return $matches[1];
+		}
+
+		return null;
+	}
+
+	/**
+	 * @param string $namespace
+	 * @return string
+	 */
+	protected function detectPluginFromNamespace(string $namespace): string {
+		$plugin = $this->getConfig(static::CONFIG_PLUGIN);
+		if ($plugin) {
+			return $plugin;
+		}
+
+		$parts = explode('\\', $namespace);
+		if (count($parts) >= 2 && $parts[1] === 'Controller') {
+			return $parts[0];
+		}
+
+		return Configure::read('App.namespace', 'App');
+	}
+
+}

--- a/src/Illuminator/TaskCollection.php
+++ b/src/Illuminator/TaskCollection.php
@@ -6,6 +6,7 @@ use Cake\Console\ConsoleIo;
 use Cake\Core\Configure;
 use IdeHelper\Console\Io;
 use IdeHelper\Illuminator\Task\AbstractTask;
+use IdeHelper\Illuminator\Task\ControllerDefaultTableTask;
 use IdeHelper\Illuminator\Task\EntityFieldTask;
 use InvalidArgumentException;
 use RuntimeException;
@@ -30,6 +31,7 @@ class TaskCollection {
 	 * @var array<class-string<\IdeHelper\Illuminator\Task\AbstractTask>, class-string<\IdeHelper\Illuminator\Task\AbstractTask>>
 	 */
 	protected array $defaultTasks = [
+		ControllerDefaultTableTask::class => ControllerDefaultTableTask::class,
 		EntityFieldTask::class => EntityFieldTask::class,
 	];
 

--- a/tests/TestCase/Illuminator/Task/ControllerDefaultTableTaskTest.php
+++ b/tests/TestCase/Illuminator/Task/ControllerDefaultTableTaskTest.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace IdeHelper\Test\TestCase\Illuminator\Task;
+
+use Cake\Console\ConsoleIo;
+use Cake\TestSuite\TestCase;
+use IdeHelper\Annotator\AbstractAnnotator;
+use IdeHelper\Console\Io;
+use IdeHelper\Illuminator\Task\ControllerDefaultTableTask;
+use Shim\TestSuite\ConsoleOutput;
+
+class ControllerDefaultTableTaskTest extends TestCase {
+
+	protected ConsoleOutput $out;
+
+	protected ConsoleOutput $err;
+
+	protected Io $io;
+
+	/**
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->out = new ConsoleOutput();
+		$this->err = new ConsoleOutput();
+		$consoleIo = new ConsoleIo($this->out, $this->err);
+		$this->io = new Io($consoleIo);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testShouldRun() {
+		$task = $this->_getTask();
+
+		$result = $task->shouldRun('src/Controller/NoTableController.php');
+		$this->assertTrue($result);
+
+		$result = $task->shouldRun('src/Controller/AppController.php');
+		$this->assertFalse($result);
+
+		$result = $task->shouldRun('src/Model/Table/Wheels.php');
+		$this->assertFalse($result);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testRunWithExistingTable() {
+		$task = $this->_getTask();
+
+		$path = APP . 'Controller/FoosController.php';
+		$this->assertFileExists($path);
+
+		$content = file_get_contents($path);
+		$result = $task->run($content, $path);
+
+		// Should not add defaultTable if table exists
+		$this->assertSame($content, $result);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testRunWithoutTable() {
+		$task = $this->_getTask();
+
+		$content = <<<'PHP'
+<?php
+namespace App\Controller;
+
+use Cake\Controller\Controller;
+
+class NoTableController extends Controller {
+}
+
+PHP;
+
+		$expected = <<<'PHP'
+<?php
+namespace App\Controller;
+
+use Cake\Controller\Controller;
+
+class NoTableController extends Controller {
+
+	protected ?string $defaultTable = '';
+}
+
+PHP;
+
+		$path = 'src/Controller/NoTableController.php';
+		$result = $task->run($content, $path);
+
+		$this->assertTextEquals($expected, $result);
+		$this->assertStringContainsString("protected ?string \$defaultTable = '';", $result);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testRunWithExistingProperty() {
+		$task = $this->_getTask();
+
+		$content = <<<'PHP'
+<?php
+namespace App\Controller;
+
+use Cake\Controller\Controller;
+
+class CustomController extends Controller {
+
+	protected ?string $defaultTable = 'CustomTable';
+}
+
+PHP;
+
+		$path = 'src/Controller/CustomController.php';
+		$result = $task->run($content, $path);
+
+		// Should not add if property already exists
+		$this->assertSame($content, $result);
+	}
+
+	/**
+	 * @param array $params
+	 * @return \IdeHelper\Illuminator\Task\ControllerDefaultTableTask
+	 */
+	protected function _getTask(array $params = []) {
+		$params += [
+			AbstractAnnotator::CONFIG_DRY_RUN => true,
+			AbstractAnnotator::CONFIG_VERBOSE => true,
+		];
+
+		return new ControllerDefaultTableTask($params);
+	}
+
+}


### PR DESCRIPTION
Refs https://github.com/dereuromark/cakephp-captcha/issues/47

```
 bin/cake illuminate src/Controller --task ControllerDefaultTable
 ```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Automatically inserts a default table property into controllers when no corresponding model table exists.
  - Included in the default task set, running out of the box.
  - Skips files where the property already exists or a matching model is found.
  - Respects project indentation and handles namespace/plugin detection.

- Tests
  - Added comprehensive tests covering path filtering, no-op scenarios, and property insertion behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->