### PR TITLE
Preserve nullable types in template variable annotations

### DIFF
--- a/src/Annotation/VariableAnnotation.php
+++ b/src/Annotation/VariableAnnotation.php
@@ -93,8 +93,30 @@ class VariableAnnotation extends AbstractAnnotation {
 	 * @return void
 	 */
 	public function replaceWith(AbstractAnnotation $annotation): void {
-		$this->type = $annotation->getType();
+		$newType = $annotation->getType();
+
+		// Preserve |null from existing type when replacing with a guessed type
+		if ($annotation->getGuessed() && $this->hasNull() && !$this->typeHasNull($newType)) {
+			$newType .= '|null';
+		}
+
+		$this->type = $newType;
 		$this->variable = $annotation->getVariable();
+	}
+
+	/**
+	 * @return bool
+	 */
+	protected function hasNull(): bool {
+		return $this->typeHasNull($this->type);
+	}
+
+	/**
+	 * @param string $type
+	 * @return bool
+	 */
+	protected function typeHasNull(string $type): bool {
+		return str_contains($type, '|null') || str_contains($type, 'null|') || $type === 'null';
 	}
 
 }

--- a/tests/TestCase/Annotation/VariableAnnotationTest.php
+++ b/tests/TestCase/Annotation/VariableAnnotationTest.php
@@ -64,4 +64,57 @@ class VariableAnnotationTest extends TestCase {
 		$this->assertSame('', $comparisonAnnotation->getDescription());
 	}
 
+	/**
+	 * @return void
+	 */
+	public function testReplaceWithPreservesNullableForGuessed() {
+		// Existing annotation has |null
+		$annotation = new VariableAnnotation('\\App\\Model\\Entity\\Home|null', '$homeData');
+
+		// New guessed annotation without null
+		$replacementAnnotation = new VariableAnnotation('mixed', '$homeData');
+		$replacementAnnotation->setGuessed(true);
+
+		$annotation->replaceWith($replacementAnnotation);
+
+		// Should preserve |null
+		$result = (string)$annotation;
+		$this->assertSame('@var mixed|null $homeData', $result);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testReplaceWithDoesNotAddNullForNonGuessed() {
+		// Existing annotation has |null
+		$annotation = new VariableAnnotation('\\App\\Model\\Entity\\Home|null', '$homeData');
+
+		// New non-guessed annotation without null
+		$replacementAnnotation = new VariableAnnotation('\\App\\Model\\Entity\\User', '$homeData');
+
+		$annotation->replaceWith($replacementAnnotation);
+
+		// Should NOT preserve |null for non-guessed
+		$result = (string)$annotation;
+		$this->assertSame('@var \\App\\Model\\Entity\\User $homeData', $result);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testReplaceWithDoesNotDuplicateNull() {
+		// Existing annotation has |null
+		$annotation = new VariableAnnotation('\\App\\Model\\Entity\\Home|null', '$homeData');
+
+		// New guessed annotation already has null
+		$replacementAnnotation = new VariableAnnotation('object|null', '$homeData');
+		$replacementAnnotation->setGuessed(true);
+
+		$annotation->replaceWith($replacementAnnotation);
+
+		// Should NOT duplicate |null
+		$result = (string)$annotation;
+		$this->assertSame('@var object|null $homeData', $result);
+	}
+
 }


### PR DESCRIPTION
## Summary
- Preserves `|null` when template annotator replaces an existing annotation with a guessed type
- Only applies when the replacement annotation is "guessed" (generic types like `mixed`, `object`, `array`)
- Non-guessed replacements still fully replace the type

## Problem
When you manually annotate a template variable as nullable:
```php
@var \App\Model\Entity\Home|null $homeData
```

The template annotator would replace it with:
```php
@var mixed $homeData
```

Losing the nullable type information.

## Solution
The `replaceWith()` method now checks if:
1. The new annotation is guessed (template-generated)
2. The existing type has `|null`
3. The new type doesn't already have `|null`

If all conditions are met, it preserves the `|null` suffix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed type annotation handling to preserve nullable types when replacing with guessed types, ensuring variables marked as nullable remain nullable after type updates.

* **Tests**
  * Added test cases validating nullability preservation during type replacement scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->