### PR TITLE
Fix annotation duplication when type contains spaces (generics)

### DIFF
--- a/src/Annotation/AnnotationFactory.php
+++ b/src/Annotation/AnnotationFactory.php
@@ -83,12 +83,38 @@ class AnnotationFactory {
 			return static::create(ExtendsAnnotation::TAG, $string);
 		}
 
-		preg_match('/^(@property|@property-read|@method|@var|@param) ([^ ]+) (.+)$/', $annotation, $matches);
-		if (!$matches) {
-			return null;
+		// Split `@tag <type> <rest>`: the type may contain spaces inside generic
+		// brackets (e.g. `Foo<int, Bar>`), so naive `[^ ]+` would cut it short.
+		// Walk the type char-by-char, tracking `<>` depth, and stop at the first
+		// top-level space.
+		if (preg_match('/^(@property|@property-read|@method|@var|@param) (.+)$/', $annotation, $matches)) {
+			$tag = $matches[1];
+			$rest = $matches[2];
+			$depth = 0;
+			$len = strlen($rest);
+			$split = -1;
+			for ($i = 0; $i < $len; $i++) {
+				$c = $rest[$i];
+				if ($c === '<') {
+					$depth++;
+				} elseif ($c === '>') {
+					$depth = max(0, $depth - 1);
+				} elseif ($c === ' ' && $depth === 0) {
+					$split = $i;
+
+					break;
+				}
+			}
+			if ($split <= 0) {
+				return null;
+			}
+			$type = substr($rest, 0, $split);
+			$content = substr($rest, $split + 1);
+
+			return static::create($tag, $type, $content);
 		}
 
-		return static::create($matches[1], $matches[2], $matches[3]);
+		return null;
 	}
 
 	/**

--- a/tests/TestCase/Annotation/AnnotationFactoryTest.php
+++ b/tests/TestCase/Annotation/AnnotationFactoryTest.php
@@ -115,4 +115,26 @@ class AnnotationFactoryTest extends TestCase {
 		$this->assertSame('!', $annotation->getDescription());
 	}
 
+	/**
+	 * Regression: types with spaces inside generic brackets (e.g. `ResultSetInterface<int, \Entity>`)
+	 * used to be split at the first space, putting part of the type into the method name.
+	 * That caused `matches()` to fail and annotations to be duplicated on subsequent runs
+	 * when `genericsInParam: 'detailed'` was enabled.
+	 *
+	 * @return void
+	 */
+	public function testCreateFromStringWithSpaceInsideGenericType() {
+		/** @var \IdeHelper\Annotation\MethodAnnotation $annotation */
+		$annotation = AnnotationFactory::createFromString('@method \Cake\Datasource\ResultSetInterface<int, \Foo\Model\Entity\Bar>|false saveMany(iterable<\Foo\Model\Entity\Bar> $entities, array<string, mixed> $options = [])');
+		$this->assertInstanceOf(MethodAnnotation::class, $annotation);
+		$this->assertSame('\Cake\Datasource\ResultSetInterface<int, \Foo\Model\Entity\Bar>|false', $annotation->getType());
+		$this->assertSame('saveMany(iterable<\Foo\Model\Entity\Bar> $entities, array<string, mixed> $options = [])', $annotation->getMethod());
+
+		/** @var \IdeHelper\Annotation\PropertyAnnotation $annotation */
+		$annotation = AnnotationFactory::createFromString('@property \Cake\ORM\Association\BelongsTo<\Foo\Model\Table\BarsTable> $Bar');
+		$this->assertInstanceOf(PropertyAnnotation::class, $annotation);
+		$this->assertSame('\Cake\ORM\Association\BelongsTo<\Foo\Model\Table\BarsTable>', $annotation->getType());
+		$this->assertSame('$Bar', $annotation->getProperty());
+	}
+
 }


### PR DESCRIPTION
## Summary

`AnnotationFactory::createFromString()` split `@method` / `@property` lines using a greedy `[^ ]+` regex for the type. That fails on types whose generic parameters contain spaces, e.g. `\Cake\Datasource\ResultSetInterface<int, \Foo\Entity>` — the type was truncated at the first space and the rest was jammed into the method half of the annotation.

Downstream effect: `MethodAnnotation::matches()` compares method names, but the broken parse left strings like `\Foo\Entity>|false saveMany(...)` in the method field, so name comparison failed. On subsequent annotator runs the "existing" entry was never matched, `needsReplacing()` returned `null`, and the generated line was appended as new while the stale one stayed. Users enabling `IdeHelper.genericsInParam => 'detailed'` on a table that already had `saveMany` / `saveManyOrFail` / `deleteMany` / `deleteManyOrFail` annotations would end up with duplicated `@method` lines.

Replaced the regex with a small depth-tracking scanner that walks the captured tail, tracking `<>` depth, and splits on the first top-level space. Covers `@method`, `@property`, `@property-read`, `@var`, and `@param`.

## Repro

1. Start with a table that has:
   ```
   @method \Cake\Datasource\ResultSetInterface<\App\Model\Entity\Foo>|false saveMany(iterable $entities, array $options = [])
   ```
2. Set `IdeHelper.genericsInParam => 'detailed'`
3. Run `bin/cake annotate models`
4. Without this fix: a second `@method ... saveMany(iterable<\App\Model\Entity\Foo> ...)` is appended.
5. With this fix: the existing line is replaced in-place.

## Test added

`AnnotationFactoryTest::testCreateFromStringWithSpaceInsideGenericType` — asserts that types with spaces inside generic brackets are preserved whole and the method/property side stays intact.