### PR TITLE
Expand SelectQuery helper examples

### DIFF
--- a/docs/CodeCompletion.md
+++ b/docs/CodeCompletion.md
@@ -41,6 +41,19 @@ $query = $this->Users->find();
 $query->where(['active' => true])->all();
 ```
 
+The generated stub intentionally focuses on methods where the subject type is stable or where Cake already has a clear subject transition, for example:
+
+| Flow | Semantic result | ide-helper support |
+| --- | --- | --- |
+| `$this->Users->find()->where(...)->all()` | `User` entities | Covered via `tableEntityQuery` + `SelectQuery<TSubject>` stub |
+| `$this->Users->find('active')->matching('Roles')->contain('Profiles')->all()` | `User` entities | Covered; these fluent methods preserve `TSubject` |
+| `$this->Users->find()->disableHydration()->all()` | `array<string, mixed>` rows | Covered; `disableHydration()` switches the query stub to array results |
+| `$this->Users->find('list')->all()` | non-entity shaped result | Not forced by default; keep this outside the entity-query assumption |
+| `$this->Users->find()->formatResults(...)` | depends on formatter | Not modeled; formatter callbacks can reshape results arbitrarily |
+| `$this->Users->find()->mapReduce(...)` | depends on mapper/reducer | Not modeled; map/reduce can reshape results arbitrarily |
+
+This keeps the default helper honest: preserve the type where the query stays subject-compatible, and avoid pretending that formatter-driven or list-style flows are still plain entity queries.
+
 For PhpStorm projects you can point the generated code completion files into `.phpstorm.meta.php/`
 so they are indexed as local project helpers:
 

--- a/src/CodeCompletion/Task/SelectQueryTask.php
+++ b/src/CodeCompletion/Task/SelectQueryTask.php
@@ -24,6 +24,7 @@ class SelectQueryTask implements TaskInterface {
 use Cake\Database\ExpressionInterface;
 use Cake\Datasource\ResultSetInterface;
 use Closure;
+use Psr\SimpleCache\CacheInterface;
 
 if (false) {
 	/**
@@ -31,12 +32,12 @@ if (false) {
 	 */
 	class SelectQuery {
 		/**
-		 * @return static
+		 * @return static<TSubject>
 		 */
 		public function find(string $finder, mixed ...$args) {}
 
 		/**
-		 * @return static
+		 * @return static<TSubject>
 		 */
 		public function where(
 			ExpressionInterface|Closure|array|string|null $conditions = null,
@@ -45,24 +46,69 @@ if (false) {
 		) {}
 
 		/**
-		 * @return static
+		 * @return static<TSubject>
 		 */
 		public function andWhere($conditions, array $types = []) {}
 
 		/**
-		 * @return static
+		 * @return static<TSubject>
+		 */
+		public function matching(string $assoc, ?Closure $builder = null) {}
+
+		/**
+		 * @return static<TSubject>
+		 */
+		public function leftJoinWith(string $assoc, ?Closure $builder = null) {}
+
+		/**
+		 * @return static<TSubject>
+		 */
+		public function innerJoinWith(string $assoc, ?Closure $builder = null) {}
+
+		/**
+		 * @return static<TSubject>
+		 */
+		public function notMatching(string $assoc, ?Closure $builder = null) {}
+
+		/**
+		 * @return static<TSubject>
 		 */
 		public function contain(mixed $associations, Closure|bool $override = false) {}
 
 		/**
-		 * @return static
+		 * @return static<TSubject>
+		 */
+		public function clearContain() {}
+
+		/**
+		 * @return static<TSubject>
+		 */
+		public function cache(Closure|string|false $key, CacheInterface|string $config = 'default') {}
+
+		/**
+		 * @return static<TSubject>
 		 */
 		public function groupBy(ExpressionInterface|array|string $fields, bool $overwrite = false) {}
 
 		/**
-		 * @return static
+		 * @return static<TSubject>
 		 */
 		public function orderBy(ExpressionInterface|Closure|array|string $fields, bool $overwrite = false) {}
+
+		/**
+		 * @return static<TSubject>
+		 */
+		public function enableAutoFields(bool $value = true) {}
+
+		/**
+		 * @return static<TSubject>
+		 */
+		public function disableAutoFields() {}
+
+		/**
+		 * @return static<array<string,mixed>>
+		 */
+		public function disableHydration() {}
 
 		/**
 		 * @return ResultSetInterface<array-key, TSubject>

--- a/tests/TestCase/CodeCompletion/CodeCompletionGeneratorTest.php
+++ b/tests/TestCase/CodeCompletion/CodeCompletionGeneratorTest.php
@@ -131,6 +131,7 @@ namespace Cake\ORM\Query;
 use Cake\Database\ExpressionInterface;
 use Cake\Datasource\ResultSetInterface;
 use Closure;
+use Psr\SimpleCache\CacheInterface;
 
 if (false) {
 	/**
@@ -138,12 +139,12 @@ if (false) {
 	 */
 	class SelectQuery {
 		/**
-		 * @return static
+		 * @return static<TSubject>
 		 */
 		public function find(string $finder, mixed ...$args) {}
 
 		/**
-		 * @return static
+		 * @return static<TSubject>
 		 */
 		public function where(
 			ExpressionInterface|Closure|array|string|null $conditions = null,
@@ -152,24 +153,69 @@ if (false) {
 		) {}
 
 		/**
-		 * @return static
+		 * @return static<TSubject>
 		 */
 		public function andWhere($conditions, array $types = []) {}
 
 		/**
-		 * @return static
+		 * @return static<TSubject>
+		 */
+		public function matching(string $assoc, ?Closure $builder = null) {}
+
+		/**
+		 * @return static<TSubject>
+		 */
+		public function leftJoinWith(string $assoc, ?Closure $builder = null) {}
+
+		/**
+		 * @return static<TSubject>
+		 */
+		public function innerJoinWith(string $assoc, ?Closure $builder = null) {}
+
+		/**
+		 * @return static<TSubject>
+		 */
+		public function notMatching(string $assoc, ?Closure $builder = null) {}
+
+		/**
+		 * @return static<TSubject>
 		 */
 		public function contain(mixed $associations, Closure|bool $override = false) {}
 
 		/**
-		 * @return static
+		 * @return static<TSubject>
+		 */
+		public function clearContain() {}
+
+		/**
+		 * @return static<TSubject>
+		 */
+		public function cache(Closure|string|false $key, CacheInterface|string $config = 'default') {}
+
+		/**
+		 * @return static<TSubject>
 		 */
 		public function groupBy(ExpressionInterface|array|string $fields, bool $overwrite = false) {}
 
 		/**
-		 * @return static
+		 * @return static<TSubject>
 		 */
 		public function orderBy(ExpressionInterface|Closure|array|string $fields, bool $overwrite = false) {}
+
+		/**
+		 * @return static<TSubject>
+		 */
+		public function enableAutoFields(bool $value = true) {}
+
+		/**
+		 * @return static<TSubject>
+		 */
+		public function disableAutoFields() {}
+
+		/**
+		 * @return static<array<string,mixed>>
+		 */
+		public function disableHydration() {}
 
 		/**
 		 * @return ResultSetInterface<array-key, TSubject>


### PR DESCRIPTION
## Summary
This follow-up builds on #426 with two focused improvements:

- document a small query inference matrix in `docs/CodeCompletion.md`
- expand the generated `SelectQuery` helper stub only for methods that keep the query subject stable, plus the explicit `disableHydration()` subject shift to array rows

## Notes
This intentionally does **not** model flows like `find('list')`, `formatResults()`, or `mapReduce()` as entity-preserving, because those can change the result shape in ways the helper should not fake.
