### PR TITLE
Add support for compact() in template variable extraction

### DIFF
--- a/src/Annotator/Template/VariableExtractor.php
+++ b/src/Annotator/Template/VariableExtractor.php
@@ -374,6 +374,21 @@ class VariableExtractor {
 				continue;
 			}
 
+			// Skip array keys (string followed by =>)
+			$nextIndex = $file->findNext(Tokens::$emptyTokens, $i + 1, $closeParen, true, null, true);
+			if ($nextIndex !== false && $tokens[$nextIndex]['code'] === T_DOUBLE_ARROW) {
+				continue;
+			}
+
+			// Skip strings in concatenation (preceded or followed by .)
+			if ($nextIndex !== false && $tokens[$nextIndex]['code'] === T_STRING_CONCAT) {
+				continue;
+			}
+			$prevIndex = $file->findPrevious(Tokens::$emptyTokens, $i - 1, $openParen, true, null, true);
+			if ($prevIndex !== false && $tokens[$prevIndex]['code'] === T_STRING_CONCAT) {
+				continue;
+			}
+
 			// Strip quotes from the string
 			$variable = trim($tokens[$i]['content'], '\'"');
 			if ($variable === '' || $variable === 'this') {

--- a/tests/TestCase/Annotator/Template/VariableExtractorTest.php
+++ b/tests/TestCase/Annotator/Template/VariableExtractorTest.php
@@ -273,6 +273,10 @@ $result = compact('foo', "bar");
 // Method calls should be ignored
 $obj->compact('ignored1');
 SomeClass::compact('ignored2');
+
+// Edge cases: array keys and concatenation should be ignored
+compact(['key' => 'arrayValue']);
+compact('concat' . 'enated');
 PHP;
 
 		$file = $this->getFile('', $content);
@@ -280,7 +284,7 @@ PHP;
 		$result = $this->variableExtractor->extract($file);
 
 		// All variables from compact() calls should be found
-		$expected = ['accounts', 'unit_options', 'homes', 'units', 'includeSubmit', 'foo', 'bar', 'result', 'obj'];
+		$expected = ['accounts', 'unit_options', 'homes', 'units', 'includeSubmit', 'foo', 'bar', 'result', 'obj', 'arrayValue'];
 		foreach ($expected as $var) {
 			$this->assertArrayHasKey($var, $result, "Variable \$$var should be found from compact()");
 		}
@@ -288,6 +292,13 @@ PHP;
 		// Method call arguments should NOT be found
 		$this->assertArrayNotHasKey('ignored1', $result, 'Method call arguments should not be extracted');
 		$this->assertArrayNotHasKey('ignored2', $result, 'Static method call arguments should not be extracted');
+
+		// Array keys should NOT be found (only values)
+		$this->assertArrayNotHasKey('key', $result, 'Array keys should not be extracted');
+
+		// Concatenated strings should NOT be found
+		$this->assertArrayNotHasKey('concat', $result, 'Concatenated strings should not be extracted');
+		$this->assertArrayNotHasKey('enated', $result, 'Concatenated strings should not be extracted');
 
 		// result is assigned, so should be excluded
 		$this->assertEquals('Assignment', $result['result']['excludeReason']);


### PR DESCRIPTION
## Summary
- Adds detection of variables passed via `compact()` function calls in templates
- The template annotator now properly recognizes variables like `compact('accounts', 'unit_options')` as variable usage
- Fixes test file to use correct path for CodeSniffer autoload

## Example

Previously, variables in this pattern would not be detected:

```php
echo $this->element(
    'residents/dropdowns', compact(
        'accounts', 'unit_options', 'homes', 'units', 'includeSubmit'
    )
);
```

Now `accounts`, `unit_options`, `homes`, `units`, and `includeSubmit` are properly recognized as template variables.

## Test plan
- [x] Added `testExtractFromCompact()` test case
- [x] All existing VariableExtractor tests pass
- [x] TemplateAnnotator tests pass
- [x] PHPStan analysis passes
- [x] Code style check passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for extracting variables passed via compact() to improve template variable detection and IDE analysis.

* **Tests**
  * Added a test covering compact() extraction behavior, including correct inclusion/exclusion in method/static call contexts and expected variable results.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->