### PR TITLE
Migrate TestClassAnnotatorTask to PathAwareClassAnnotatorTaskInterface

### DIFF
--- a/docs/Annotations.md
+++ b/docs/Annotations.md
@@ -434,6 +434,10 @@ Paths are project-root relative for app context, plugin-root relative when run w
 They are walked recursively. Paths that do not exist on disk are silently skipped, and a
 path declared by multiple tasks is walked only once.
 
+Convention: return paths with forward slashes and a trailing slash (e.g. `'tests/Factory/'`),
+independent of OS. The command normalizes to the OS-native separator before walking, so the
+dedup key stays stable across Windows / *nix and across tasks that disagree on style.
+
 The interface is optional and additive — existing tasks that do not implement it behave
 unchanged. The feature is opt-in: a path-aware task is only consulted when it is registered
 in `IdeHelper.classAnnotatorTasks`.

--- a/src/Annotator/ClassAnnotatorTask/PathAwareClassAnnotatorTaskInterface.php
+++ b/src/Annotator/ClassAnnotatorTask/PathAwareClassAnnotatorTaskInterface.php
@@ -19,7 +19,12 @@ namespace IdeHelper\Annotator\ClassAnnotatorTask;
  * without first instantiating it with an `Io` and per-file content. Paths
  * are project-root relative for app context, and plugin-root relative
  * when the command is run with `-p <plugin>` (or `-p all`). Paths are
