### PR TITLE
Fix type hinting in beforeRedirect()

### DIFF
--- a/src/CodeCompletion/Task/ControllerEventsTask.php
+++ b/src/CodeCompletion/Task/ControllerEventsTask.php
@@ -32,6 +32,7 @@ class ControllerEventsTask implements TaskInterface {
 
 use Cake\Event\EventInterface;
 use Cake\Http\Response;
+use Psr\Http\Message\UriInterface;
 
 if (false) {
 	class Controller {
@@ -69,7 +70,7 @@ TXT;
 		$docBlockRedirect = <<<TXT
 		/**
 		 * @param \Cake\Event\EventInterface \$event
-		 * @param array|string \$url
+		 * @param \Psr\Http\Message\UriInterface|array|string \$url
 		 * @param \Cake\Http\Response \$response
 		 *
 		 * @return void
@@ -93,7 +94,7 @@ TXT;
 		{$docBlock}public function shutdown(EventInterface \$event)$type {
 		}
 
-		{$docBlockRedirect}public function beforeRedirect(EventInterface \$event, \$url, Response \$response)$type {
+		{$docBlockRedirect}public function beforeRedirect(EventInterface \$event, UriInterface|array|string \$url, Response \$response)$type {
 		}
 TXT;
 

--- a/tests/TestCase/CodeCompletion/Task/ControllerEventsTaskTest.php
+++ b/tests/TestCase/CodeCompletion/Task/ControllerEventsTaskTest.php
@@ -31,6 +31,7 @@ class ControllerEventsTaskTest extends TestCase {
 
 use Cake\Event\EventInterface;
 use Cake\Http\Response;
+use Psr\Http\Message\UriInterface;
 
 if (false) {
 	class Controller {
@@ -76,12 +77,12 @@ if (false) {
 
 		/**
 		 * @param \Cake\Event\EventInterface $event
-		 * @param array|string $url
+		 * @param \Psr\Http\Message\UriInterface|array|string $url
 		 * @param \Cake\Http\Response $response
 		 *
 		 * @return void
 		 */
-		public function beforeRedirect(EventInterface $event, $url, Response $response) {
+		public function beforeRedirect(EventInterface $event, UriInterface|array|string $url, Response $response) {
 		}
 	}
 
@@ -128,12 +129,12 @@ if (false) {
 
 		/**
 		 * @param \Cake\Event\EventInterface $event
-		 * @param array|string $url
+		 * @param \Psr\Http\Message\UriInterface|array|string $url
 		 * @param \Cake\Http\Response $response
 		 *
 		 * @return void
 		 */
-		public function beforeRedirect(EventInterface $event, $url, Response $response) {
+		public function beforeRedirect(EventInterface $event, UriInterface|array|string $url, Response $response) {
 		}
 	}
 }
@@ -154,6 +155,7 @@ TXT;
 
 use Cake\Event\EventInterface;
 use Cake\Http\Response;
+use Psr\Http\Message\UriInterface;
 
 if (false) {
 	class Controller {
@@ -174,12 +176,12 @@ if (false) {
 
 		/**
 		 * @param \Cake\Event\EventInterface $event
-		 * @param array|string $url
+		 * @param \Psr\Http\Message\UriInterface|array|string $url
 		 * @param \Cake\Http\Response $response
 		 *
 		 * @return void
 		 */
-		public function beforeRedirect(EventInterface $event, $url, Response $response): void {
+		public function beforeRedirect(EventInterface $event, UriInterface|array|string $url, Response $response): void {
 		}
 	}
 
@@ -201,12 +203,12 @@ if (false) {
 
 		/**
 		 * @param \Cake\Event\EventInterface $event
-		 * @param array|string $url
+		 * @param \Psr\Http\Message\UriInterface|array|string $url
 		 * @param \Cake\Http\Response $response
 		 *
 		 * @return void
 		 */
-		public function beforeRedirect(EventInterface $event, $url, Response $response): void {
+		public function beforeRedirect(EventInterface $event, UriInterface|array|string $url, Response $response): void {
 		}
 	}
 }


### PR DESCRIPTION
Maybe there's a reason for not adding type hinting here but if its an oversight, then go ahead an merge this :-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Strengthened type declarations for redirect event handlers to include URI objects alongside arrays and strings.

* **Tests**
  * Updated test cases to reflect the new union type for redirect parameters and ensure consistent event handling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->