### PR TITLE
Add PathAwareClassAnnotatorTaskInterface for extra scan paths

### DIFF
--- a/docs/Annotations.md
+++ b/docs/Annotations.md
@@ -401,6 +401,43 @@ The key `'MyClassAnnotatorTask'` can be any string.
 You want more examples?
 - [Custom Class Annotators](Annotations/Class.md)
 
+#### Targeting custom directories
+
+By default `bin/cake annotate classes` walks `src/` (app + plugin classpaths) and
+`tests/TestCase/` (when `TestClassAnnotatorTask` is registered). A custom task whose
+subjects live elsewhere — for example test-fixture factories under `tests/Factory/`,
+scenario classes, generated stubs — can opt into having those directories walked
+by also implementing `PathAwareClassAnnotatorTaskInterface`:
+
+```php
+namespace App\Annotator\ClassAnnotatorTask;
+
+use IdeHelper\Annotator\ClassAnnotatorTask\AbstractClassAnnotatorTask;
+use IdeHelper\Annotator\ClassAnnotatorTask\PathAwareClassAnnotatorTaskInterface;
+
+class MyClassAnnotatorTask extends AbstractClassAnnotatorTask implements PathAwareClassAnnotatorTaskInterface {
+
+    /**
+     * @return array<string>
+     */
+    public static function scanPaths(): array {
+        return ['tests/Factory/'];
+    }
+
+    public function shouldRun(string $path, string $content): bool { /* ... */ }
+    public function annotate(string $path): bool { /* ... */ }
+
+}
+```
+
+Paths are project-root relative for app context, plugin-root relative when run with `-p`.
+They are walked recursively. Paths that do not exist on disk are silently skipped, and a
+path declared by multiple tasks is walked only once.
+
+The interface is optional and additive — existing tasks that do not implement it behave
+unchanged. The feature is opt-in: a path-aware task is only consulted when it is registered
+in `IdeHelper.classAnnotatorTasks`.
+
 #### Replacing native tasks
 Using associative arrays you can even exchange any native task with your own implementation:
 ```php

--- a/src/Annotator/ClassAnnotatorTask/PathAwareClassAnnotatorTaskInterface.php
+++ b/src/Annotator/ClassAnnotatorTask/PathAwareClassAnnotatorTaskInterface.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace IdeHelper\Annotator\ClassAnnotatorTask;
+
+/**
+ * Optional interface that a class annotator task can implement to declare
+ * extra directories that the `bin/cake annotate classes` command should walk
+ * in addition to its default `src/` (app + plugin classpaths) and
+ * `tests/TestCase/` scans.
+ *
+ * The intended use is third-party packages whose subjects live outside the
+ * conventional source tree — e.g. a test-fixture factory plugin whose
+ * subclasses live under `tests/Factory/`. By declaring the path on the
+ * task itself, the package does not need to ship its own bake/annotate
+ * subcommand: registering the task in `IdeHelper.classAnnotatorTasks` is
+ * enough for the existing command to reach the relevant files.
+ *
+ * `scanPaths()` is `static` so the command can query a task's paths
+ * without first instantiating it with an `Io` and per-file content. Paths
+ * are project-root relative for app context, and plugin-root relative
+ * when the command is run with `-p <plugin>` (or `-p all`). Paths are
+ * walked recursively. Trailing slashes are optional.
+ */
+interface PathAwareClassAnnotatorTaskInterface extends ClassAnnotatorTaskInterface {
+
+	/**
+	 * @return array<string>
+	 */
+	public static function scanPaths(): array;
+
+}

--- a/src/Command/Annotate/ClassesCommand.php
+++ b/src/Command/Annotate/ClassesCommand.php
@@ -7,6 +7,7 @@ use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
 use Cake\Core\Configure;
 use IdeHelper\Annotator\ClassAnnotator;
+use IdeHelper\Annotator\ClassAnnotatorTask\PathAwareClassAnnotatorTaskInterface;
 use IdeHelper\Annotator\ClassAnnotatorTask\TestClassAnnotatorTask;
 use IdeHelper\Annotator\ClassAnnotatorTaskCollection;
 use IdeHelper\Command\AnnotateCommand;
@@ -52,31 +53,69 @@ class ClassesCommand extends AnnotateCommand {
 
 		$collection = new ClassAnnotatorTaskCollection();
 		$tasks = $collection->defaultTasks();
-		if (!in_array(TestClassAnnotatorTask::class, $tasks, true)) {
-			return static::CODE_SUCCESS;
-		}
 
-		$paths = $this->getPaths();
-		foreach ($paths as $plugin => $pluginPaths) {
-			$this->setPlugin($plugin);
-			foreach ($pluginPaths as $path) {
-				$path .= 'tests' . DS . 'TestCase' . DS;
-				if (!is_dir($path)) {
-					continue;
-				}
+		if (in_array(TestClassAnnotatorTask::class, $tasks, true)) {
+			$paths = $this->getPaths();
+			foreach ($paths as $plugin => $pluginPaths) {
+				$this->setPlugin($plugin);
+				foreach ($pluginPaths as $path) {
+					$path .= 'tests' . DS . 'TestCase' . DS;
+					if (!is_dir($path)) {
+						continue;
+					}
 
-				$folders = glob($path . '*', GLOB_ONLYDIR) ?: [];
-				foreach ($folders as $folder) {
-					$this->_classes($folder . DS);
+					$folders = glob($path . '*', GLOB_ONLYDIR) ?: [];
+					foreach ($folders as $folder) {
+						$this->_classes($folder . DS);
+					}
 				}
 			}
 		}
+
+		$this->_walkPathAwareTasks($tasks);
 
 		if ($args->getOption('ci') && $this->_annotatorMadeChanges()) {
 			return static::CODE_CHANGES;
 		}
 
 		return static::CODE_SUCCESS;
+	}
+
+	/**
+	 * Walk every directory declared by a path-aware annotator task, in app
+	 * context and (when `-p <plugin>` is used) per-plugin. The standard
+	 * ClassAnnotator runs over each *.php it finds; tasks gate themselves
+	 * via shouldRun(), so unrelated tasks self-skip these paths.
+	 *
+	 * @param array<class-string<\IdeHelper\Annotator\ClassAnnotatorTask\ClassAnnotatorTaskInterface>> $tasks
+	 * @return void
+	 */
+	protected function _walkPathAwareTasks(array $tasks): void {
+		$pathAware = array_filter(
+			$tasks,
+			fn (string $cls): bool => is_a($cls, PathAwareClassAnnotatorTaskInterface::class, true),
+		);
+		if (!$pathAware) {
+			return;
+		}
+
+		$paths = $this->getPaths();
+		$walked = [];
+		foreach ($paths as $plugin => $pluginPaths) {
+			$this->setPlugin($plugin);
+			foreach ($pluginPaths as $rootPath) {
+				foreach ($pathAware as $taskClass) {
+					foreach ($taskClass::scanPaths() as $relPath) {
+						$folder = $rootPath . trim($relPath, '/' . DS) . DS;
+						if (isset($walked[$folder]) || !is_dir($folder)) {
+							continue;
+						}
+						$walked[$folder] = true;
+						$this->_classes($folder);
+					}
+				}
+			}
+		}
 	}
 
 	/**

--- a/tests/TestCase/Command/Annotate/ClassesCommandPathAwareTest.php
+++ b/tests/TestCase/Command/Annotate/ClassesCommandPathAwareTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace IdeHelper\Test\TestCase\Command\Annotate;
+
+use Cake\Console\TestSuite\ConsoleIntegrationTestTrait;
+use Cake\Core\Configure;
+use Cake\TestSuite\TestCase;
+use IdeHelper\Test\TestCase\Command\Annotate\Fixture\TestPathAwareAnnotatorTask;
+
+class ClassesCommandPathAwareTest extends TestCase {
+
+	use ConsoleIntegrationTestTrait;
+
+	/**
+	 * @var array<string>
+	 */
+	protected array $createdFiles = [];
+
+	/**
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->loadPlugins(['IdeHelper']);
+	}
+
+	/**
+	 * @return void
+	 */
+	protected function tearDown(): void {
+		Configure::delete('IdeHelper.classAnnotatorTasks');
+		foreach ($this->createdFiles as $path) {
+			@unlink($path);
+		}
+		$this->createdFiles = [];
+		@rmdir(ROOT . DS . 'tests' . DS . 'fixtures-pathaware');
+		@rmdir(ROOT . DS . 'tests' . DS);
+		parent::tearDown();
+	}
+
+	/**
+	 * Drop a tiny PHP class into the directory the fixture task declares so
+	 * `_classes()` will visit it and emit verbose-mode output we can match.
+	 *
+	 * @return string
+	 */
+	protected function placeFixtureFile(): string {
+		$dir = ROOT . DS . 'tests' . DS . 'fixtures-pathaware' . DS;
+		if (!is_dir($dir)) {
+			mkdir($dir, 0o777, true);
+		}
+		$path = $dir . 'CustomScannedClass.php';
+		file_put_contents($path, "<?php\nclass CustomScannedClass {}\n");
+		$this->createdFiles[] = $path;
+
+		return $path;
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testPathAwareTaskDirectoryIsWalked(): void {
+		$this->placeFixtureFile();
+
+		Configure::write('IdeHelper.classAnnotatorTasks', [
+			TestPathAwareAnnotatorTask::class => TestPathAwareAnnotatorTask::class,
+		]);
+
+		$this->exec('annotate classes -d -v');
+		$this->assertExitSuccess();
+		$this->assertOutputContains('tests' . DS . 'fixtures-pathaware');
+		$this->assertOutputContains('CustomScannedClass');
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testNonExistentPathAwareDirectoryIsSkippedSilently(): void {
+		Configure::write('IdeHelper.classAnnotatorTasks', [
+			TestPathAwareAnnotatorTask::class => TestPathAwareAnnotatorTask::class,
+		]);
+
+		$this->exec('annotate classes -d -v');
+		$this->assertExitSuccess();
+		// No fixture file placed; the declared directory does not exist.
+		// Just must not crash; default scan still ran.
+	}
+
+}

--- a/tests/TestCase/Command/Annotate/ClassesCommandPathAwareTest.php
+++ b/tests/TestCase/Command/Annotate/ClassesCommandPathAwareTest.php
@@ -5,6 +5,7 @@ namespace IdeHelper\Test\TestCase\Command\Annotate;
 use Cake\Console\TestSuite\ConsoleIntegrationTestTrait;
 use Cake\Core\Configure;
 use Cake\TestSuite\TestCase;
+use IdeHelper\Test\TestCase\Command\Annotate\Fixture\SecondTestPathAwareAnnotatorTask;
 use IdeHelper\Test\TestCase\Command\Annotate\Fixture\TestPathAwareAnnotatorTask;
 
 class ClassesCommandPathAwareTest extends TestCase {
@@ -22,7 +23,7 @@ class ClassesCommandPathAwareTest extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->loadPlugins(['IdeHelper']);
+		$this->loadPlugins(['IdeHelper', 'Awesome']);
 	}
 
 	/**
@@ -36,7 +37,24 @@ class ClassesCommandPathAwareTest extends TestCase {
 		$this->createdFiles = [];
 		@rmdir(ROOT . DS . 'tests' . DS . 'fixtures-pathaware');
 		@rmdir(ROOT . DS . 'tests' . DS);
+		@rmdir(PLUGINS . 'Awesome' . DS . 'tests' . DS . 'fixtures-pathaware');
+		@rmdir(PLUGINS . 'Awesome' . DS . 'tests');
 		parent::tearDown();
+	}
+
+	/**
+	 * @return string
+	 */
+	protected function placePluginFixtureFile(): string {
+		$dir = PLUGINS . 'Awesome' . DS . 'tests' . DS . 'fixtures-pathaware' . DS;
+		if (!is_dir($dir)) {
+			mkdir($dir, 0o777, true);
+		}
+		$path = $dir . 'PluginScannedClass.php';
+		file_put_contents($path, "<?php\nclass PluginScannedClass {}\n");
+		$this->createdFiles[] = $path;
+
+		return $path;
 	}
 
 	/**
@@ -71,6 +89,57 @@ class ClassesCommandPathAwareTest extends TestCase {
 		$this->assertExitSuccess();
 		$this->assertOutputContains('tests' . DS . 'fixtures-pathaware');
 		$this->assertOutputContains('CustomScannedClass');
+	}
+
+	/**
+	 * Plugin-mode integration: with `-p PluginName`, scanPaths() is resolved
+	 * relative to the plugin's root, so the fixture directory inside the
+	 * plugin is reached even though the same path inside the app is empty.
+	 *
+	 * @return void
+	 */
+	public function testPathAwareTaskWalksPluginPathInPluginMode(): void {
+		$this->placePluginFixtureFile();
+
+		Configure::write('IdeHelper.classAnnotatorTasks', [
+			TestPathAwareAnnotatorTask::class => TestPathAwareAnnotatorTask::class,
+		]);
+
+		$this->exec('annotate classes -p Awesome -d -v');
+		$this->assertExitSuccess();
+		$this->assertOutputContains('fixtures-pathaware');
+		$this->assertOutputContains('PluginScannedClass');
+	}
+
+	/**
+	 * Two registered path-aware tasks declaring the same scan path: the
+	 * directory must be walked once. Verbose output shows the directory
+	 * header on every walk, so we count occurrences and assert exactly 1.
+	 *
+	 * @return void
+	 */
+	public function testDuplicateScanPathsAcrossTasksAreWalkedOnlyOnce(): void {
+		$this->placeFixtureFile();
+
+		Configure::write('IdeHelper.classAnnotatorTasks', [
+			TestPathAwareAnnotatorTask::class => TestPathAwareAnnotatorTask::class,
+			SecondTestPathAwareAnnotatorTask::class => SecondTestPathAwareAnnotatorTask::class,
+		]);
+
+		$this->exec('annotate classes -d -v');
+		$this->assertExitSuccess();
+
+		$marker = 'tests' . DS . 'fixtures-pathaware';
+		$count = substr_count($this->_out->messages()[0] ?? '', $marker);
+		// Some Cake versions return messages as array; concat for safety:
+		if (!$count) {
+			$count = substr_count(implode("\n", $this->_out->messages()), $marker);
+		}
+		$this->assertSame(
+			1,
+			$count,
+			"Directory '{$marker}' should be walked exactly once when two tasks declare it; saw {$count} occurrences.",
+		);
 	}
 
 	/**

--- a/tests/TestCase/Command/Annotate/Fixture/SecondTestPathAwareAnnotatorTask.php
+++ b/tests/TestCase/Command/Annotate/Fixture/SecondTestPathAwareAnnotatorTask.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace IdeHelper\Test\TestCase\Command\Annotate\Fixture;
+
+use IdeHelper\Annotator\ClassAnnotatorTask\AbstractClassAnnotatorTask;
+use IdeHelper\Annotator\ClassAnnotatorTask\PathAwareClassAnnotatorTaskInterface;
+
+/**
+ * Second test fixture: declares the same scan path as TestPathAwareAnnotatorTask
+ * to exercise the dedup branch in ClassesCommand::_walkPathAwareTasks().
+ */
+class SecondTestPathAwareAnnotatorTask extends AbstractClassAnnotatorTask implements PathAwareClassAnnotatorTaskInterface {
+
+	/**
+	 * @return array<string>
+	 */
+	public static function scanPaths(): array {
+		return ['tests/fixtures-pathaware/'];
+	}
+
+	/**
+	 * @param string $path
+	 * @param string $content
+	 * @return bool
+	 */
+	public function shouldRun(string $path, string $content): bool {
+		return false;
+	}
+
+	/**
+	 * @param string $path
+	 * @return bool
+	 */
+	public function annotate(string $path): bool {
+		return false;
+	}
+
+}

--- a/tests/TestCase/Command/Annotate/Fixture/TestPathAwareAnnotatorTask.php
+++ b/tests/TestCase/Command/Annotate/Fixture/TestPathAwareAnnotatorTask.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace IdeHelper\Test\TestCase\Command\Annotate\Fixture;
+
+use IdeHelper\Annotator\ClassAnnotatorTask\AbstractClassAnnotatorTask;
+use IdeHelper\Annotator\ClassAnnotatorTask\PathAwareClassAnnotatorTaskInterface;
+
+/**
+ * Test fixture: a class annotator task that declares a custom scan path
+ * via PathAwareClassAnnotatorTaskInterface but does no real annotation
+ * work (shouldRun always false).
+ */
+class TestPathAwareAnnotatorTask extends AbstractClassAnnotatorTask implements PathAwareClassAnnotatorTaskInterface {
+
+	/**
+	 * @return array<string>
+	 */
+	public static function scanPaths(): array {
+		return ['tests/fixtures-pathaware/'];
+	}
+
+	/**
+	 * @param string $path
+	 * @param string $content
+	 * @return bool
+	 */
+	public function shouldRun(string $path, string $content): bool {
+		return false;
+	}
+
+	/**
+	 * @param string $path
+	 * @return bool
+	 */
+	public function annotate(string $path): bool {
+		return false;
+	}
+
+}


### PR DESCRIPTION
## Summary

Adds an optional `PathAwareClassAnnotatorTaskInterface` so a class annotator
task can declare extra directories that `bin/cake annotate classes` should
walk on top of the default `src/` and `tests/TestCase/` scans.

## The gap this fills

`ClassesCommand` currently walks two fixed directory trees (the app/plugin
classpath, plus `tests/TestCase/` when `TestClassAnnotatorTask` is
registered). Anything else — test-fixture factories under `tests/Factory/`,
scenario classes, generated stubs, etc. — falls outside its reach. A
plugin can register a task in `IdeHelper.classAnnotatorTasks`, but the
command never visits the relevant files, so the registration is dead
code and each plugin ends up shipping its own bake/annotate subcommand
just to walk its own tree.

## How it works

```php
namespace IdeHelper\Annotator\ClassAnnotatorTask;

