### PR TITLE
Fix detailed mode emitting wider types than expected

### DIFF
--- a/src/Annotator/ModelAnnotator.php
+++ b/src/Annotator/ModelAnnotator.php
@@ -209,11 +209,13 @@ class ModelAnnotator extends AbstractAnnotator {
 				$dataType = $detailed ? 'array<string, mixed>' : 'array<mixed>';
 				$dataListType = $detailed ? 'array<array<string, mixed>>' : 'array<mixed>';
 				$optionsType = 'array<string, mixed>';
-				$iterable = "iterable<{$entityInterface}>";
+				// Detailed mode always narrows iterables to the concrete entity — a UsersTable only ever handles User entities.
+				$iterableEntity = $detailed ? $fullClassName : $entityInterface;
+				$iterable = "iterable<{$iterableEntity}>";
 			}
 			if ($detailed) {
 				$finderType = 'array<string, mixed>|string';
-				$findOrCreateSearchType = "\Cake\ORM\Query\SelectQuery<{$entityInterface}>|callable|array<string, mixed>";
+				$findOrCreateSearchType = "\Cake\ORM\Query\SelectQuery<{$fullClassName}>|callable|array<string, mixed>";
 			}
 
 			/**

--- a/src/Utility/GenericString.php
+++ b/src/Utility/GenericString.php
@@ -14,6 +14,17 @@ class GenericString {
 	 * @return string
 	 */
 	public static function generate(string $value, ?string $type = null): string {
+		if ($type !== null && str_starts_with($type, '\\')) {
+			$typeCheck = substr($type, 1);
+		} else {
+			$typeCheck = $type;
+		}
+
+		$detailed = Configure::read('IdeHelper.genericsInParam') === 'detailed';
+		if ($detailed && $typeCheck === ResultSetInterface::class) {
+			return sprintf($type . '<int, %s>', $value);
+		}
+
 		if (Configure::read('IdeHelper.arrayAsGenerics') && ($type === null || in_array($type, ['array', 'iterable'], true))) {
 			return sprintf(($type ?: 'array' ) . '<%s>', $value);
 		}
@@ -21,16 +32,7 @@ class GenericString {
 			return sprintf($type . '<%s>', $value);
 		}
 
-		if ($type !== null && str_starts_with($type, '\\')) {
-			$typeCheck = substr($type, 1);
-		} else {
-			$typeCheck = $type;
-		}
-
 		if ($typeCheck === ResultSetInterface::class) {
-			if (Configure::read('IdeHelper.genericsInParam') === 'detailed') {
-				return sprintf($type . '<int, %s>', $value);
-			}
 			if (Configure::read('IdeHelper.concreteEntitiesInParam')) {
 				return sprintf($type . '<%s>', $value);
 			}

--- a/src/View/Helper/DocBlockHelper.php
+++ b/src/View/Helper/DocBlockHelper.php
@@ -171,11 +171,12 @@ class DocBlockHelper extends BakeDocBlockHelper {
 			$dataType = $detailed ? 'array<string, mixed>' : 'array<mixed>';
 			$dataListType = $detailed ? 'array<array<string, mixed>>' : 'array<mixed>';
 			$optionsType = 'array<string, mixed>';
-			$itterable = "iterable<{$classInterface}>";
+			$iterableEntity = $detailed ? $class : $classInterface;
+			$itterable = "iterable<{$iterableEntity}>";
 		}
 		if ($detailed) {
 			$finderType = 'array<string, mixed>|string';
-			$findOrCreateSearchType = "\Cake\ORM\Query\SelectQuery<{$classInterface}>|callable|array<string, mixed>";
+			$findOrCreateSearchType = "\Cake\ORM\Query\SelectQuery<{$class}>|callable|array<string, mixed>";
 		}
 
 		$annotations[] = "@method {$class} newEmptyEntity()";

--- a/tests/TestCase/Annotator/ModelAnnotatorTest.php
+++ b/tests/TestCase/Annotator/ModelAnnotatorTest.php
@@ -291,6 +291,38 @@ class ModelAnnotatorTest extends TestCase {
 	/**
 	 * @return void
 	 */
+	public function testAnnotateDetailed() {
+		Configure::write('IdeHelper.genericsInParam', 'detailed');
+		Configure::write('IdeHelper.arrayAsGenerics', true);
+		Configure::write('IdeHelper.objectAsGenerics', true);
+
+		$annotator = $this->_getAnnotatorMock([]);
+
+		$expectedContent = str_replace("\r\n", "\n", file_get_contents(TEST_FILES . 'Model/Table/BarBarsDetailedTable.php'));
+		$callback = function ($value) use ($expectedContent) {
+			$value = str_replace(["\r\n", "\r"], "\n", $value);
+			if ($value !== $expectedContent) {
+				$this->_displayDiff($expectedContent, $value);
+			}
+
+			return $value === $expectedContent;
+		};
+		$annotator->expects($this->once())->method('storeFile')->with($this->anything(), $this->callback($callback));
+
+		$path = APP . 'Model/Table/BarBarsTable.php';
+		$annotator->annotate($path);
+
+		Configure::delete('IdeHelper.genericsInParam');
+		Configure::delete('IdeHelper.arrayAsGenerics');
+		Configure::delete('IdeHelper.objectAsGenerics');
+
+		$output = $this->out->output();
+		$this->assertTextContains('  -> 18 annotations added', $output);
+	}
+
+	/**
+	 * @return void
+	 */
 	public function testAnnotateWithEntityFindQuery() {
 		Configure::write('IdeHelper.tableEntityQuery', true);
 

--- a/tests/test_files/Model/Table/BarBarsDetailedTable.php
+++ b/tests/test_files/Model/Table/BarBarsDetailedTable.php
@@ -1,0 +1,47 @@
+<?php
+namespace TestApp\Model\Table;
+
+use Cake\ORM\Table;
+
+/**
+ * @property \Cake\ORM\Association\BelongsTo<\TestApp\Model\Table\FoosTable> $Foos
+ * @property \Cake\ORM\Association\BelongsToMany<\Awesome\Model\Table\HousesTable> $Houses
+ *
+ * @method \TestApp\Model\Entity\BarBar newEmptyEntity()
+ * @method \TestApp\Model\Entity\BarBar newEntity(array<string, mixed> $data, array<string, mixed> $options = [])
+ * @method array<\TestApp\Model\Entity\BarBar> newEntities(array<array<string, mixed>> $data, array<string, mixed> $options = [])
+ * @method \TestApp\Model\Entity\BarBar get(mixed $primaryKey, array<string, mixed>|string $finder = 'all', \Psr\SimpleCache\CacheInterface|string|null $cache = null, \Closure|string|null $cacheKey = null, mixed ...$args)
+ * @method \TestApp\Model\Entity\BarBar findOrCreate(\Cake\ORM\Query\SelectQuery<\TestApp\Model\Entity\BarBar>|callable|array<string, mixed> $search, ?callable $callback = null, array<string, mixed> $options = [])
+ * @method \TestApp\Model\Entity\BarBar patchEntity(\Cake\Datasource\EntityInterface $entity, array<string, mixed> $data, array<string, mixed> $options = [])
+ * @method array<\TestApp\Model\Entity\BarBar> patchEntities(iterable<\TestApp\Model\Entity\BarBar> $entities, array<array<string, mixed>> $data, array<string, mixed> $options = [])
+ * @method \TestApp\Model\Entity\BarBar|false save(\Cake\Datasource\EntityInterface $entity, array<string, mixed> $options = [])
+ * @method \TestApp\Model\Entity\BarBar saveOrFail(\Cake\Datasource\EntityInterface $entity, array<string, mixed> $options = [])
+ * @method \Cake\Datasource\ResultSetInterface<int, \TestApp\Model\Entity\BarBar>|false saveMany(iterable<\TestApp\Model\Entity\BarBar> $entities, array<string, mixed> $options = [])
+ * @method \Cake\Datasource\ResultSetInterface<int, \TestApp\Model\Entity\BarBar> saveManyOrFail(iterable<\TestApp\Model\Entity\BarBar> $entities, array<string, mixed> $options = [])
+ * @method \Cake\Datasource\ResultSetInterface<int, \TestApp\Model\Entity\BarBar>|false deleteMany(iterable<\TestApp\Model\Entity\BarBar> $entities, array<string, mixed> $options = [])
+ * @method \Cake\Datasource\ResultSetInterface<int, \TestApp\Model\Entity\BarBar> deleteManyOrFail(iterable<\TestApp\Model\Entity\BarBar> $entities, array<string, mixed> $options = [])
+ *
+ * @mixin \Cake\ORM\Behavior\TimestampBehavior
+ * @mixin \MyNamespace\MyPlugin\Model\Behavior\MyBehavior
+ *
+ * @extends \Cake\ORM\Table<array{My: \MyNamespace\MyPlugin\Model\Behavior\MyBehavior, Timestamp: \Cake\ORM\Behavior\TimestampBehavior}>
+ */
+class BarBarsTable extends Table {
+
+	/**
+	 * @param array $config
+	 * @return void
+	 */
+	public function initialize(array $config): void {
+		parent::initialize($config);
+
+		$this->belongsTo('Foos');
+		$this->belongsToMany('Houses', [
+			'className' => 'Awesome.Houses',
+			'through' => 'Awesome.Windows',
+		]);
+		$this->addBehavior('Timestamp');
+		$this->addBehavior('MyNamespace/MyPlugin.My');
+	}
+
+}


### PR DESCRIPTION
Follow-up to #428. Two real-world cases still produced wider annotations than the `'detailed'` mode promised:

## 1. `ResultSetInterface<TEntity>` instead of `ResultSetInterface<int, TEntity>`

When `IdeHelper.objectAsGenerics` was enabled, `GenericString::generate()` returned via the `objectAsGenerics` branch **before** reaching the detailed branch, emitting `ResultSetInterface<\Entity>` and dropping the `int` key. PHPStan/Psalm model `ResultSetInterface` with two template params (`TKey`, `TValue`), so a single-arg form binds the entity to `TKey`, which is wrong.

The detailed-mode `ResultSetInterface<int, TEntity>` check now runs first so it takes precedence over the `objectAsGenerics` early return.

## 2. `iterable<EntityInterface>` and `SelectQuery<EntityInterface>` instead of concrete entity

Without `IdeHelper.concreteEntitiesInParam`, detailed mode still bound `iterable<>` and `findOrCreate()`'s `SelectQuery<>` to `EntityInterface` (the parent `Table` signature). But a `UsersTable::saveMany()` only ever operates on `User` entities — the wider type throws away information that static analyzers and IDEs can use.

Detailed mode now always narrows the following to the concrete entity class regardless of `concreteEntitiesInParam`:

- `iterable<TEntity>` on `patchEntities` / `saveMany` / `saveManyOrFail` / `deleteMany` / `deleteManyOrFail`
- `SelectQuery<TEntity>` inside `findOrCreate()`'s search param

Single-entity params (`patchEntity(EntityInterface \$entity, ...)`, `save()`, `saveOrFail()`) still respect `concreteEntitiesInParam`, since those slots are actually defined by the parent `Table` contract.

## Test coverage

New `testAnnotateDetailed` in `ModelAnnotatorTest` exercises detailed mode with `objectAsGenerics` + `arrayAsGenerics` and **without** `concreteEntitiesInParam` — the exact combo that uncovered the gaps. New expected fixture `BarBarsDetailedTable.php` pins the correct output.