### PR TITLE
Add SelectQuery code completion stubs

### DIFF
--- a/config/app.example.php
+++ b/config/app.example.php
@@ -23,6 +23,7 @@ return [
 		'assocsAsGenerics' => false, // Enable to have modern generics syntax (NOT recommended yet) in doc blocks
 		'genericsInParam' => false, // Enable to have generics in generated method param doc blocks (NOT recommended yet)
 		'concreteEntitiesInParam' => false, // Enable to have specific entities in generated method param doc blocks (NOT recommended)
+		'tableEntityQuery' => false, // Enable to annotate `Table::find()` as returning `SelectQuery<TEntity>` for IDEs
 		// Set to `false` to disable, or string if you have a custom FQCN to be used
 		'templateCollectionObject' => true,
 		// Set to `false` to disable, defaults to `mixed` if enabled, you can also pass callable for logic

--- a/docs/Annotations.md
+++ b/docs/Annotations.md
@@ -83,6 +83,7 @@ A LocationsTable class would then get the following doc block annotations added 
  * @method \App\Model\Entity\Location newEntity(array $data, array $options = [])
  * @method array<\App\Model\Entity\Location> newEntities(array $data, array $options = [])
  * @method \App\Model\Entity\Location get(mixed $primaryKey, array|string $finder = 'all', \Psr\SimpleCache\CacheInterface|string|null $cache = null, \Closure|string|null $cacheKey = null, mixed ...$args)
+ * @method \Cake\ORM\Query\SelectQuery<\App\Model\Entity\Location> find(string $type = 'all', mixed ...$args)
  * @method \App\Model\Entity\Location|false save(\Cake\Datasource\EntityInterface $entity, array $options = [])
  * @method \App\Model\Entity\Location saveOrFail(\Cake\Datasource\EntityInterface $entity, array $options = [])
  * @method \App\Model\Entity\Location patchEntity(\Cake\Datasource\EntityInterface $entity, array $data, array $options = [])
@@ -97,7 +98,16 @@ A LocationsTable class would then get the following doc block annotations added 
  * @property \Cake\ORM\Association\BelongsTo<\App\Model\Table\UsersTable> $Users
  *
  * @mixin \Cake\ORM\Behavior\TimestampBehavior
+ ```
+
+If you want the table annotations to also expose the entity-aware `find()` return type for IDEs, enable:
+```php
+'IdeHelper' => [
+    'tableEntityQuery' => true,
+],
 ```
+
+This is intentionally optional, because finder result shapes can still widen beyond plain entities.
 
 ### Entities
 Entities should annotate their properties and relations.

--- a/docs/CodeCompletion.md
+++ b/docs/CodeCompletion.md
@@ -24,6 +24,38 @@ With the generated code completion file this becomes not necessary anymore.
 It will automatically detect this property as the right behavior class hint `Search` as `\Search\Model\Behavior\SearchBehavior`, making
 `searchManager()` available in the IDE for method argument checking and following.
 
+### SelectQuery generics
+The code completion generator also ships a `Cake\ORM\Query\SelectQuery` helper stub for fluent query chains.
+This is especially useful together with the model annotation option:
+
+```php
+'IdeHelper' => [
+    'tableEntityQuery' => true,
+],
+```
+
+That combination lets IDEs preserve the concrete entity type through calls such as:
+
+```php
+$query = $this->Users->find();
+$query->where(['active' => true])->all();
+```
+
+For PhpStorm projects you can point the generated code completion files into `.phpstorm.meta.php/`
+so they are indexed as local project helpers:
+
+```php
+'IdeHelper' => [
+    'codeCompletionPath' => ROOT . DS . '.phpstorm.meta.php' . DS,
+],
+```
+
+Then regenerate the files with:
+
+```php
+bin/cake generate code_completion
+```
+
 
 ### Adding your own tasks
 Just create your own Task class:

--- a/src/Annotator/ModelAnnotator.php
+++ b/src/Annotator/ModelAnnotator.php
@@ -216,6 +216,9 @@ class ModelAnnotator extends AbstractAnnotator {
 			$annotations[] = "@method {$fullClassNameCollection} newEntities({$dataType} \$data, {$optionsType} \$options = [])";
 
 			$annotations[] = "@method {$fullClassName} get(mixed \$primaryKey, array|string \$finder = 'all', \Psr\SimpleCache\CacheInterface|string|null \$cache = null, \Closure|string|null \$cacheKey = null, mixed ...\$args)";
+			if (Configure::read('IdeHelper.tableEntityQuery')) {
+				$annotations[] = "@method \Cake\ORM\Query\SelectQuery<{$fullClassName}> find(string \$type = 'all', mixed ...\$args)";
+			}
 			$annotations[] = "@method {$fullClassName} findOrCreate(\Cake\ORM\Query\SelectQuery|callable|array \$search, ?callable \$callback = null, {$optionsType} \$options = [])";
 
 			$annotations[] = "@method {$fullClassName} patchEntity({$entityInterface} \$entity, {$dataType} \$data, {$optionsType} \$options = [])";

--- a/src/CodeCompletion/Task/SelectQueryTask.php
+++ b/src/CodeCompletion/Task/SelectQueryTask.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace IdeHelper\CodeCompletion\Task;
+
+class SelectQueryTask implements TaskInterface {
+
+	/**
+	 * @var string
+	 */
+	public const TYPE_NAMESPACE = 'Cake\ORM\Query';
+
+	/**
+	 * @return string
+	 */
+	public function type(): string {
+		return static::TYPE_NAMESPACE;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function create(): string {
+		return <<<'CODE'
+use Cake\Database\ExpressionInterface;
+use Cake\Datasource\ResultSetInterface;
+use Closure;
+
+if (false) {
+	/**
+	 * @template TSubject
+	 */
+	class SelectQuery {
+		/**
+		 * @return static
+		 */
+		public function find(string $finder, mixed ...$args) {}
+
+		/**
+		 * @return static
+		 */
+		public function where(
+			ExpressionInterface|Closure|array|string|null $conditions = null,
+			array $types = [],
+			bool $overwrite = false,
+		) {}
+
+		/**
+		 * @return static
+		 */
+		public function andWhere($conditions, array $types = []) {}
+
+		/**
+		 * @return static
+		 */
+		public function contain(mixed $associations, Closure|bool $override = false) {}
+
+		/**
+		 * @return static
+		 */
+		public function groupBy(ExpressionInterface|array|string $fields, bool $overwrite = false) {}
+
+		/**
+		 * @return static
+		 */
+		public function orderBy(ExpressionInterface|Closure|array|string $fields, bool $overwrite = false) {}
+
+		/**
+		 * @return ResultSetInterface<array-key, TSubject>
+		 */
+		public function all() {}
+
+		/**
+		 * @return TSubject|null
+		 */
+		public function first() {}
+
+		/**
+		 * @return TSubject
+		 */
+		public function firstOrFail() {}
+
+		/**
+		 * @return array<TSubject>
+		 */
+		public function toArray() {}
+	}
+}
+
+CODE;
+	}
+
+}

--- a/src/CodeCompletion/TaskCollection.php
+++ b/src/CodeCompletion/TaskCollection.php
@@ -6,6 +6,7 @@ use Cake\Core\Configure;
 use IdeHelper\CodeCompletion\Task\BehaviorTask;
 use IdeHelper\CodeCompletion\Task\ControllerEventsTask;
 use IdeHelper\CodeCompletion\Task\ModelEventsTask;
+use IdeHelper\CodeCompletion\Task\SelectQueryTask;
 use IdeHelper\CodeCompletion\Task\TaskInterface;
 use IdeHelper\CodeCompletion\Task\ViewEventsTask;
 use InvalidArgumentException;
@@ -18,6 +19,7 @@ class TaskCollection {
 	protected array $defaultTasks = [
 		BehaviorTask::class => BehaviorTask::class,
 		ModelEventsTask::class => ModelEventsTask::class,
+		SelectQueryTask::class => SelectQueryTask::class,
 		ControllerEventsTask::class => ControllerEventsTask::class,
 		ViewEventsTask::class => ViewEventsTask::class,
 	];

--- a/tests/TestCase/Annotator/ModelAnnotatorTest.php
+++ b/tests/TestCase/Annotator/ModelAnnotatorTest.php
@@ -109,6 +109,7 @@ class ModelAnnotatorTest extends TestCase {
 		parent::tearDown();
 
 		Configure::delete('IdeHelper.assocsAsGenerics');
+		Configure::delete('IdeHelper.tableEntityQuery');
 		Configure::delete('IdeHelper.tableBehaviors');
 	}
 
@@ -285,6 +286,38 @@ class ModelAnnotatorTest extends TestCase {
 
 		$output = $this->out->output();
 		$this->assertTextContains('  -> 18 annotations added', $output);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testAnnotateWithEntityFindQuery() {
+		Configure::write('IdeHelper.tableEntityQuery', true);
+
+		$annotator = $this->_getAnnotatorMock([]);
+
+		$expectedContent = str_replace("\r\n", "\n", file_get_contents(TEST_FILES . 'Model/Table/BarBarsTable.php'));
+		$expectedContent = str_replace(
+			" * @method \\TestApp\\Model\\Entity\\BarBar get(mixed \$primaryKey, array|string \$finder = 'all', \\Psr\\SimpleCache\\CacheInterface|string|null \$cache = null, \\Closure|string|null \$cacheKey = null, mixed ...\$args)\n * @method \\TestApp\\Model\\Entity\\BarBar findOrCreate(\\Cake\\ORM\\Query\\SelectQuery|callable|array \$search, ?callable \$callback = null, array \$options = [])",
+			" * @method \\TestApp\\Model\\Entity\\BarBar get(mixed \$primaryKey, array|string \$finder = 'all', \\Psr\\SimpleCache\\CacheInterface|string|null \$cache = null, \\Closure|string|null \$cacheKey = null, mixed ...\$args)\n * @method \\Cake\\ORM\\Query\\SelectQuery<\\TestApp\\Model\\Entity\\BarBar> find(string \$type = 'all', mixed ...\$args)\n * @method \\TestApp\\Model\\Entity\\BarBar findOrCreate(\\Cake\\ORM\\Query\\SelectQuery|callable|array \$search, ?callable \$callback = null, array \$options = [])",
+			$expectedContent,
+		);
+
+		$callback = function ($value) use ($expectedContent) {
+			$value = str_replace(["\r\n", "\r"], "\n", $value);
+			if ($value !== $expectedContent) {
+				$this->_displayDiff($expectedContent, $value);
+			}
+
+			return $value === $expectedContent;
+		};
+		$annotator->expects($this->once())->method('storeFile')->with($this->anything(), $this->callback($callback));
+
+		$path = APP . 'Model/Table/BarBarsTable.php';
+		$annotator->annotate($path);
+
+		$output = $this->out->output();
+		$this->assertTextContains('  -> 19 annotations added', $output);
 	}
 
 }

--- a/tests/TestCase/CodeCompletion/CodeCompletionGeneratorTest.php
+++ b/tests/TestCase/CodeCompletion/CodeCompletionGeneratorTest.php
@@ -24,6 +24,10 @@ class CodeCompletionGeneratorTest extends TestCase {
 		if (file_exists($file)) {
 			unlink($file);
 		}
+		$file = TMP . 'CodeCompletionCakeORMQuery.php';
+		if (file_exists($file)) {
+			unlink($file);
+		}
 	}
 
 	/**
@@ -35,11 +39,13 @@ class CodeCompletionGeneratorTest extends TestCase {
 		$expected = [
 			'Cake\Controller',
 			'Cake\ORM',
+			'Cake\ORM\Query',
 			'Cake\View',
 		];
 
 		$this->assertSame($expected, $result);
 		$this->assertFileExists(TMP . 'CodeCompletionCakeORM.php');
+		$this->assertFileExists(TMP . 'CodeCompletionCakeORMQuery.php');
 
 		$result = file_get_contents(TMP . 'CodeCompletionCakeORM.php');
 
@@ -106,6 +112,84 @@ if (false) {
 		public function beforeDelete(EventInterface $event, EntityInterface $entity, ArrayObject $options): void {}
 		public function afterDelete(EventInterface $event, EntityInterface $entity, ArrayObject $options): void {}
 		public function afterDeleteCommit(EventInterface $event, EntityInterface $entity, ArrayObject $options): void {}
+	}
+}
+
+TXT;
+
+		$this->assertTextEquals($expected, $result);
+
+		$result = file_get_contents(TMP . 'CodeCompletionCakeORMQuery.php');
+
+		$expected = <<<'TXT'
+<?php
+namespace Cake\ORM\Query;
+
+/**
+ * Only for code completion - regenerate using `bin/cake code_completion generate`.
+ */
+use Cake\Database\ExpressionInterface;
+use Cake\Datasource\ResultSetInterface;
+use Closure;
+
+if (false) {
+	/**
+	 * @template TSubject
+	 */
+	class SelectQuery {
+		/**
+		 * @return static
+		 */
+		public function find(string $finder, mixed ...$args) {}
+
+		/**
+		 * @return static
+		 */
+		public function where(
+			ExpressionInterface|Closure|array|string|null $conditions = null,
+			array $types = [],
+			bool $overwrite = false,
+		) {}
+
+		/**
+		 * @return static
+		 */
+		public function andWhere($conditions, array $types = []) {}
+
+		/**
+		 * @return static
+		 */
+		public function contain(mixed $associations, Closure|bool $override = false) {}
+
+		/**
+		 * @return static
+		 */
+		public function groupBy(ExpressionInterface|array|string $fields, bool $overwrite = false) {}
+
+		/**
+		 * @return static
+		 */
+		public function orderBy(ExpressionInterface|Closure|array|string $fields, bool $overwrite = false) {}
+
+		/**
+		 * @return ResultSetInterface<array-key, TSubject>
+		 */
+		public function all() {}
+
+		/**
+		 * @return TSubject|null
+		 */
+		public function first() {}
+
+		/**
+		 * @return TSubject
+		 */
+		public function firstOrFail() {}
+
+		/**
+		 * @return array<TSubject>
+		 */
+		public function toArray() {}
 	}
 }
 

--- a/tests/TestCase/Command/GenerateCodeCompletionCommandTest.php
+++ b/tests/TestCase/Command/GenerateCodeCompletionCommandTest.php
@@ -12,6 +12,7 @@ class GenerateCodeCompletionCommandTest extends TestCase {
 	protected array $files = [
 		TMP . 'CodeCompletionCakeController.php',
 		TMP . 'CodeCompletionCakeORM.php',
+		TMP . 'CodeCompletionCakeORMQuery.php',
 		TMP . 'CodeCompletionCakeView.php',
 	];
 
@@ -47,7 +48,7 @@ class GenerateCodeCompletionCommandTest extends TestCase {
 	 */
 	public function testGenerate() {
 		$this->exec('generate code_completion');
-		$this->assertOutputContains('CodeCompletion files generated: Cake\Controller, Cake\ORM, Cake\View');
+		$this->assertOutputContains('CodeCompletion files generated: Cake\Controller, Cake\ORM, Cake\ORM\Query, Cake\View');
 		$this->assertExitSuccess();
 	}
 


### PR DESCRIPTION
## Summary
This adds the non-core autocomplete layer for entity-aware query chains.

- optional `@method ... find(): SelectQuery<Entity>` generation in `ModelAnnotator`
- a new `SelectQuery` code-completion task that preserves generic query subjects across fluent calls like `where()`, `contain()`, `groupBy()`, `orderBy()`, and terminal calls like `all()` / `first()` / `toArray()`
- documentation for using `codeCompletionPath` to place the generated helper under `.phpstorm.meta.php/`

## Notes
The `tableEntityQuery` annotation is intentionally opt-in because finder result shapes can still widen beyond plain entities.