- * walked recursively. Trailing slashes are optional.
+ * walked recursively.
+ *
+ * Convention: return paths with forward slashes and a trailing slash
+ * (e.g. `'tests/Factory/'`), independent of OS. The command normalizes
+ * to the OS-native separator before walking, so the dedup key is stable
+ * when two tasks declare the same path.
  */
 interface PathAwareClassAnnotatorTaskInterface extends ClassAnnotatorTaskInterface {
 

--- a/src/Annotator/ClassAnnotatorTask/TestClassAnnotatorTask.php
+++ b/src/Annotator/ClassAnnotatorTask/TestClassAnnotatorTask.php
@@ -21,7 +21,7 @@ class TestClassAnnotatorTask extends AbstractClassAnnotatorTask implements PathA
 	 * @return array<string>
 	 */
 	public static function scanPaths(): array {
-		return ['tests' . DIRECTORY_SEPARATOR . 'TestCase'];
+		return ['tests/TestCase/'];
 	}
 
 	/**

--- a/src/Annotator/ClassAnnotatorTask/TestClassAnnotatorTask.php
+++ b/src/Annotator/ClassAnnotatorTask/TestClassAnnotatorTask.php
@@ -15,7 +15,14 @@ use IdeHelper\Annotation\UsesAnnotation;
  *
  * Use Configure key `IdeHelper.testClassPatterns` to add more types and their regex pattern.
  */
-class TestClassAnnotatorTask extends AbstractClassAnnotatorTask implements ClassAnnotatorTaskInterface {
+class TestClassAnnotatorTask extends AbstractClassAnnotatorTask implements PathAwareClassAnnotatorTaskInterface {
+
+	/**
+	 * @return array<string>
+	 */
+	public static function scanPaths(): array {
+		return ['tests' . DIRECTORY_SEPARATOR . 'TestCase'];
+	}
 
 	/**
 	 * Deprecated: $content, use $this->content instead.

--- a/src/Command/Annotate/ClassesCommand.php
+++ b/src/Command/Annotate/ClassesCommand.php
@@ -8,7 +8,6 @@ use Cake\Console\ConsoleOptionParser;
 use Cake\Core\Configure;
 use IdeHelper\Annotator\ClassAnnotator;
 use IdeHelper\Annotator\ClassAnnotatorTask\PathAwareClassAnnotatorTaskInterface;
-use IdeHelper\Annotator\ClassAnnotatorTask\TestClassAnnotatorTask;
 use IdeHelper\Annotator\ClassAnnotatorTaskCollection;
 use IdeHelper\Command\AnnotateCommand;
 
@@ -53,24 +52,6 @@ class ClassesCommand extends AnnotateCommand {
 
 		$collection = new ClassAnnotatorTaskCollection();
 		$tasks = $collection->defaultTasks();
-
-		if (in_array(TestClassAnnotatorTask::class, $tasks, true)) {
-			$paths = $this->getPaths();
-			foreach ($paths as $plugin => $pluginPaths) {
-				$this->setPlugin($plugin);
-				foreach ($pluginPaths as $path) {
-					$path .= 'tests' . DS . 'TestCase' . DS;
-					if (!is_dir($path)) {
-						continue;
-					}
-
-					$folders = glob($path . '*', GLOB_ONLYDIR) ?: [];
-					foreach ($folders as $folder) {
-						$this->_classes($folder . DS);
-					}
-				}
-			}
-		}
 
 		$this->_walkPathAwareTasks($tasks);
 

--- a/src/Command/Annotate/ClassesCommand.php
+++ b/src/Command/Annotate/ClassesCommand.php
@@ -87,7 +87,7 @@ class ClassesCommand extends AnnotateCommand {
 			foreach ($pluginPaths as $rootPath) {
 				foreach ($pathAware as $taskClass) {
 					foreach ($taskClass::scanPaths() as $relPath) {
-						$folder = $rootPath . trim($relPath, '/' . DS) . DS;
+						$folder = $rootPath . $this->_normalizeScanPath($relPath);
 						if (isset($walked[$folder]) || !is_dir($folder)) {
 							continue;
 						}
@@ -97,6 +97,23 @@ class ClassesCommand extends AnnotateCommand {
 				}
 			}
 		}
+	}
+
+	/**
+	 * Normalize a scan path declared by a path-aware task to the OS-native
+	 * separator with exactly one trailing separator, regardless of whether
+	 * the task author used forward slashes, backslashes, or no trailing
+	 * separator. This keeps the `$walked[$folder]` dedup key stable across
+	 * portability quirks.
+	 *
+	 * @param string $relPath
+	 * @return string
+	 */
+	protected function _normalizeScanPath(string $relPath): string {
+		$forward = str_replace('\\', '/', $relPath);
+		$trimmed = rtrim($forward, '/');
+
+		return str_replace('/', DS, $trimmed) . DS;
 	}
 
 	/**

--- a/tests/TestCase/Command/Annotate/ClassesCommandTestCaseWalkTest.php
+++ b/tests/TestCase/Command/Annotate/ClassesCommandTestCaseWalkTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace IdeHelper\Test\TestCase\Command\Annotate;
+
+use Cake\Console\TestSuite\ConsoleIntegrationTestTrait;
+use Cake\TestSuite\TestCase;
+
+/**
+ * Regression test for the default `tests/TestCase/` walk performed by
+ * `bin/cake annotate classes` when `TestClassAnnotatorTask` is in the
+ * registered task list. Guards against the walk silently disappearing
+ * during refactors.
+ */
+class ClassesCommandTestCaseWalkTest extends TestCase {
+
+	use ConsoleIntegrationTestTrait;
+
+	/**
+	 * @var array<string>
+	 */
+	protected array $createdFiles = [];
+
+	/**
+	 * @var array<string>
+	 */
+	protected array $createdDirs = [];
+
+	/**
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->loadPlugins(['IdeHelper']);
+	}
+
+	/**
+	 * @return void
+	 */
+	protected function tearDown(): void {
+		foreach ($this->createdFiles as $path) {
+			@unlink($path);
+		}
+		foreach (array_reverse($this->createdDirs) as $dir) {
+			@rmdir($dir);
+		}
+		$this->createdFiles = [];
+		$this->createdDirs = [];
+		parent::tearDown();
+	}
+
+	/**
+	 * Drop a controller-test class into the app's tests/TestCase/Controller/
+	 * tree so the command's verbose output reports the directory walk.
+	 *
+	 * @return void
+	 */
+	protected function placeControllerTestFile(): void {
+		$testCaseDir = ROOT . DS . 'tests' . DS . 'TestCase' . DS;
+		$controllerDir = $testCaseDir . 'Controller' . DS;
+		foreach ([$testCaseDir, $controllerDir] as $dir) {
+			if (!is_dir($dir)) {
+				mkdir($dir, 0o777, true);
+				$this->createdDirs[] = $dir;
+			}
+		}
+		$path = $controllerDir . 'WalkProbeControllerTest.php';
+		file_put_contents(
+			$path,
+			"<?php\nnamespace App\\Test\\TestCase\\Controller;\nclass WalkProbeControllerTest {}\n",
+		);
+		$this->createdFiles[] = $path;
+	}
+
+	/**
+	 * The default test-case scan must reach files inside tests/TestCase/.
+	 * Verbose output emits the directory header for every walked folder, so
+	 * we assert the marker shows up.
+	 *
+	 * @return void
+	 */
+	public function testTestCaseDirectoryIsWalkedByDefault(): void {
+		$this->placeControllerTestFile();
+
+		$this->exec('annotate classes -d -v');
+		$this->assertExitSuccess();
+		$this->assertOutputContains('tests' . DS . 'TestCase' . DS . 'Controller');
+		$this->assertOutputContains('WalkProbeControllerTest');
+	}
+
+}

--- a/tests/TestCase/Command/Annotate/Fixture/SecondTestPathAwareAnnotatorTask.php
+++ b/tests/TestCase/Command/Annotate/Fixture/SecondTestPathAwareAnnotatorTask.php
@@ -7,7 +7,10 @@ use IdeHelper\Annotator\ClassAnnotatorTask\PathAwareClassAnnotatorTaskInterface;
 
 /**
  * Second test fixture: declares the same scan path as TestPathAwareAnnotatorTask
- * to exercise the dedup branch in ClassesCommand::_walkPathAwareTasks().
+ * but in a deliberately different shape — backslash separators and no trailing
+ * slash — to exercise both the dedup branch in
+ * ClassesCommand::_walkPathAwareTasks() and the path normalization that makes
+ * the dedup key stable across separator / trailing-slash style variations.
  */
 class SecondTestPathAwareAnnotatorTask extends AbstractClassAnnotatorTask implements PathAwareClassAnnotatorTaskInterface {
 
@@ -15,7 +18,7 @@ class SecondTestPathAwareAnnotatorTask extends AbstractClassAnnotatorTask implem
 	 * @return array<string>
 	 */
 	public static function scanPaths(): array {
-		return ['tests/fixtures-pathaware/'];
+		return ['tests\\fixtures-pathaware'];
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Follow-up to #435. Migrates `TestClassAnnotatorTask` to the new
`PathAwareClassAnnotatorTaskInterface` and removes the dedicated
`tests/TestCase/` walk block from `ClassesCommand::execute()`, which
predated the path-aware mechanism and is now redundant.

## Why

`ClassesCommand` carried a special case: when `TestClassAnnotatorTask`
appeared in the default task list, the command ran a hand-rolled walk
of `tests/TestCase/` next to its `src/` walk. Since #435, every other
task that needs an extra path declares it via `scanPaths()` and the
shared `_walkPathAwareTasks()` handles the recursion + dedup. The
test-case walk is the last remaining "special" path; folding it into
the same mechanism removes a one-off code path and puts the path next
to the task that actually consumes it.

## Behavior preserved

- The walk still fires under the same condition: `TestClassAnnotatorTask`
  is in the registered task list, which it is by default. Users who
  override defaults to drop the task continue to see the walk skip.
- `_classes()` is unchanged; same files visited, same `ClassAnnotator`
  dispatch runs every registered task on each file.
- Per-task gating is preserved: `TestClassAnnotatorTask::shouldRun()`
  already requires `DS . tests . DS . TestCase . DS` in the path, so
  the move into the path-aware queue does not change which files it
  fires on.
- The path-aware dedup map collapses any overlap between this default
  walk and a third-party task that declares the same root.

## Diff shape

- `src/Annotator/ClassAnnotatorTask/TestClassAnnotatorTask.php`
  implements `PathAwareClassAnnotatorTaskInterface` and adds a
  one-line `scanPaths(): array` returning `['tests/TestCase']`.
- `src/Command/Annotate/ClassesCommand.php` drops the 19-line block
  that walked `tests/TestCase/` and the now-unused
  `TestClassAnnotatorTask` import.
- `tests/TestCase/Command/Annotate/ClassesCommandTestCaseWalkTest.php`
  is added as a regression guard (see below).

## Tests

`ClassesCommandTestCaseWalkTest::testTestCaseDirectoryIsWalkedByDefault`
drops a probe file into the test app's
`tests/TestCase/Controller/` tree, runs `bin/cake annotate classes
-d -v`, and asserts the verbose directory header and the probe class
name appear in stdout.

The test was confirmed RED-sensitive during development: with the
`tests/TestCase/` walk removed from `ClassesCommand` but
`TestClassAnnotatorTask` still implementing the plain
`ClassAnnotatorTaskInterface`, the assertion fails because the
directory is never walked. Adding the path-aware interface to the
task makes it pass.

## Verification

- `composer test`: 278 tests, 848 assertions, OK
- `composer stan`: clean
- `composer cs-check`: clean
