### PR TITLE
Fix PHPStan undefined variable in addNewInlineDocBlock

### DIFF
--- a/src/Annotator/ClassAnnotatorTask/AbstractClassAnnotatorTask.php
+++ b/src/Annotator/ClassAnnotatorTask/AbstractClassAnnotatorTask.php
@@ -151,18 +151,12 @@ abstract class AbstractClassAnnotatorTask extends AbstractAnnotator {
 	protected function addNewInlineDocBlock(File $file, int $index, array $annotations) {
 		$tokens = $file->getTokens();
 
-		foreach ($annotations as $key => $annotation) {
-			if (is_string($annotation)) {
-				continue;
-			}
-			$annotations[$key] = (string)$annotation;
-		}
-
 		if (count($annotations) !== 1) {
 			throw new RuntimeException('Cannot work with annotation count != 1 right now');
 		}
 
-		$annotationString = '/** ' . $annotation . ' */';
+		$annotation = reset($annotations);
+		$annotationString = '/** ' . (string)$annotation . ' */';
 		if (PHP_EOL !== "\n") {
 			$annotationString = str_replace("\n", PHP_EOL, $annotationString);
 		}


### PR DESCRIPTION
## Summary

The CI [job](https://github.com/dereuromark/cakephp-ide-helper/actions/runs/25143461860/job/73698180579) started failing because PHPStan 2.1.54 became stricter about loop-variable lifetime and now flags `src/Annotator/ClassAnnotatorTask/AbstractClassAnnotatorTask.php:165`:

```
Variable \$annotation might not be defined.
```

`addNewInlineDocBlock()` was looping over `\$annotations`, casting each element to string in place, and then re-using the loop variable `\$annotation` after the loop body. If the array was empty the loop never ran, leaving `\$annotation` undefined. The existing `count(\$annotations) !== 1` guard protected this at runtime, but PHPStan can't reason about the loop variable's lifetime.

This restructures the method to:

- run the count guard first,
- pull the single value out via `reset(\$annotations)`,
- cast that value to string at the point of use.

The pre-loop string conversion was unnecessary — the array itself was never read again, only its single value, so dropping the cast loop is a strict simplification.

Behavior is unchanged (still throws on count != 1, still emits `/** ... */`).