interface PathAwareClassAnnotatorTaskInterface extends ClassAnnotatorTaskInterface
{
    /**
     * @return array<string>
     */
    public static function scanPaths(): array;
}
```

- `static` so the command can query the paths without instantiating the
  task with an `Io` and per-file content (which only makes sense per
  file).
- Paths are project-root relative for app context, plugin-root relative
  when run with `-p`.
- `ClassesCommand` walks each declared path through the same recursive
  `_classes()` helper that already handles `src/` and `tests/TestCase/`.
- The existing `ClassAnnotator` task dispatch runs every registered
  task on the discovered files; per-task gating is provided by the
  task's existing `shouldRun()` (every default task — Mailer, Form,
  Test, ModelAware — already gates strictly).
- Paths that don't exist on disk are silently skipped.
- A path declared by multiple tasks is walked once.

## Compatibility

Fully back-compatible. The new interface is optional. Tasks that do not
implement it behave exactly as before. Default tasks are unchanged.

## Motivating consumer

[`dereuromark/cakephp-fixture-factories`](https://github.com/dereuromark/cakephp-fixture-factories)
will use this to drop its bespoke `bin/cake annotate_factories` command:
its `FactoryAnnotatorTask` simply implements `scanPaths()` returning
`['tests/Factory/']`, and `bin/cake annotate classes` reaches every app
+ plugin factory through one unified entry point.

## Tests

`tests/TestCase/Command/Annotate/ClassesCommandPathAwareTest.php`:

- Registered path-aware task with an existing target directory: command
  walks it and the verbose output shows the expected directory plus a
  discovered class name.
- Registered path-aware task with a non-existent target directory:
  command silently skips it, default scan still runs, exits success.

The fixture annotator class lives in its own file under
`tests/TestCase/Command/Annotate/Fixture/` to satisfy PSR-1 and PSR-4.

## Verification

- `composer test`: 275 tests, 840 assertions, OK
- `composer stan`: clean
- `composer cs-check`: clean
