### PR TITLE
Add TableValidationLinkTask to link table validation methods

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,7 @@
 		"php": ">=8.1",
 		"cakephp/bake": "^3.0.4",
 		"cakephp/cakephp": "^5.1.5",
+		"nikic/php-parser": "^5.0",
 		"phpstan/phpdoc-parser": "^2.1.0",
 		"sebastian/diff": "^5.0 || ^6.0 || ^7.0",
 		"squizlabs/php_codesniffer": "^3.13 || ^4.0"

--- a/src/Illuminator/Task/TableValidationLinkTask.php
+++ b/src/Illuminator/Task/TableValidationLinkTask.php
@@ -1,0 +1,230 @@
+<?php
+
+namespace IdeHelper\Illuminator\Task;
+
+use PhpParser\Node;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitorAbstract;
+use PhpParser\ParserFactory;
+
+/**
+ * Adds @link annotations above validator->add() calls that reference table provider methods.
+ *
+ * When validation rules use 'provider' => 'table' with a method reference,
+ * this task adds a @link annotation to help IDEs recognize the method usage.
+ */
+class TableValidationLinkTask extends AbstractTask {
+
+	/**
+	 * @param string $path
+	 * @return bool
+	 */
+	public function shouldRun(string $path): bool {
+		$className = pathinfo($path, PATHINFO_FILENAME);
+
+		return $className !== 'Table' && str_ends_with($className, 'Table');
+	}
+
+	/**
+	 * @param string $content
+	 * @param string $path Path to file.
+	 * @return string
+	 */
+	public function run(string $content, string $path): string {
+		$links = $this->findTableProviderMethods($content);
+		if (!$links) {
+			return $content;
+		}
+
+		return $this->insertLinkAnnotations($content, $links);
+	}
+
+	/**
+	 * Find all ->add() calls with 'provider' => 'table' and extract the method names.
+	 *
+	 * @param string $content
+	 * @return array<int, string> Map of line number => method name
+	 */
+	protected function findTableProviderMethods(string $content): array {
+		$parser = (new ParserFactory())->createForNewestSupportedVersion();
+
+		try {
+			$ast = $parser->parse($content);
+		} catch (\Throwable $e) {
+			return [];
+		}
+
+		if ($ast === null) {
+			return [];
+		}
+
+		$visitor = new class extends NodeVisitorAbstract {
+			/**
+			 * @var array<int, string>
+			 */
+			public array $links = [];
+
+			/**
+			 * @param \PhpParser\Node $node
+			 * @return int|null
+			 */
+			public function enterNode(Node $node): ?int {
+				if (!$node instanceof Node\Expr\MethodCall) {
+					return null;
+				}
+
+				if (!$node->name instanceof Node\Identifier || $node->name->name !== 'add') {
+					return null;
+				}
+
+				// Need at least 3 arguments: field, ruleName, options array
+				if (count($node->args) < 3) {
+					return null;
+				}
+
+				$optionsArg = $node->args[2];
+				if (!$optionsArg instanceof Node\Arg) {
+					return null;
+				}
+
+				$options = $optionsArg->value;
+				if (!$options instanceof Node\Expr\Array_) {
+					return null;
+				}
+
+				$methodName = $this->extractTableProviderMethod($options);
+				if ($methodName !== null) {
+					$this->links[$node->getStartLine()] = $methodName;
+				}
+
+				return null;
+			}
+
+			/**
+			 * @param \PhpParser\Node\Expr\Array_ $options
+			 * @return string|null
+			 */
+			protected function extractTableProviderMethod(Node\Expr\Array_ $options): ?string {
+				$hasTableProvider = false;
+				$methodName = null;
+
+				foreach ($options->items as $item) {
+					if (!$item instanceof Node\Expr\ArrayItem || $item->key === null) {
+						continue;
+					}
+
+					$key = $this->getStringValue($item->key);
+					if ($key === null) {
+						continue;
+					}
+
+					if ($key === 'provider') {
+						$value = $this->getStringValue($item->value);
+						if ($value === 'table') {
+							$hasTableProvider = true;
+						}
+					}
+
+					if ($key === 'rule') {
+						$methodName = $this->extractMethodFromRule($item->value);
+					}
+				}
+
+				if ($hasTableProvider && $methodName !== null) {
+					return $methodName;
+				}
+
+				return null;
+			}
+
+			/**
+			 * @param \PhpParser\Node\Expr $value
+			 * @return string|null
+			 */
+			protected function extractMethodFromRule(Node\Expr $value): ?string {
+				// 'rule' => 'methodName'
+				$stringValue = $this->getStringValue($value);
+				if ($stringValue !== null) {
+					return $stringValue;
+				}
+
+				// 'rule' => ['methodName', 'arg1', ...]
+				if ($value instanceof Node\Expr\Array_ && count($value->items) > 0) {
+					$firstItem = $value->items[0];
+					if ($firstItem instanceof Node\Expr\ArrayItem) {
+						return $this->getStringValue($firstItem->value);
+					}
+				}
+
+				return null;
+			}
+
+			/**
+			 * @param \PhpParser\Node\Expr $expr
+			 * @return string|null
+			 */
+			protected function getStringValue(Node\Expr $expr): ?string {
+				if ($expr instanceof Node\Scalar\String_) {
+					return $expr->value;
+				}
+
+				return null;
+			}
+		};
+
+		$traverser = new NodeTraverser();
+		$traverser->addVisitor($visitor);
+		$traverser->traverse($ast);
+
+		return $visitor->links;
+	}
+
+	/**
+	 * Insert @link annotations above the specified lines.
+	 *
+	 * @param string $content
+	 * @param array<int, string> $links Map of line number => method name
+	 * @return string
+	 */
+	protected function insertLinkAnnotations(string $content, array $links): string {
+		$lines = explode("\n", $content);
+
+		// Sort by line number descending to avoid offset issues when inserting
+		krsort($links);
+
+		foreach ($links as $lineNumber => $methodName) {
+			$index = $lineNumber - 1; // Convert to 0-based index
+			if (!isset($lines[$index])) {
+				continue;
+			}
+
+			// Check if there's already a @link annotation for this method
+			if ($index > 0 && $this->hasLinkAnnotation($lines[$index - 1], $methodName)) {
+				continue;
+			}
+
+			// Get the indentation of the target line
+			$targetLine = $lines[$index];
+			preg_match('/^(\s*)/', $targetLine, $matches);
+			$indent = $matches[1] ?? '';
+
+			// Insert the @link annotation
+			$annotation = $indent . '/** @link ' . $methodName . '() */';
+			array_splice($lines, $index, 0, [$annotation]);
+		}
+
+		return implode("\n", $lines);
+	}
+
+	/**
+	 * Check if a line already contains a @link annotation for the given method.
+	 *
+	 * @param string $line
+	 * @param string $methodName
+	 * @return bool
+	 */
+	protected function hasLinkAnnotation(string $line, string $methodName): bool {
+		return str_contains($line, '@link') && str_contains($line, $methodName);
+	}
+
+}

