### PR TITLE
Fix annotation generation for virtual fields with nested generics

### DIFF
--- a/src/Annotator/EntityAnnotator.php
+++ b/src/Annotator/EntityAnnotator.php
@@ -428,9 +428,26 @@ class EntityAnnotator extends AbstractAnnotator {
 
 			$content = $tokens[$classNameIndex]['content'];
 
-			$spaceIndex = strpos($content, ' ');
-			if ($spaceIndex) {
-				$content = substr($content, 0, $spaceIndex);
+			// Find the end of the type, accounting for nested generics
+			// Spaces inside <> brackets should not be treated as type boundaries
+			$bracketDepth = 0;
+			$typeEnd = null;
+			$length = strlen($content);
+			for ($j = 0; $j < $length; $j++) {
+				$char = $content[$j];
+				if ($char === '<') {
+					$bracketDepth++;
+				} elseif ($char === '>') {
+					$bracketDepth--;
+				} elseif ($char === ' ' && $bracketDepth === 0) {
+					$typeEnd = $j;
+
+					break;
+				}
+			}
+
+			if ($typeEnd !== null) {
+				$content = substr($content, 0, $typeEnd);
 			}
 
 			return $content;

--- a/tests/TestCase/Annotator/EntityAnnotatorTest.php
+++ b/tests/TestCase/Annotator/EntityAnnotatorTest.php
@@ -340,7 +340,7 @@ class EntityAnnotatorTest extends TestCase {
 
 		$output = $this->out->output();
 
-		$this->assertTextContains('   -> 10 annotations added', $output);
+		$this->assertTextContains('   -> 11 annotations added', $output);
 	}
 
 	/**

--- a/tests/test_app/src/Model/Entity/PHP7/Virtual.php
+++ b/tests/test_app/src/Model/Entity/PHP7/Virtual.php
@@ -13,4 +13,11 @@ class Virtual extends Entity {
 		return 'Virtual Two';
 	}
 
+	/**
+	 * @return array<int, array<string>>
+	 */
+	protected function _getNestedGeneric(): array {
+		return [[1 => ['a', 'b']]];
+	}
+
 }

--- a/tests/test_files/Model/Entity/PHP7/Virtual.php
+++ b/tests/test_files/Model/Entity/PHP7/Virtual.php
@@ -12,6 +12,7 @@ use Cake\ORM\Entity;
  * @property \Cake\I18n\DateTime $created
  * @property \Cake\I18n\DateTime|null $modified
  * @property string $virtual_two
+ * @property array<int, array<string>> $nested_generic
  * @property \TestApp\Model\Entity\Wheel[] $wheels
  *
  * @property-read string|null $virtual_one
@@ -24,6 +25,13 @@ class Virtual extends Entity {
 
 	protected function _getVirtualTwo(): string {
 		return 'Virtual Two';
+	}
+
+	/**
+	 * @return array<int, array<string>>
+	 */
+	protected function _getNestedGeneric(): array {
+		return [[1 => ['a', 'b']]];
 	}
 
 }


### PR DESCRIPTION
## Summary

- Fix `extractReturnType()` to handle nested generic types like `array<int, array<string>>`
- Add test case for virtual fields with nested generic return types

The previous implementation used `strpos($content, ' ')` to find where the type ended, but this broke for nested generics because there's a space inside the type (after the comma in `array<int, array<...>>`).

Now tracks bracket depth (`<` and `>`) to only consider a space as the type boundary when outside all brackets.

Fixes #424