### PR TITLE
Fix regex error with nested namespace Form classes

### DIFF
--- a/src/Annotator/ClassAnnotatorTask/FormClassAnnotatorTask.php
+++ b/src/Annotator/ClassAnnotatorTask/FormClassAnnotatorTask.php
@@ -29,7 +29,7 @@ class FormClassAnnotatorTask extends AbstractClassAnnotatorTask implements Class
 		}
 
 		$varName = lcfirst($matches[2]) . 'Form';
-		if (!preg_match('#\$' . $varName . '->execute\(#', $content)) {
+		if (!preg_match('#\$' . preg_quote($varName, '#') . '->execute\(#', $content)) {
 			return false;
 		}
 
@@ -53,7 +53,7 @@ class FormClassAnnotatorTask extends AbstractClassAnnotatorTask implements Class
 		$rows = explode(PHP_EOL, $this->content);
 		$rowToAnnotate = null;
 		foreach ($rows as $i => $row) {
-			if (!preg_match('#\$' . $varName . '->execute\(#', $row)) {
+			if (!preg_match('#\$' . preg_quote($varName, '#') . '->execute\(#', $row)) {
 				continue;
 			}
 			$rowToAnnotate = $i + 1;

--- a/src/Annotator/ClassAnnotatorTask/MailerClassAnnotatorTask.php
+++ b/src/Annotator/ClassAnnotatorTask/MailerClassAnnotatorTask.php
@@ -50,7 +50,7 @@ class MailerClassAnnotatorTask extends AbstractClassAnnotatorTask implements Cla
 			return true;
 		}
 
-		if (!preg_match('#\$' . $varName . '->send\(\'\w+\'#', $content)) {
+		if (!preg_match('#\$' . preg_quote($varName, '#') . '->send\(\'\w+\'#', $content)) {
 			return false;
 		}
 
@@ -95,7 +95,7 @@ class MailerClassAnnotatorTask extends AbstractClassAnnotatorTask implements Cla
 			$rowToAnnotate = null;
 			$rowMatches = null;
 			foreach ($rows as $i => $row) {
-				if (!preg_match('#\$' . $varName . '->send\(\'(\w+)\'#', $row, $rowMatches)) {
+				if (!preg_match('#\$' . preg_quote($varName, '#') . '->send\(\'(\w+)\'#', $row, $rowMatches)) {
 					continue;
 				}
 				$rowToAnnotate = $i + 1;
@@ -104,7 +104,6 @@ class MailerClassAnnotatorTask extends AbstractClassAnnotatorTask implements Cla
 				break;
 			}
 		} else {
-			assert(!empty($callMatches));
 			assert($singleCallAction !== null);
 			$rows = explode(PHP_EOL, $this->content);
 			$rowToAnnotate = null;

--- a/tests/TestCase/Annotator/ClassAnnotatorTask/FormClassAnnotatorTaskTest.php
+++ b/tests/TestCase/Annotator/ClassAnnotatorTask/FormClassAnnotatorTaskTest.php
@@ -44,6 +44,29 @@ class FormClassAnnotatorTaskTest extends TestCase {
 	}
 
 	/**
+	 * Test that nested namespace Forms (e.g. App\Form\Admin\ContactForm) don't cause regex errors.
+	 *
+	 * Without preg_quote(), the backslash in "Admin\Contact" would cause:
+	 * "preg_match(): Compilation failed: unrecognized character follows \"
+	 *
+	 * @return void
+	 */
+	public function testShouldRunNestedNamespace() {
+		$task = $this->getTask('');
+
+		// Nested namespace Form class with matching variable name (contains backslash)
+		// lcfirst('Admin\Contact') = 'admin\Contact', + 'Form' = 'admin\ContactForm'
+		$content = 'namespace TestApp\\Foo' . PHP_EOL . 'use TestApp\\Form\\Admin\\ContactForm' . PHP_EOL . '$admin\\ContactForm->execute()';
+		$result = $task->shouldRun('/src/Foo.php', $content);
+		$this->assertTrue($result);
+
+		// Without the execute() call, should return false
+		$content = 'namespace TestApp\\Foo' . PHP_EOL . 'use TestApp\\Form\\Admin\\ContactForm' . PHP_EOL . '$admin\\ContactForm->something()';
+		$result = $task->shouldRun('/src/Foo.php', $content);
+		$this->assertFalse($result);
+	}
+
+	/**
 	 * @return void
 	 */
 	public function testAnnotate() {


### PR DESCRIPTION
## Summary
- Fix preg_match() compilation error when using Form classes in nested namespaces (e.g. `App\Form\Admin\ContactForm`)
- Add test case for nested namespace Form classes

The backslash in captured namespace paths (like `Admin\Contact` from `App\Form\Admin\ContactForm`) was being interpolated directly into a regex pattern, causing errors like:
```
preg_match(): Compilation failed: unrecognized character follows \ at offset 8
```

Fixed by using `preg_quote()` to escape the variable before using it in the regex pattern.

Fixes #422

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced form class annotation to safely process form classes with complex namespace paths, ensuring special characters in class names don't interfere with pattern matching and annotation detection.

* **Tests**
  * Expanded test coverage for form class annotation with nested namespace paths, verifying correct behavior with complex class naming scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->