### PR TITLE
Support new Cake\ORM\Table TEntity template param (CakePHP 5.4)

### DIFF
--- a/src/Annotator/ModelAnnotator.php
+++ b/src/Annotator/ModelAnnotator.php
@@ -140,7 +140,7 @@ class ModelAnnotator extends AbstractAnnotator {
 		$entityName = substr($entityClassName, strrpos($entityClassName, '\\') + 1);
 
 		$parentClass = (string)get_parent_class($table);
-		$resTable = $this->table($path, $entityName, $associations, $behaviors, $parentClass);
+		$resTable = $this->table($path, $entityName, $associations, $behaviors, $parentClass, $entityClassName);
 		$resEntity = $this->entity($entityClassName, $entityName, $schema, $tableAssociations);
 
 		return $resTable || $resEntity;
@@ -152,16 +152,17 @@ class ModelAnnotator extends AbstractAnnotator {
 	 * @param array<string, mixed> $associations
 	 * @param array<string> $behaviors
 	 * @param string $parentClass
+	 * @param string $entityClass
 	 * @return bool
 	 */
-	protected function table(string $path, string $entityName, array $associations, array $behaviors, string $parentClass): bool {
+	protected function table(string $path, string $entityName, array $associations, array $behaviors, string $parentClass, string $entityClass = ''): bool {
 		$content = file_get_contents($path);
 		if ($content === false) {
 			throw new RuntimeException('Cannot read file');
 		}
 
 		$behaviors += $this->parseLoadedBehaviors($content);
-		$annotations = $this->buildAnnotations($associations, $entityName, $behaviors, $parentClass);
+		$annotations = $this->buildAnnotations($associations, $entityName, $behaviors, $parentClass, $entityClass);
 
 		return $this->annotateContent($path, $content, $annotations);
 	}
@@ -171,9 +172,10 @@ class ModelAnnotator extends AbstractAnnotator {
 	 * @param string $entity
 	 * @param array<string> $behaviors
 	 * @param string $parentClass
+	 * @param string $entityClass
 	 * @return array<\IdeHelper\Annotation\AbstractAnnotation>
 	 */
-	protected function buildAnnotations(array $associations, string $entity, array $behaviors, string $parentClass): array {
+	protected function buildAnnotations(array $associations, string $entity, array $behaviors, string $parentClass, string $entityClass = ''): array {
 		$namespace = $this->getConfig(static::CONFIG_NAMESPACE);
 		$annotations = [];
 		foreach ($associations as $type => $assocs) {
@@ -258,7 +260,7 @@ class ModelAnnotator extends AbstractAnnotator {
 		}
 
 		$result = $this->addBehaviorMixins($result, $behaviors);
-		$result = $this->addBehaviorExtends($result, $behaviors, $parentClass);
+		$result = $this->addBehaviorExtends($result, $behaviors, $parentClass, $entityClass);
 
 		return $result;
 	}
@@ -484,9 +486,10 @@ class ModelAnnotator extends AbstractAnnotator {
 	 * @param array<\IdeHelper\Annotation\AbstractAnnotation> $result
 	 * @param array<string> $behaviors
 	 * @param string $parentClass
+	 * @param string $entityClass
 	 * @return array<\IdeHelper\Annotation\AbstractAnnotation>
 	 */
-	protected function addBehaviorExtends(array $result, array $behaviors, string $parentClass): array {
+	protected function addBehaviorExtends(array $result, array $behaviors, string $parentClass, string $entityClass = ''): array {
 		if (!in_array(static::BEHAVIOR_EXTENDS, $this->_config[static::TABLE_BEHAVIORS], true)) {
 			return $result;
 		}
@@ -504,7 +507,9 @@ class ModelAnnotator extends AbstractAnnotator {
 			$list[] = $name . ': \\' . $className;
 		}
 
-		if (!$list) {
+		$entityTemplate = $this->supportsEntityTemplate() && $entityClass ? ', \\' . ltrim($entityClass, '\\') : '';
+
+		if (!$list && !$entityTemplate) {
 			return $result;
 		}
 
@@ -515,9 +520,18 @@ class ModelAnnotator extends AbstractAnnotator {
 		if (!$parentClass) {
 			$parentClass = '\\Cake\\ORM\\Table';
 		}
-		$result[] = AnnotationFactory::createOrFail(ExtendsAnnotation::TAG, '\\' . $parentClass . '<array{' . $list . '}>');
+		$result[] = AnnotationFactory::createOrFail(ExtendsAnnotation::TAG, '\\' . $parentClass . '<array{' . $list . '}' . $entityTemplate . '>');
 
 		return $result;
+	}
+
+	/**
+	 * Whether `\Cake\ORM\Table` declares a second `TEntity` template parameter (CakePHP 5.4+).
+	 *
+	 * @return bool
+	 */
+	protected function supportsEntityTemplate(): bool {
+		return version_compare(Configure::version(), '5.4.0', '>=');
 	}
 
 }

--- a/tests/TestCase/Annotator/ModelAnnotatorTest.php
+++ b/tests/TestCase/Annotator/ModelAnnotatorTest.php
@@ -128,6 +128,26 @@ class ModelAnnotatorTest extends TestCase {
 	}
 
 	/**
+	 * @param array $params
+	 * @return \IdeHelper\Annotator\ModelAnnotator|\PHPUnit\Framework\MockObject\MockObject
+	 */
+	protected function _getEntityTemplateAnnotatorMock(array $params): ModelAnnotator {
+		$params += [
+			AbstractAnnotator::CONFIG_REMOVE => true,
+			AbstractAnnotator::CONFIG_DRY_RUN => true,
+			AbstractAnnotator::CONFIG_VERBOSE => true,
+		];
+
+		$mock = $this->getMockBuilder(ModelAnnotator::class)
+			->onlyMethods(['storeFile', 'supportsEntityTemplate'])
+			->setConstructorArgs([$this->io, $params])
+			->getMock();
+		$mock->method('supportsEntityTemplate')->willReturn(true);
+
+		return $mock;
+	}
+
+	/**
 	 * @return void
 	 */
 	public function testAnnotate() {
@@ -350,6 +370,30 @@ class ModelAnnotatorTest extends TestCase {
 
 		$output = $this->out->output();
 		$this->assertTextContains('  -> 19 annotations added', $output);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testAnnotateWithEntityTemplate() {
+		$annotator = $this->_getEntityTemplateAnnotatorMock([]);
+
+		$expectedContent = str_replace("\r\n", "\n", file_get_contents(TEST_FILES . 'Model/Table/BarBarsEntityTemplateTable.php'));
+		$callback = function ($value) use ($expectedContent) {
+			$value = str_replace(["\r\n", "\r"], "\n", $value);
+			if ($value !== $expectedContent) {
+				$this->_displayDiff($expectedContent, $value);
+			}
+
+			return $value === $expectedContent;
+		};
+		$annotator->expects($this->once())->method('storeFile')->with($this->anything(), $this->callback($callback));
+
+		$path = APP . 'Model/Table/BarBarsTable.php';
+		$annotator->annotate($path);
+
+		$output = $this->out->output();
+		$this->assertTextContains('  -> 18 annotations added', $output);
 	}
 
 }

--- a/tests/test_files/Model/Table/BarBarsEntityTemplateTable.php
+++ b/tests/test_files/Model/Table/BarBarsEntityTemplateTable.php
@@ -1,0 +1,47 @@
+<?php
+namespace TestApp\Model\Table;
+
+use Cake\ORM\Table;
+
+/**
+ * @property \Cake\ORM\Association\BelongsTo<\TestApp\Model\Table\FoosTable> $Foos
+ * @property \Cake\ORM\Association\BelongsToMany<\Awesome\Model\Table\HousesTable> $Houses
+ *
+ * @method \TestApp\Model\Entity\BarBar newEmptyEntity()
+ * @method \TestApp\Model\Entity\BarBar newEntity(array $data, array $options = [])
+ * @method \TestApp\Model\Entity\BarBar[] newEntities(array $data, array $options = [])
+ * @method \TestApp\Model\Entity\BarBar get(mixed $primaryKey, array|string $finder = 'all', \Psr\SimpleCache\CacheInterface|string|null $cache = null, \Closure|string|null $cacheKey = null, mixed ...$args)
+ * @method \TestApp\Model\Entity\BarBar findOrCreate(\Cake\ORM\Query\SelectQuery|callable|array $search, ?callable $callback = null, array $options = [])
+ * @method \TestApp\Model\Entity\BarBar patchEntity(\Cake\Datasource\EntityInterface $entity, array $data, array $options = [])
+ * @method \TestApp\Model\Entity\BarBar[] patchEntities(iterable $entities, array $data, array $options = [])
+ * @method \TestApp\Model\Entity\BarBar|false save(\Cake\Datasource\EntityInterface $entity, array $options = [])
+ * @method \TestApp\Model\Entity\BarBar saveOrFail(\Cake\Datasource\EntityInterface $entity, array $options = [])
+ * @method \TestApp\Model\Entity\BarBar[]|\Cake\Datasource\ResultSetInterface<\TestApp\Model\Entity\BarBar>|false saveMany(iterable $entities, array $options = [])
+ * @method \TestApp\Model\Entity\BarBar[]|\Cake\Datasource\ResultSetInterface<\TestApp\Model\Entity\BarBar> saveManyOrFail(iterable $entities, array $options = [])
+ * @method \TestApp\Model\Entity\BarBar[]|\Cake\Datasource\ResultSetInterface<\TestApp\Model\Entity\BarBar>|false deleteMany(iterable $entities, array $options = [])
+ * @method \TestApp\Model\Entity\BarBar[]|\Cake\Datasource\ResultSetInterface<\TestApp\Model\Entity\BarBar> deleteManyOrFail(iterable $entities, array $options = [])
+ *
+ * @mixin \Cake\ORM\Behavior\TimestampBehavior
+ * @mixin \MyNamespace\MyPlugin\Model\Behavior\MyBehavior
+ *
+ * @extends \Cake\ORM\Table<array{My: \MyNamespace\MyPlugin\Model\Behavior\MyBehavior, Timestamp: \Cake\ORM\Behavior\TimestampBehavior}, \TestApp\Model\Entity\BarBar>
+ */
+class BarBarsTable extends Table {
+
+	/**
+	 * @param array $config
+	 * @return void
+	 */
+	public function initialize(array $config): void {
+		parent::initialize($config);
+
+		$this->belongsTo('Foos');
+		$this->belongsToMany('Houses', [
+			'className' => 'Awesome.Houses',
+			'through' => 'Awesome.Windows',
+		]);
+		$this->addBehavior('Timestamp');
+		$this->addBehavior('MyNamespace/MyPlugin.My');
+	}
+
+}


### PR DESCRIPTION
Closes #431.

CakePHP 5.4 adds a second template parameter to `Cake\ORM\Table`:

```
@template TBehaviors of array<string, \Cake\ORM\Behavior> = array{}
@template TEntity of \Cake\Datasource\EntityInterface = \Cake\Datasource\EntityInterface
```

Without the second arg, Psalm v7 reports `MissingTemplateParam` on every table class.

## Changes

- `ModelAnnotator::addBehaviorExtends()` now appends the entity FQCN as a second template arg when the running CakePHP version is `>= 5.4.0`.
- The annotation is also emitted for tables without behaviors on 5.4+ (so plain tables get the required template params), while the pre-5.4 behavior — emit only if behaviors exist, single arg — is preserved.
- Detection lives in a small protected `supportsEntityTemplate()` method using `version_compare(Configure::version(), '5.4.0', '>=')`. No new config key, no `composer.json` bump.
- The entity FQCN is plumbed through `table()` -> `buildAnnotations()` -> `addBehaviorExtends()` from `Table::getEntityClass()`. New parameters are nullable / default to `''` so subclasses overriding these protected methods aren't broken.

## Output examples

Before (any version):
```
@extends \Cake\ORM\Table<array{Timestamp: \Cake\ORM\Behavior\TimestampBehavior}>
```

After, on CakePHP 5.4+:
```
@extends \Cake\ORM\Table<array{Timestamp: \Cake\ORM\Behavior\TimestampBehavior}, \App\Model\Entity\Vpn>
```

Plain table without behaviors on 5.4+:
```
@extends \Cake\ORM\Table<array{}, \App\Model\Entity\Vpn>
```

On CakePHP < 5.4 the output is unchanged.

## Tests

- Added `testAnnotateWithEntityTemplate` which mocks `supportsEntityTemplate()` to true and asserts the new two-arg output via a new fixture `tests/test_files/Model/Table/BarBarsEntityTemplateTable.php`.
- All 273 existing tests still pass on the installed CakePHP 5.3.x; PHPStan and PHPCS clean.

## Notes / open questions

- For tables extending a custom abstract (e.g. `App\Model\Table\AbstractTable`), the second arg is appended unconditionally on 5.4+. The user's abstract is expected to template both `TBehaviors` and `TEntity` accordingly. Happy to gate this to `\Cake\ORM\Table` only if you'd prefer.
- If `tableBehaviors` is set to disable `BEHAVIOR_EXTENDS` (e.g. `'mixin'`-only), no `@extends` is emitted at all, even on 5.4+. That preserves the explicit user opt-out but does mean Psalm errors will remain in that mode.