### PR TITLE
Preserve custom View class annotations in templates

### DIFF
--- a/tests/TestCase/Annotator/TemplateAnnotatorTest.php
+++ b/tests/TestCase/Annotator/TemplateAnnotatorTest.php
@@ -544,6 +544,34 @@ class TemplateAnnotatorTest extends TestCase {
 	}
 
 	/**
+	 * Tests that existing custom view annotations are preserved when the class exists.
+	 *
+	 * @return void
+	 */
+	public function testAnnotatePreservesCustomViewAnnotation() {
+		$annotator = $this->_getAnnotatorMock([]);
+
+		$expectedContent = str_replace("\r\n", "\n", file_get_contents(TEST_FILES . 'templates/custom_view.php'));
+		$callback = function($value) use ($expectedContent) {
+			$value = str_replace(["\r\n", "\r"], "\n", $value);
+			if ($value !== $expectedContent) {
+				$this->_displayDiff($expectedContent, $value);
+			}
+
+			return $value === $expectedContent;
+		};
+		$annotator->expects($this->once())->method('storeFile')->with($this->anything(), $this->callback($callback));
+
+		$path = APP_ROOT . DS . 'templates/Foos/custom_view.php';
+		$annotator->annotate($path);
+
+		$output = $this->out->output();
+
+		// Should add 1 annotation ($cars) but skip updating the existing $this annotation
+		$this->assertTextContains('   -> 1 annotation added, 1 annotation skipped.', $output);
+	}
+
+	/**
 	 * @param array $params
 	 * @return \IdeHelper\Annotator\TemplateAnnotator|\PHPUnit\Framework\MockObject\MockObject
 	 */

--- a/tests/test_app/src/View/CustomView.php
+++ b/tests/test_app/src/View/CustomView.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace TestApp\View;
+
+/**
+ * Custom View class for testing view annotation preservation.
+ */
+class CustomView extends AppView {
+}

--- a/tests/test_app/templates/Foos/custom_view.php
+++ b/tests/test_app/templates/Foos/custom_view.php
@@ -1,0 +1,8 @@
+<?php
+/**
+ * @var \TestApp\View\CustomView $this
+ */
+?>
+<div>
+	<?php foreach ($cars as $car) {} ?>
+</div>

--- a/tests/test_files/templates/custom_view.php
+++ b/tests/test_files/templates/custom_view.php
@@ -1,0 +1,9 @@
+<?php
+/**
+ * @var \TestApp\View\CustomView $this
+ * @var \TestApp\Model\Entity\Car[]|\Cake\Collection\CollectionInterface $cars
+ */
+?>
+<div>
+	<?php foreach ($cars as $car) {} ?>
+</div>


### PR DESCRIPTION
## Summary
- When a template has an existing `@var` annotation for `$this` that references a valid View subclass, preserve it instead of replacing it with the default AppView
- Fixes the issue where running the annotator would overwrite specific view annotations like `@var \Calendar\View\IcalView $this` with the generic `@var \App\View\AppView $this`

## Test plan
- [x] Added test case `testAnnotatePreservesCustomViewAnnotation` that verifies custom view annotations are preserved
- [x] All existing tests pass
- [x] PHPStan passes
- [x] PHPCS passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved annotation system to better preserve existing custom view annotations during updates, preventing unintended overwriting of valid annotations.

* **Tests**
  * Added test coverage for custom view annotation preservation behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->