### PR TITLE
Fix CakePHP 5.3 deprecation

### DIFF
--- a/src/CodeCompletion/CodeCompletionGenerator.php
+++ b/src/CodeCompletion/CodeCompletionGenerator.php
@@ -19,7 +19,13 @@ class CodeCompletionGenerator {
 	 * @return array<string>
 	 */
 	public function generate(): array {
-		$map = $this->taskCollection->getMapped();
+		if (method_exists($this->taskCollection, 'getMapped')) {
+			$map = $this->taskCollection->getMapped();
+		} else {
+			// @codeCoverageIgnoreStart
+			$map = $this->taskCollection->getMap();
+			// @codeCoverageIgnoreEnd
+		}
 
 		foreach ($map as $namespace => $array) {
 			$content = $this->buildContent($array);

--- a/src/Generator/PhpstormGenerator.php
+++ b/src/Generator/PhpstormGenerator.php
@@ -24,7 +24,13 @@ class PhpstormGenerator implements GeneratorInterface {
 	 * @return string
 	 */
 	public function generate(): string {
-		$map = $this->taskCollection->getMapped();
+		if (method_exists($this->taskCollection, 'getMapped')) {
+			$map = $this->taskCollection->getMapped();
+		} else {
+			// @codeCoverageIgnoreStart
+			$map = $this->taskCollection->getMap();
+			// @codeCoverageIgnoreEnd
+		}
 
 		$this->outputSetInfo($map);
 


### PR DESCRIPTION
## Summary
- Replace deprecated `getMap()` with `getMapped()`

## Details
The `getMap()` method was deprecated in CakePHP 5.3 in favor of `getMapped()` and will be removed in CakePHP 6.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal data-mapping retrieval so the system more reliably selects the preferred mapping method, preserving existing behavior while enhancing maintainability and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->