--- a/src/Illuminator/TaskCollection.php
+++ b/src/Illuminator/TaskCollection.php
@@ -8,6 +8,7 @@ use IdeHelper\Console\Io;
 use IdeHelper\Illuminator\Task\AbstractTask;
 use IdeHelper\Illuminator\Task\ControllerDefaultTableTask;
 use IdeHelper\Illuminator\Task\EntityFieldTask;
+use IdeHelper\Illuminator\Task\TableValidationLinkTask;
 use InvalidArgumentException;
 use RuntimeException;
 use SebastianBergmann\Diff\Differ;
@@ -33,6 +34,7 @@ class TaskCollection {
 	protected array $defaultTasks = [
 		ControllerDefaultTableTask::class => ControllerDefaultTableTask::class,
 		EntityFieldTask::class => EntityFieldTask::class,
+		TableValidationLinkTask::class => TableValidationLinkTask::class,
 	];
 
 	/**

--- a/tests/TestCase/Illuminator/IlluminatorTest.php
+++ b/tests/TestCase/Illuminator/IlluminatorTest.php
@@ -43,7 +43,7 @@ class IlluminatorTest extends TestCase {
 		$path = TEST_FILES;
 		$count = $this->illuminator->illuminate($path, null);
 
-		$this->assertSame(13, $count);
+		$this->assertSame(14, $count);
 
 		$out = $this->out->output();
 

--- a/tests/TestCase/Illuminator/Task/TableValidationLinkTaskTest.php
+++ b/tests/TestCase/Illuminator/Task/TableValidationLinkTaskTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace IdeHelper\Test\TestCase\Illuminator\Task;
+
+use Cake\TestSuite\TestCase;
+use IdeHelper\Annotator\AbstractAnnotator;
+use IdeHelper\Illuminator\Task\TableValidationLinkTask;
+
+class TableValidationLinkTaskTest extends TestCase {
+
+	/**
+	 * @return void
+	 */
+	public function testShouldRun(): void {
+		$task = $this->getTask();
+
+		$result = $task->shouldRun('src/Model/Table/WheelsTable.php');
+		$this->assertTrue($result);
+
+		$result = $task->shouldRun('src/Model/Table/Table.php');
+		$this->assertFalse($result);
+
+		$result = $task->shouldRun('src/Model/Entity/Wheel.php');
+		$this->assertFalse($result);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testRun(): void {
+		$task = $this->getTask();
+
+		$path = TEST_FILES . 'Model/Table/Validation/IpRulesTable.php';
+		$content = file_get_contents($path);
+		$this->assertIsString($content);
+
+		$result = $task->run($content, $path);
+
+		$this->assertStringContainsString('/** @link verifyIpRanges() */', $result);
+		$this->assertStringContainsString('/** @link verifyDenyRanges() */', $result);
+
+		$result = str_replace('    ', "\t", $result);
+		$expected = file_get_contents(TEST_FILES . 'Model/Table/ValidationResult/IpRulesTable.php');
+		$this->assertIsString($expected);
+		$this->assertTextEquals($expected, $result);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testRunNoChanges(): void {
+		$task = $this->getTask();
+
+		// Test with already annotated file
+		$path = TEST_FILES . 'Model/Table/ValidationResult/IpRulesTable.php';
+		$content = file_get_contents($path);
+		$this->assertIsString($content);
+
+		$result = $task->run($content, $path);
+
+		// Should not add duplicate annotations
+		$this->assertEquals($content, $result);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testRunNoTableProvider(): void {
+		$task = $this->getTask();
+
+		$content = <<<'PHP'
+<?php
+class FooTable {
+	public function validationDefault($validator) {
+		$validator->add('email', 'valid', [
+			'rule' => 'email',
+		]);
+		return $validator;
+	}
+}
+PHP;
+
+		$result = $task->run($content, 'src/Model/Table/FooTable.php');
+
+		// No @link should be added (no table provider)
+		$this->assertStringNotContainsString('@link', $result);
+		$this->assertEquals($content, $result);
+	}
+
+	/**
+	 * @param array<string, mixed> $params
+	 * @return \IdeHelper\Illuminator\Task\TableValidationLinkTask
+	 */
+	protected function getTask(array $params = []): TableValidationLinkTask {
+		$params += [
+			AbstractAnnotator::CONFIG_DRY_RUN => true,
+			AbstractAnnotator::CONFIG_VERBOSE => true,
+		];
+
+		return new TableValidationLinkTask($params);
+	}
+
+}

--- a/tests/test_files/Model/Table/Validation/IpRulesTable.php
+++ b/tests/test_files/Model/Table/Validation/IpRulesTable.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace TestApp\Model\Table;
+
+use Cake\ORM\Table;
+use Cake\Validation\Validator;
+
+class IpRulesTable extends Table {
+
+	/**
+	 * @param \Cake\Validation\Validator $validator
+	 * @return \Cake\Validation\Validator
+	 */
+	public function validationDefault(Validator $validator): Validator {
+		$validator->add('allow', 'range', [
+			'rule' => ['verifyIpRanges', 'allow'],
+			'provider' => 'table',
+			'message' => 'Please provide valid ip ranges',
+		]);
+
+		$validator->add('deny', 'range', [
+			'rule' => 'verifyDenyRanges',
+			'provider' => 'table',
+		]);
+
+		// This should NOT get a link (no table provider)
+		$validator->add('email', 'valid', [
+			'rule' => 'email',
+			'message' => 'Please provide a valid email',
+		]);
+
+		return $validator;
+	}
+
+	/**
+	 * @param string $value
+	 * @param array $context
+	 * @return bool
+	 */
+	public function verifyIpRanges(string $value, array $context): bool {
+		return true;
+	}
+
+	/**
+	 * @param string $value
+	 * @param array $context
+	 * @return bool
+	 */
+	public function verifyDenyRanges(string $value, array $context): bool {
+		return true;
+	}
+
+}

--- a/tests/test_files/Model/Table/ValidationResult/IpRulesTable.php
+++ b/tests/test_files/Model/Table/ValidationResult/IpRulesTable.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace TestApp\Model\Table;
+
+use Cake\ORM\Table;
+use Cake\Validation\Validator;
+
+class IpRulesTable extends Table {
+
+	/**
+	 * @param \Cake\Validation\Validator $validator
+	 * @return \Cake\Validation\Validator
+	 */
+	public function validationDefault(Validator $validator): Validator {
+		/** @link verifyIpRanges() */
+		$validator->add('allow', 'range', [
+			'rule' => ['verifyIpRanges', 'allow'],
+			'provider' => 'table',
+			'message' => 'Please provide valid ip ranges',
+		]);
+
+		/** @link verifyDenyRanges() */
+		$validator->add('deny', 'range', [
+			'rule' => 'verifyDenyRanges',
+			'provider' => 'table',
+		]);
+
+		// This should NOT get a link (no table provider)
+		$validator->add('email', 'valid', [
+			'rule' => 'email',
+			'message' => 'Please provide a valid email',
+		]);
+
+		return $validator;
+	}
+
+	/**
+	 * @param string $value
+	 * @param array $context
+	 * @return bool
+	 */
+	public function verifyIpRanges(string $value, array $context): bool {
+		return true;
+	}
+
+	/**
+	 * @param string $value
+	 * @param array $context
+	 * @return bool
+	 */
+	public function verifyDenyRanges(string $value, array $context): bool {
+		return true;
+	}
+
+}


### PR DESCRIPTION
## Summary
- Adds a new Illuminator task `TableValidationLinkTask` that adds `@link` annotations above `validator->add()` calls that reference table provider methods
- Uses `nikic/php-parser` for reliable AST parsing to find `->add()` calls with `'provider' => 'table'` and extract the method names from the `'rule'` configuration
- Helps IDEs recognize validation method usage and provides navigation from the validator call to the actual method

### Before
```php
$validator->add('allow', 'range', [
    'rule' => ['verifyIpRanges', 'allow'],
    'provider' => 'table',
]);
```
IDE marks `verifyIpRanges()` as unused, no navigation available.

### After
```php
/** @link verifyIpRanges() */
$validator->add('allow', 'range', [
    'rule' => ['verifyIpRanges', 'allow'],
    'provider' => 'table',
]);
```
IDE recognizes the method as used and provides clickable navigation.

## Test plan
- [x] Unit tests for `shouldRun()` filtering
- [x] Unit tests for `run()` with table provider methods
- [x] Unit tests for idempotency (no duplicate annotations)
- [x] Unit tests for files without table provider
- [x] All existing tests pass
- [x] phpcs passes
- [x] phpstan passes on new files (existing baseline issues unrelated)

Fixes #403

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * New automatic validation link annotation system. Scans PHP Table classes and inserts @link annotations above validation rules configured with table providers, improving IDE documentation capabilities and code navigation.

* **Tests**
  * Added comprehensive test coverage for the new validation annotation feature, including various scenarios and edge case handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->