### PR TITLE
Skip @property annotations for typed Table properties in controllers

### DIFF
--- a/tests/TestCase/Annotator/ControllerAnnotatorTest.php
+++ b/tests/TestCase/Annotator/ControllerAnnotatorTest.php
@@ -83,7 +83,7 @@ class ControllerAnnotatorTest extends TestCase {
 
 		$output = $this->out->output();
 
-		$this->assertTextContains('   -> 4 annotations added.', $output);
+		$this->assertTextContains('   -> 3 annotations added.', $output);
 	}
 
 	/**

--- a/tests/test_files/Controller/BarController.php
+++ b/tests/test_files/Controller/BarController.php
@@ -4,7 +4,6 @@ namespace TestApp\Controller;
 use TestApp\Model\Table\WheelsTable;
 
 /**
- * @property \TestApp\Model\Table\WheelsTable $Wheels
  * @property \TestApp\Model\Table\BarBarsTable $BarBars
  * @property \MyNamespace\MyPlugin\Controller\Component\MyComponent $My
  *


### PR DESCRIPTION
## Summary

- Skip generating `@property` annotations for Table classes when typed property declarations already exist
- Example: If a controller has `protected UsersTable $Users;`, don't add `@property \App\Model\Table\UsersTable $Users`
- With `-r` flag, existing redundant annotations will also be removed

This reduces annotation clutter in modern codebases using typed properties.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved annotation handling to prevent redundant property annotations when properties already have explicit type declarations, resulting in cleaner IDE support.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->