### PR TITLE
Update finder return type from Query to SelectQuery

### DIFF
--- a/src/Generator/Task/TableFinderTask.php
+++ b/src/Generator/Task/TableFinderTask.php
@@ -4,7 +4,6 @@ namespace IdeHelper\Generator\Task;
 
 use Cake\Datasource\QueryInterface;
 use Cake\ORM\Association;
-use Cake\ORM\Query;
 use Cake\ORM\Query\SelectQuery;
 use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
@@ -36,7 +35,7 @@ class TableFinderTask extends ModelTask {
 	/**
 	 * @var string
 	 */
-	public const CLASS_QUERY = Query::class;
+	public const CLASS_QUERY = SelectQuery::class;
 
 	/**
 	 * @var array<string>

--- a/tests/TestCase/Generator/Task/TableFinderTaskTest.php
+++ b/tests/TestCase/Generator/Task/TableFinderTaskTest.php
@@ -52,13 +52,13 @@ class TableFinderTaskTest extends TestCase {
 		}, $map);
 
 		$expectedMap = [
-			'all' => '\Cake\ORM\Query::class',
-			'children' => '\Cake\ORM\Query::class',
-			'list' => '\Cake\ORM\Query::class',
-			'path' => '\Cake\ORM\Query::class',
-			'somethingCustom' => '\Cake\ORM\Query::class',
-			'threaded' => '\Cake\ORM\Query::class',
-			'treeList' => '\Cake\ORM\Query::class',
+			'all' => '\Cake\ORM\Query\SelectQuery::class',
+			'children' => '\Cake\ORM\Query\SelectQuery::class',
+			'list' => '\Cake\ORM\Query\SelectQuery::class',
+			'path' => '\Cake\ORM\Query\SelectQuery::class',
+			'somethingCustom' => '\Cake\ORM\Query\SelectQuery::class',
+			'threaded' => '\Cake\ORM\Query\SelectQuery::class',
+			'treeList' => '\Cake\ORM\Query\SelectQuery::class',
 		];
 		$this->assertSame($expectedMap, $map);
 	}

--- a/tests/test_files/meta/phpstorm/.meta.php
+++ b/tests/test_files/meta/phpstorm/.meta.php
@@ -253,13 +253,13 @@ namespace PHPSTORM_META {
 	override(
 		\Cake\Datasource\QueryInterface::find(0),
 		map([
-			'all' => \Cake\ORM\Query::class,
-			'children' => \Cake\ORM\Query::class,
-			'list' => \Cake\ORM\Query::class,
-			'path' => \Cake\ORM\Query::class,
-			'somethingCustom' => \Cake\ORM\Query::class,
-			'threaded' => \Cake\ORM\Query::class,
-			'treeList' => \Cake\ORM\Query::class,
+			'all' => \Cake\ORM\Query\SelectQuery::class,
+			'children' => \Cake\ORM\Query\SelectQuery::class,
+			'list' => \Cake\ORM\Query\SelectQuery::class,
+			'path' => \Cake\ORM\Query\SelectQuery::class,
+			'somethingCustom' => \Cake\ORM\Query\SelectQuery::class,
+			'threaded' => \Cake\ORM\Query\SelectQuery::class,
+			'treeList' => \Cake\ORM\Query\SelectQuery::class,
 		]),
 	);
 
@@ -302,13 +302,13 @@ namespace PHPSTORM_META {
 	override(
 		\Cake\ORM\Association::find(0),
 		map([
-			'all' => \Cake\ORM\Query::class,
-			'children' => \Cake\ORM\Query::class,
-			'list' => \Cake\ORM\Query::class,
-			'path' => \Cake\ORM\Query::class,
-			'somethingCustom' => \Cake\ORM\Query::class,
-			'threaded' => \Cake\ORM\Query::class,
-			'treeList' => \Cake\ORM\Query::class,
+			'all' => \Cake\ORM\Query\SelectQuery::class,
+			'children' => \Cake\ORM\Query\SelectQuery::class,
+			'list' => \Cake\ORM\Query\SelectQuery::class,
+			'path' => \Cake\ORM\Query\SelectQuery::class,
+			'somethingCustom' => \Cake\ORM\Query\SelectQuery::class,
+			'threaded' => \Cake\ORM\Query\SelectQuery::class,
+			'treeList' => \Cake\ORM\Query\SelectQuery::class,
 		]),
 	);
 
@@ -482,13 +482,13 @@ namespace PHPSTORM_META {
 	override(
 		\Cake\ORM\Table::find(0),
 		map([
-			'all' => \Cake\ORM\Query::class,
-			'children' => \Cake\ORM\Query::class,
-			'list' => \Cake\ORM\Query::class,
-			'path' => \Cake\ORM\Query::class,
-			'somethingCustom' => \Cake\ORM\Query::class,
-			'threaded' => \Cake\ORM\Query::class,
-			'treeList' => \Cake\ORM\Query::class,
+			'all' => \Cake\ORM\Query\SelectQuery::class,
+			'children' => \Cake\ORM\Query\SelectQuery::class,
+			'list' => \Cake\ORM\Query\SelectQuery::class,
+			'path' => \Cake\ORM\Query\SelectQuery::class,
+			'somethingCustom' => \Cake\ORM\Query\SelectQuery::class,
+			'threaded' => \Cake\ORM\Query\SelectQuery::class,
+			'treeList' => \Cake\ORM\Query\SelectQuery::class,
 		]),
 	);
 

--- a/tests/test_files/meta/phpstorm/.meta_lowest.php
+++ b/tests/test_files/meta/phpstorm/.meta_lowest.php
@@ -251,13 +251,13 @@ namespace PHPSTORM_META {
 	override(
 		\Cake\Datasource\QueryInterface::find(0),
 		map([
-			'all' => \Cake\ORM\Query::class,
-			'children' => \Cake\ORM\Query::class,
-			'list' => \Cake\ORM\Query::class,
-			'path' => \Cake\ORM\Query::class,
-			'somethingCustom' => \Cake\ORM\Query::class,
-			'threaded' => \Cake\ORM\Query::class,
-			'treeList' => \Cake\ORM\Query::class,
+			'all' => \Cake\ORM\Query\SelectQuery::class,
+			'children' => \Cake\ORM\Query\SelectQuery::class,
+			'list' => \Cake\ORM\Query\SelectQuery::class,
+			'path' => \Cake\ORM\Query\SelectQuery::class,
+			'somethingCustom' => \Cake\ORM\Query\SelectQuery::class,
+			'threaded' => \Cake\ORM\Query\SelectQuery::class,
+			'treeList' => \Cake\ORM\Query\SelectQuery::class,
 		]),
 	);
 
@@ -300,13 +300,13 @@ namespace PHPSTORM_META {
 	override(
 		\Cake\ORM\Association::find(0),
 		map([
-			'all' => \Cake\ORM\Query::class,
-			'children' => \Cake\ORM\Query::class,
-			'list' => \Cake\ORM\Query::class,
-			'path' => \Cake\ORM\Query::class,
-			'somethingCustom' => \Cake\ORM\Query::class,
-			'threaded' => \Cake\ORM\Query::class,
-			'treeList' => \Cake\ORM\Query::class,
+			'all' => \Cake\ORM\Query\SelectQuery::class,
+			'children' => \Cake\ORM\Query\SelectQuery::class,
+			'list' => \Cake\ORM\Query\SelectQuery::class,
+			'path' => \Cake\ORM\Query\SelectQuery::class,
+			'somethingCustom' => \Cake\ORM\Query\SelectQuery::class,
+			'threaded' => \Cake\ORM\Query\SelectQuery::class,
+			'treeList' => \Cake\ORM\Query\SelectQuery::class,
 		]),
 	);
 
@@ -480,13 +480,13 @@ namespace PHPSTORM_META {
 	override(
 		\Cake\ORM\Table::find(0),
 		map([
-			'all' => \Cake\ORM\Query::class,
-			'children' => \Cake\ORM\Query::class,
-			'list' => \Cake\ORM\Query::class,
-			'path' => \Cake\ORM\Query::class,
-			'somethingCustom' => \Cake\ORM\Query::class,
-			'threaded' => \Cake\ORM\Query::class,
-			'treeList' => \Cake\ORM\Query::class,
+			'all' => \Cake\ORM\Query\SelectQuery::class,
+			'children' => \Cake\ORM\Query\SelectQuery::class,
+			'list' => \Cake\ORM\Query\SelectQuery::class,
+			'path' => \Cake\ORM\Query\SelectQuery::class,
+			'somethingCustom' => \Cake\ORM\Query\SelectQuery::class,
+			'threaded' => \Cake\ORM\Query\SelectQuery::class,
+			'treeList' => \Cake\ORM\Query\SelectQuery::class,
 		]),
 	);
 


### PR DESCRIPTION
## Summary
- Updated finder method return type annotations from `\Cake\ORM\Query` to `\Cake\ORM\Query\SelectQuery`
- Updated `TableFinderTask::CLASS_QUERY` constant to use `SelectQuery::class`
- Removed unused `Query` import from TableFinderTask
- Updated all test expectations and fixture files to reflect the new type

## Changes
This PR updates the type override mappings for finder methods across:
- `\Cake\ORM\Table::find()`
- `\Cake\ORM\Association::find()`
- `\Cake\Datasource\QueryInterface::find()`

All finder methods ('all', 'children', 'list', 'path', 'threaded', 'treeList', and custom finders) now correctly reference `SelectQuery` instead of the deprecated `Query` class.

## Test Plan
- All 250 tests pass successfully
- Coding standards verified with phpcs
- Test fixtures updated to match new expectations

Fixes #400

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated query type references throughout the system for improved type accuracy.
  * Enhanced type mapping for finder methods to align with more specific class definitions, improving IDE support and static analysis compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->