### PR TITLE
Add 'detailed' mode for genericsInParam config

### DIFF
--- a/config/app.example.php
+++ b/config/app.example.php
@@ -21,7 +21,7 @@ return [
 		'arrayAsGenerics' => false, // Enable to have modern generics syntax (recommended) in doc blocks
 		'objectAsGenerics' => false, // Enable to have modern generics syntax (recommended) in doc blocks
 		'assocsAsGenerics' => false, // Enable to have modern generics syntax (NOT recommended yet) in doc blocks
-		'genericsInParam' => false, // Enable to have generics in generated method param doc blocks (NOT recommended yet)
+		'genericsInParam' => false, // true for basic generics, 'detailed' for fully detailed types (array<string, mixed>, ResultSetInterface<int, TEntity>, ...)
 		'concreteEntitiesInParam' => false, // Enable to have specific entities in generated method param doc blocks (NOT recommended)
 		'tableEntityQuery' => false, // Enable to annotate `Table::find()` as returning `SelectQuery<TEntity>` for IDEs
 		// Set to `false` to disable, or string if you have a custom FQCN to be used

--- a/docs/Annotations.md
+++ b/docs/Annotations.md
@@ -109,6 +109,25 @@ If you want the table annotations to also expose the entity-aware `find()` retur
 
 This is intentionally optional, because finder result shapes can still widen beyond plain entities.
 
+#### Detailed param types
+
+The `IdeHelper.genericsInParam` option is tri-state:
+
+- `false` (default): bare `array` params, legacy behavior.
+- `true`: basic generics — `array<mixed>` / `array<string, mixed>` / `iterable<TEntity>`.
+- `'detailed'`: fully detailed types throughout, matching the richer form PHPStan and Psalm understand best.
+
+With `'detailed'`, the generated method annotations look like:
+```php
+ * @method \App\Model\Entity\User newEntity(array<string, mixed> $data, array<string, mixed> $options = [])
+ * @method array<\App\Model\Entity\User> newEntities(array<array<string, mixed>> $data, array<string, mixed> $options = [])
+ * @method \App\Model\Entity\User get(mixed $primaryKey, array<string, mixed>|string $finder = 'all', \Psr\SimpleCache\CacheInterface|string|null $cache = null, \Closure|string|null $cacheKey = null, mixed ...$args)
+ * @method \App\Model\Entity\User findOrCreate(\Cake\ORM\Query\SelectQuery<\App\Model\Entity\User>|callable|array<string, mixed> $search, ?callable $callback = null, array<string, mixed> $options = [])
+ * @method \Cake\Datasource\ResultSetInterface<int, \App\Model\Entity\User>|false saveMany(iterable<\App\Model\Entity\User> $entities, array<string, mixed> $options = [])
+```
+
+Switching the value is additive — existing `true` users keep their current output, and the new `'detailed'` opt-in can be enabled at any time.
+
 ### Entities
 Entities should annotate their properties and relations.
 

--- a/src/Annotator/ModelAnnotator.php
+++ b/src/Annotator/ModelAnnotator.php
@@ -197,13 +197,23 @@ class ModelAnnotator extends AbstractAnnotator {
 				$entityInterface = $fullClassName;
 			}
 
+			$generics = Configure::read('IdeHelper.genericsInParam');
+			$detailed = $generics === 'detailed';
 			$dataType = 'array';
+			$dataListType = 'array';
 			$optionsType = 'array';
 			$iterable = 'iterable';
-			if (Configure::read('IdeHelper.genericsInParam')) {
-				$dataType = 'array<mixed>';
+			$finderType = 'array|string';
+			$findOrCreateSearchType = '\Cake\ORM\Query\SelectQuery|callable|array';
+			if ($generics) {
+				$dataType = $detailed ? 'array<string, mixed>' : 'array<mixed>';
+				$dataListType = $detailed ? 'array<array<string, mixed>>' : 'array<mixed>';
 				$optionsType = 'array<string, mixed>';
 				$iterable = "iterable<{$entityInterface}>";
+			}
+			if ($detailed) {
+				$finderType = 'array<string, mixed>|string';
+				$findOrCreateSearchType = "\Cake\ORM\Query\SelectQuery<{$entityInterface}>|callable|array<string, mixed>";
 			}
 
 			/**
@@ -213,16 +223,16 @@ class ModelAnnotator extends AbstractAnnotator {
 			 */
 			$annotations[] = "@method {$fullClassName} newEmptyEntity()";
 			$annotations[] = "@method {$fullClassName} newEntity({$dataType} \$data, {$optionsType} \$options = [])";
-			$annotations[] = "@method {$fullClassNameCollection} newEntities({$dataType} \$data, {$optionsType} \$options = [])";
+			$annotations[] = "@method {$fullClassNameCollection} newEntities({$dataListType} \$data, {$optionsType} \$options = [])";
 
-			$annotations[] = "@method {$fullClassName} get(mixed \$primaryKey, array|string \$finder = 'all', \Psr\SimpleCache\CacheInterface|string|null \$cache = null, \Closure|string|null \$cacheKey = null, mixed ...\$args)";
+			$annotations[] = "@method {$fullClassName} get(mixed \$primaryKey, {$finderType} \$finder = 'all', \Psr\SimpleCache\CacheInterface|string|null \$cache = null, \Closure|string|null \$cacheKey = null, mixed ...\$args)";
 			if (Configure::read('IdeHelper.tableEntityQuery')) {
 				$annotations[] = "@method \Cake\ORM\Query\SelectQuery<{$fullClassName}> find(string \$type = 'all', mixed ...\$args)";
 			}
-			$annotations[] = "@method {$fullClassName} findOrCreate(\Cake\ORM\Query\SelectQuery|callable|array \$search, ?callable \$callback = null, {$optionsType} \$options = [])";
+			$annotations[] = "@method {$fullClassName} findOrCreate({$findOrCreateSearchType} \$search, ?callable \$callback = null, {$optionsType} \$options = [])";
 
 			$annotations[] = "@method {$fullClassName} patchEntity({$entityInterface} \$entity, {$dataType} \$data, {$optionsType} \$options = [])";
-			$annotations[] = "@method {$fullClassNameCollection} patchEntities({$iterable} \$entities, {$dataType} \$data, {$optionsType} \$options = [])";
+			$annotations[] = "@method {$fullClassNameCollection} patchEntities({$iterable} \$entities, {$dataListType} \$data, {$optionsType} \$options = [])";
 
 			$annotations[] = "@method {$fullClassName}|false save({$entityInterface} \$entity, {$optionsType} \$options = [])";
 			$annotations[] = "@method {$fullClassName} saveOrFail({$entityInterface} \$entity, {$optionsType} \$options = [])";

--- a/src/Utility/GenericString.php
+++ b/src/Utility/GenericString.php
@@ -28,6 +28,9 @@ class GenericString {
 		}
 
 		if ($typeCheck === ResultSetInterface::class) {
+			if (Configure::read('IdeHelper.genericsInParam') === 'detailed') {
+				return sprintf($type . '<int, %s>', $value);
+			}
 			if (Configure::read('IdeHelper.concreteEntitiesInParam')) {
 				return sprintf($type . '<%s>', $value);
 			}

--- a/src/View/Helper/DocBlockHelper.php
+++ b/src/View/Helper/DocBlockHelper.php
@@ -159,28 +159,39 @@ class DocBlockHelper extends BakeDocBlockHelper {
 			$classInterface = $class;
 		}
 
+		$generics = Configure::read('IdeHelper.genericsInParam');
+		$detailed = $generics === 'detailed';
 		$dataType = 'array';
+		$dataListType = 'array';
 		$optionsType = 'array';
 		$itterable = 'iterable';
-		if (Configure::read('IdeHelper.genericsInParam')) {
-			$dataType = 'array<mixed>';
+		$finderType = 'array|string';
+		$findOrCreateSearchType = '\Cake\ORM\Query\SelectQuery|callable|array';
+		if ($generics) {
+			$dataType = $detailed ? 'array<string, mixed>' : 'array<mixed>';
+			$dataListType = $detailed ? 'array<array<string, mixed>>' : 'array<mixed>';
 			$optionsType = 'array<string, mixed>';
 			$itterable = "iterable<{$classInterface}>";
+		}
+		if ($detailed) {
+			$finderType = 'array<string, mixed>|string';
+			$findOrCreateSearchType = "\Cake\ORM\Query\SelectQuery<{$classInterface}>|callable|array<string, mixed>";
 		}
 
 		$annotations[] = "@method {$class} newEmptyEntity()";
 		$annotations[] = "@method {$class} newEntity({$dataType} \$data, {$optionsType} \$options = [])";
-		$annotations[] = "@method {$classes} newEntities({$dataType} \$data, {$optionsType} \$options = [])";
-		$annotations[] = "@method {$class} get(mixed \$primaryKey, array|string \$finder = 'all', \Psr\SimpleCache\CacheInterface|string|null \$cache = null, \Closure|string|null \$cacheKey = null, mixed ...\$args)";
-		$annotations[] = "@method {$class} findOrCreate(\Cake\ORM\Query\SelectQuery|callable|array \$search, ?callable \$callback = null, {$optionsType} \$options = [])";
+		$annotations[] = "@method {$classes} newEntities({$dataListType} \$data, {$optionsType} \$options = [])";
+		$annotations[] = "@method {$class} get(mixed \$primaryKey, {$finderType} \$finder = 'all', \Psr\SimpleCache\CacheInterface|string|null \$cache = null, \Closure|string|null \$cacheKey = null, mixed ...\$args)";
+		$annotations[] = "@method {$class} findOrCreate({$findOrCreateSearchType} \$search, ?callable \$callback = null, {$optionsType} \$options = [])";
 		$annotations[] = "@method {$class} patchEntity({$classInterface} \$entity, {$dataType} \$data, {$optionsType} \$options = [])";
-		$annotations[] = "@method {$classes} patchEntities({$itterable} \$entities, {$dataType} \$data, {$optionsType} \$options = [])";
+		$annotations[] = "@method {$classes} patchEntities({$itterable} \$entities, {$dataListType} \$data, {$optionsType} \$options = [])";
 		$annotations[] = "@method {$class}|false save({$classInterface} \$entity, {$optionsType} \$options = [])";
 		$annotations[] = "@method {$class} saveOrFail({$classInterface} \$entity, {$optionsType} \$options = [])";
-		$annotations[] = "@method {$classes}|\Cake\Datasource\ResultSetInterface<{$class}>|false saveMany({$itterable} \$entities, {$optionsType} \$options = [])";
-		$annotations[] = "@method {$classes}|\Cake\Datasource\ResultSetInterface<{$class}> saveManyOrFail({$itterable} \$entities, {$optionsType} \$options = [])";
-		$annotations[] = "@method {$classes}|\Cake\Datasource\ResultSetInterface<{$class}>|false deleteMany({$itterable} \$entities, {$optionsType} \$options = [])";
-		$annotations[] = "@method {$classes}|\Cake\Datasource\ResultSetInterface<{$class}> deleteManyOrFail({$itterable} \$entities, {$optionsType} \$options = [])";
+		$resultSet = $detailed ? "\Cake\Datasource\ResultSetInterface<int, {$class}>" : "{$classes}|\Cake\Datasource\ResultSetInterface<{$class}>";
+		$annotations[] = "@method {$resultSet}|false saveMany({$itterable} \$entities, {$optionsType} \$options = [])";
+		$annotations[] = "@method {$resultSet} saveManyOrFail({$itterable} \$entities, {$optionsType} \$options = [])";
+		$annotations[] = "@method {$resultSet}|false deleteMany({$itterable} \$entities, {$optionsType} \$options = [])";
+		$annotations[] = "@method {$resultSet} deleteManyOrFail({$itterable} \$entities, {$optionsType} \$options = [])";
 
 		foreach ($behaviors as $behavior => $behaviorData) {
 			$className = App::className($behavior, 'Model/Behavior', 'Behavior');

--- a/tests/TestCase/Annotator/ModelAnnotatorSpecificTest.php
+++ b/tests/TestCase/Annotator/ModelAnnotatorSpecificTest.php
@@ -153,6 +153,33 @@ class ModelAnnotatorSpecificTest extends TestCase {
 	/**
 	 * @return void
 	 */
+	public function testAnnotateSpecificDetailed() {
+		Configure::write('IdeHelper.genericsInParam', 'detailed');
+
+		$annotator = $this->_getAnnotatorMock([]);
+
+		$expectedContent = str_replace("\r\n", "\n", file_get_contents(TEST_FILES . 'Model/Table/Specific/BarBarsDetailedTable.php'));
+		$callback = function($value) use ($expectedContent) {
+			$value = str_replace(["\r\n", "\r"], "\n", $value);
+			if ($value !== $expectedContent) {
+				$this->_displayDiff($expectedContent, $value);
+			}
+
+			return $value === $expectedContent;
+		};
+		$annotator->expects($this->once())->method('storeFile')->with($this->anything(), $this->callback($callback));
+
+		$path = APP . 'Model/Table/Specific/BarBarsTable.php';
+		$annotator->annotate($path);
+
+		$output = $this->out->output();
+
+		$this->assertTextContains('  -> 7 annotations added', $output);
+	}
+
+	/**
+	 * @return void
+	 */
 	public function testAnnotateSpecificExistingMerge() {
 		$annotator = $this->_getAnnotatorMock([]);
 

--- a/tests/test_files/Model/Table/Specific/BarBarsDetailedTable.php
+++ b/tests/test_files/Model/Table/Specific/BarBarsDetailedTable.php
@@ -1,0 +1,45 @@
+<?php
+namespace TestApp\Model\Table;
+
+use Cake\ORM\Table;
+
+/**
+ * @property \Cake\ORM\Association\BelongsTo<\TestApp\Model\Table\FoosTable> $Foos
+ * @property \Cake\ORM\Association\BelongsToMany<\Awesome\Model\Table\HousesTable> $Houses
+ *
+ * @method \TestApp\Model\Entity\BarBar newEmptyEntity()
+ * @method \TestApp\Model\Entity\BarBar newEntity(array<string, mixed> $data, array<string, mixed> $options = [])
+ * @method \TestApp\Model\Entity\BarBar[] newEntities(array<array<string, mixed>> $data, array<string, mixed> $options = [])
+ * @method \TestApp\Model\Entity\BarBar get(mixed $primaryKey, array<string, mixed>|string $finder = 'all', \Psr\SimpleCache\CacheInterface|string|null $cache = null, \Closure|string|null $cacheKey = null, mixed ...$args)
+ * @method \TestApp\Model\Entity\BarBar findOrCreate(\Cake\ORM\Query\SelectQuery<\TestApp\Model\Entity\BarBar>|callable|array<string, mixed> $search, ?callable $callback = null, array<string, mixed> $options = [])
+ * @method \TestApp\Model\Entity\BarBar patchEntity(\TestApp\Model\Entity\BarBar $entity, array<string, mixed> $data, array<string, mixed> $options = [])
+ * @method \TestApp\Model\Entity\BarBar[] patchEntities(iterable<\TestApp\Model\Entity\BarBar> $entities, array<array<string, mixed>> $data, array<string, mixed> $options = [])
+ * @method \TestApp\Model\Entity\BarBar|false save(\TestApp\Model\Entity\BarBar $entity, array<string, mixed> $options = [])
+ * @method \TestApp\Model\Entity\BarBar saveOrFail(\TestApp\Model\Entity\BarBar $entity, array<string, mixed> $options = [])
+ * @method \Cake\Datasource\ResultSetInterface<int, \TestApp\Model\Entity\BarBar>|false saveMany(iterable<\TestApp\Model\Entity\BarBar> $entities, array<string, mixed> $options = [])
+ * @method \Cake\Datasource\ResultSetInterface<int, \TestApp\Model\Entity\BarBar> saveManyOrFail(iterable<\TestApp\Model\Entity\BarBar> $entities, array<string, mixed> $options = [])
+ * @method \Cake\Datasource\ResultSetInterface<int, \TestApp\Model\Entity\BarBar>|false deleteMany(iterable<\TestApp\Model\Entity\BarBar> $entities, array<string, mixed> $options = [])
+ * @method \Cake\Datasource\ResultSetInterface<int, \TestApp\Model\Entity\BarBar> deleteManyOrFail(iterable<\TestApp\Model\Entity\BarBar> $entities, array<string, mixed> $options = [])
+ *
+ * @mixin \Cake\ORM\Behavior\TimestampBehavior
+ * @mixin \MyNamespace\MyPlugin\Model\Behavior\MyBehavior
+ */
+class BarBarsTable extends Table {
+
+	/**
+	 * @param array $config
+	 * @return void
+	 */
+	public function initialize(array $config): void {
+		parent::initialize($config);
+
+		$this->belongsTo('Foos');
+		$this->belongsToMany('Houses', [
+			'className' => 'Awesome.Houses',
+			'through' => 'Awesome.Windows',
+		]);
+		$this->addBehavior('Timestamp');
+		$this->addBehavior('MyNamespace/MyPlugin.My');
+	}
+
+}


### PR DESCRIPTION
## Summary

Adds a new tri-state value for the existing `IdeHelper.genericsInParam` config:

- `false` (default): bare `array` params — unchanged.
- `true`: basic generics (`array<mixed>`, `array<string, mixed>`, `iterable<TEntity>`) — unchanged.
- `'detailed'`: fully detailed param types throughout the Table `@method` annotations.

This is fully backwards compatible — existing `true` and `false` users see no change in output.

## Motivation

When a project hand-authors the richer annotation form (e.g. `array<string, mixed>` on `newEntity`, `ResultSetInterface<int, TEntity>` on `saveMany`), the annotator currently reverts those details on the next run because its own templates emit the less specific form. The new `'detailed'` opt-in lets such projects pin the richer form as the canonical output, so annotator runs stay idempotent.

## What `'detailed'` emits

```php
 * @method \App\Model\Entity\User newEntity(array<string, mixed> \$data, array<string, mixed> \$options = [])
 * @method array<\App\Model\Entity\User> newEntities(array<array<string, mixed>> \$data, array<string, mixed> \$options = [])
 * @method \App\Model\Entity\User get(mixed \$primaryKey, array<string, mixed>|string \$finder = 'all', ...)
 * @method \App\Model\Entity\User findOrCreate(\Cake\ORM\Query\SelectQuery<\App\Model\Entity\User>|callable|array<string, mixed> \$search, ?callable \$callback = null, array<string, mixed> \$options = [])
 * @method \Cake\Datasource\ResultSetInterface<int, \App\Model\Entity\User>|false saveMany(iterable<\App\Model\Entity\User> \$entities, array<string, mixed> \$options = [])
```

Upgrades over the plain `true` behavior:
- `newEntity` / `patchEntity` `\$data` → `array<string, mixed>` (was `array<mixed>`).
- `newEntities` / `patchEntities` `\$data` → `array<array<string, mixed>>`.
- `get()` `\$finder` → `array<string, mixed>|string`.
- `findOrCreate()` `\$search` → `SelectQuery<TEntity>|callable|array<string, mixed>`.
- `saveMany` / `saveManyOrFail` / `deleteMany` / `deleteManyOrFail` return → `ResultSetInterface<int, TEntity>`.

## Changes

- `ModelAnnotator` and `DocBlockHelper` pick up the new mode and branch the relevant types.
- `GenericString::generate()` emits `ResultSetInterface<int, TEntity>` when `genericsInParam === 'detailed'`.
- `config/app.example.php` and `docs/Annotations.md` document the new value.
- New test `testAnnotateSpecificDetailed` plus expected fixture `BarBarsDetailedTable.php` cover the detailed output.