### PR TITLE
Drop PHP 7.4 support, require PHP 8.1+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,11 +11,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ['7.4', '8.3']
+        php-version: ['8.1', '8.3']
         db-type: [sqlite, mysql, pgsql]
         prefer-lowest: ['']
         include:
-          - php-version: '7.4'
+          - php-version: '8.1'
             db-type: 'sqlite'
             prefer-lowest: 'prefer-lowest'
 
@@ -70,7 +70,7 @@ jobs:
         if [[ ${{ matrix.db-type }} == 'sqlite' ]]; then export DB_URL='sqlite:///:memory:'; fi
         if [[ ${{ matrix.db-type }} == 'mysql' ]]; then export DB_URL='mysql://root:root@127.0.0.1/cakephp'; fi
         if [[ ${{ matrix.db-type }} == 'pgsql' ]]; then export DB_URL='postgres://postgres:postgres@127.0.0.1/postgres'; fi
-        if [[ ${{ matrix.php-version }} == '7.4' && ${{ matrix.db-type }} == 'sqlite' ]]; then
+        if [[ ${{ matrix.php-version }} == '8.1' && ${{ matrix.db-type }} == 'sqlite' ]]; then
           vendor/bin/phpunit --coverage-clover=coverage.xml
         else
           vendor/bin/phpunit
@@ -80,7 +80,7 @@ jobs:
       run: if ${{ matrix.prefer-lowest == 'prefer-lowest' }}; then vendor/bin/validate-prefer-lowest -m; fi
 
     - name: Code Coverage Report
-      if: success() && matrix.php-version == '7.4' && matrix.db-type == 'sqlite'
+      if: success() && matrix.php-version == '8.1' && matrix.db-type == 'sqlite'
       uses: codecov/codecov-action@v3
 
   validation:
@@ -93,7 +93,7 @@ jobs:
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
       with:
-        php-version: '7.4'
+        php-version: '8.1'
         extensions: mbstring, intl
         coverage: none
 

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
 		"source": "https://github.com/dereuromark/cakephp-ide-helper/"
 	},
 	"require": {
-		"php": ">=7.4",
+		"php": ">=8.1",
 		"cakephp/cakephp": "^4.4.0",
 		"cakephp/bake": "^2.1.0",
 		"sebastian/diff": "^4.0.3||^5.0",


### PR DESCRIPTION
## Summary

- Updated minimum PHP requirement from 7.4 to 8.1 in composer.json
- Updated CI workflow to test PHP 8.1 and 8.3 instead of 7.4 and 8.3

## Reason

CI is failing because `laminas/laminas-diactoros` 2.18+ requires PHP 8.0+, which is pulled in by CakePHP 4.4+. Since both PHP 7.4 and 8.0 are EOL, updating the minimum to PHP 8.1 (still in active support).

## Test plan

- [ ] CI passes on cake4 branch