### PR TITLE
Add 'strict' tier to concreteEntitiesInParam

### DIFF
--- a/config/app.example.php
+++ b/config/app.example.php
@@ -22,7 +22,7 @@ return [
 		'objectAsGenerics' => false, // Enable to have modern generics syntax (recommended) in doc blocks
 		'assocsAsGenerics' => false, // Enable to have modern generics syntax (NOT recommended yet) in doc blocks
 		'genericsInParam' => false, // true for basic generics, 'detailed' for fully detailed types (array<string, mixed>, ResultSetInterface<int, TEntity>, ...)
-		'concreteEntitiesInParam' => false, // Enable to have specific entities in generated method param doc blocks (NOT recommended)
+		'concreteEntitiesInParam' => false, // true for concrete entity in patchEntity/save/saveOrFail, 'strict' to also narrow iterable params and emit delete/deleteOrFail/loadInto annotations
 		'tableEntityQuery' => false, // Enable to annotate `Table::find()` as returning `SelectQuery<TEntity>` for IDEs
 		// Set to `false` to disable, or string if you have a custom FQCN to be used
 		'templateCollectionObject' => true,

--- a/docs/annotations/models.md
+++ b/docs/annotations/models.md
@@ -73,6 +73,41 @@ With `'detailed'`, the generated method annotations look like:
 Switching the value is additive — existing `true` users keep their current
 output, and the new `'detailed'` opt-in can be enabled at any time.
 
+### Concrete entity types in params
+
+The `IdeHelper.concreteEntitiesInParam` option is tri-state:
+
+- `false` (default) — entity params accept `\Cake\Datasource\EntityInterface`.
+- `true` — `patchEntity()`, `save()`, and `saveOrFail()` declare the concrete
+  entity class for their `$entity` parameter, so PHPStan can catch a mismatched
+  entity passed to the wrong table.
+- `'strict'` — same as `true`, plus:
+  - iterable params on `patchEntities` / `saveMany` / `saveManyOrFail` /
+    `deleteMany` / `deleteManyOrFail` are narrowed to
+    `iterable<\App\Model\Entity\X>` even when `genericsInParam` is `false`.
+  - `delete()`, `deleteOrFail()`, and `loadInto()` get explicit `@method` lines
+    typed with the concrete entity class.
+
+This mirrors the runtime check proposed upstream in
+[cakephp/cakephp#19428](https://github.com/cakephp/cakephp/pull/19428): a
+`Table::delete($order)` call against an `InvoicesTable` is rejected at
+static-analysis time instead of silently deleting from the wrong table.
+
+With `'strict'` (and `genericsInParam` left at default `false`), the generated
+method block adds:
+
+```php
+ * @method \App\Model\Entity\User patchEntity(\App\Model\Entity\User $entity, array $data, array $options = [])
+ * @method \App\Model\Entity\User[] patchEntities(iterable<\App\Model\Entity\User> $entities, array $data, array $options = [])
+ * @method bool delete(\App\Model\Entity\User $entity, array $options = [])
+ * @method bool deleteOrFail(\App\Model\Entity\User $entity, array $options = [])
+ * @method \App\Model\Entity\User|array<\App\Model\Entity\User> loadInto(\App\Model\Entity\User|array<\App\Model\Entity\User> $entities, array $contain)
+```
+
+Switching is additive — existing `true` users keep their current output, and
+`'strict'` can be enabled at any time. Pair with `genericsInParam` at `true` or
+`'detailed'` for fully typed params throughout.
+
 ## Entities
 
 Entities annotate their properties and relations.

--- a/src/Annotator/ModelAnnotator.php
+++ b/src/Annotator/ModelAnnotator.php
@@ -195,7 +195,9 @@ class ModelAnnotator extends AbstractAnnotator {
 			$entityInterface = '\\' . EntityInterface::class;
 			$resultSetInterfaceCollection = GenericString::generate($fullClassName, '\\' . ResultSetInterface::class);
 
-			if (Configure::read('IdeHelper.concreteEntitiesInParam')) {
+			$concrete = Configure::read('IdeHelper.concreteEntitiesInParam');
+			$strict = $concrete === 'strict';
+			if ($concrete) {
 				$entityInterface = $fullClassName;
 			}
 
@@ -214,6 +216,9 @@ class ModelAnnotator extends AbstractAnnotator {
 				// Detailed mode always narrows iterables to the concrete entity — a UsersTable only ever handles User entities.
 				$iterableEntity = $detailed ? $fullClassName : $entityInterface;
 				$iterable = "iterable<{$iterableEntity}>";
+			} elseif ($strict) {
+				// Strict mode narrows the iterable to the concrete entity even without genericsInParam.
+				$iterable = "iterable<{$fullClassName}>";
 			}
 			if ($detailed) {
 				$finderType = 'array<string, mixed>|string';
@@ -246,6 +251,12 @@ class ModelAnnotator extends AbstractAnnotator {
 
 			$annotations[] = "@method {$resultSetInterfaceCollection}|false deleteMany({$iterable} \$entities, {$optionsType} \$options = [])";
 			$annotations[] = "@method {$resultSetInterfaceCollection} deleteManyOrFail({$iterable} \$entities, {$optionsType} \$options = [])";
+
+			if ($strict) {
+				$annotations[] = "@method bool delete({$fullClassName} \$entity, {$optionsType} \$options = [])";
+				$annotations[] = "@method bool deleteOrFail({$fullClassName} \$entity, {$optionsType} \$options = [])";
+				$annotations[] = "@method {$fullClassName}|array<{$fullClassName}> loadInto({$fullClassName}|array<{$fullClassName}> \$entities, array \$contain)";
+			}
 		}
 
 		// Make replaceable via parsed object

--- a/src/View/Helper/DocBlockHelper.php
+++ b/src/View/Helper/DocBlockHelper.php
@@ -155,7 +155,9 @@ class DocBlockHelper extends BakeDocBlockHelper {
 		$class = "\\{$namespace}\\Model\\Entity\\{$entity}";
 		$classes = GenericString::generate($class);
 		$classInterface = '\\Cake\\Datasource\\EntityInterface';
-		if (Configure::read('IdeHelper.concreteEntitiesInParam')) {
+		$concrete = Configure::read('IdeHelper.concreteEntitiesInParam');
+		$strict = $concrete === 'strict';
+		if ($concrete) {
 			$classInterface = $class;
 		}
 
@@ -173,6 +175,8 @@ class DocBlockHelper extends BakeDocBlockHelper {
 			$optionsType = 'array<string, mixed>';
 			$iterableEntity = $detailed ? $class : $classInterface;
 			$itterable = "iterable<{$iterableEntity}>";
+		} elseif ($strict) {
+			$itterable = "iterable<{$class}>";
 		}
 		if ($detailed) {
 			$finderType = 'array<string, mixed>|string';
@@ -193,6 +197,12 @@ class DocBlockHelper extends BakeDocBlockHelper {
 		$annotations[] = "@method {$resultSet} saveManyOrFail({$itterable} \$entities, {$optionsType} \$options = [])";
 		$annotations[] = "@method {$resultSet}|false deleteMany({$itterable} \$entities, {$optionsType} \$options = [])";
 		$annotations[] = "@method {$resultSet} deleteManyOrFail({$itterable} \$entities, {$optionsType} \$options = [])";
+
+		if ($strict) {
+			$annotations[] = "@method bool delete({$class} \$entity, {$optionsType} \$options = [])";
+			$annotations[] = "@method bool deleteOrFail({$class} \$entity, {$optionsType} \$options = [])";
+			$annotations[] = "@method {$class}|array<{$class}> loadInto({$class}|array<{$class}> \$entities, array \$contain)";
+		}
 
 		foreach ($behaviors as $behavior => $behaviorData) {
 			$className = App::className($behavior, 'Model/Behavior', 'Behavior');

--- a/tests/TestCase/Annotator/ModelAnnotatorSpecificTest.php
+++ b/tests/TestCase/Annotator/ModelAnnotatorSpecificTest.php
@@ -153,6 +153,61 @@ class ModelAnnotatorSpecificTest extends TestCase {
 	/**
 	 * @return void
 	 */
+	public function testAnnotateSpecificStrict() {
+		Configure::write('IdeHelper.concreteEntitiesInParam', 'strict');
+
+		$annotator = $this->_getAnnotatorMock([]);
+
+		$expectedContent = str_replace("\r\n", "\n", file_get_contents(TEST_FILES . 'Model/Table/Specific/BarBarsStrictTable.php'));
+		$callback = function($value) use ($expectedContent) {
+			$value = str_replace(["\r\n", "\r"], "\n", $value);
+			if ($value !== $expectedContent) {
+				$this->_displayDiff($expectedContent, $value);
+			}
+
+			return $value === $expectedContent;
+		};
+		$annotator->expects($this->once())->method('storeFile')->with($this->anything(), $this->callback($callback));
+
+		$path = APP . 'Model/Table/Specific/BarBarsTable.php';
+		$annotator->annotate($path);
+
+		$output = $this->out->output();
+
+		$this->assertTextContains('annotations added', $output);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testAnnotateSpecificStrictBare() {
+		Configure::write('IdeHelper.concreteEntitiesInParam', 'strict');
+		Configure::write('IdeHelper.genericsInParam', false);
+
+		$annotator = $this->_getAnnotatorMock([]);
+
+		$expectedContent = str_replace("\r\n", "\n", file_get_contents(TEST_FILES . 'Model/Table/Specific/BarBarsStrictBareTable.php'));
+		$callback = function($value) use ($expectedContent) {
+			$value = str_replace(["\r\n", "\r"], "\n", $value);
+			if ($value !== $expectedContent) {
+				$this->_displayDiff($expectedContent, $value);
+			}
+
+			return $value === $expectedContent;
+		};
+		$annotator->expects($this->once())->method('storeFile')->with($this->anything(), $this->callback($callback));
+
+		$path = APP . 'Model/Table/Specific/BarBarsTable.php';
+		$annotator->annotate($path);
+
+		$output = $this->out->output();
+
+		$this->assertTextContains('annotations added', $output);
+	}
+
+	/**
+	 * @return void
+	 */
 	public function testAnnotateSpecificDetailed() {
 		Configure::write('IdeHelper.genericsInParam', 'detailed');
 

--- a/tests/test_files/Model/Table/Specific/BarBarsStrictBareTable.php
+++ b/tests/test_files/Model/Table/Specific/BarBarsStrictBareTable.php
@@ -1,0 +1,48 @@
+<?php
+namespace TestApp\Model\Table;
+
+use Cake\ORM\Table;
+
+/**
+ * @property \Cake\ORM\Association\BelongsTo<\TestApp\Model\Table\FoosTable> $Foos
+ * @property \Cake\ORM\Association\BelongsToMany<\Awesome\Model\Table\HousesTable> $Houses
+ *
+ * @method \TestApp\Model\Entity\BarBar newEmptyEntity()
+ * @method \TestApp\Model\Entity\BarBar newEntity(array $data, array $options = [])
+ * @method \TestApp\Model\Entity\BarBar[] newEntities(array $data, array $options = [])
+ * @method \TestApp\Model\Entity\BarBar get(mixed $primaryKey, array|string $finder = 'all', \Psr\SimpleCache\CacheInterface|string|null $cache = null, \Closure|string|null $cacheKey = null, mixed ...$args)
+ * @method \TestApp\Model\Entity\BarBar findOrCreate(\Cake\ORM\Query\SelectQuery|callable|array $search, ?callable $callback = null, array $options = [])
+ * @method \TestApp\Model\Entity\BarBar patchEntity(\TestApp\Model\Entity\BarBar $entity, array $data, array $options = [])
+ * @method \TestApp\Model\Entity\BarBar[] patchEntities(iterable<\TestApp\Model\Entity\BarBar> $entities, array $data, array $options = [])
+ * @method \TestApp\Model\Entity\BarBar|false save(\TestApp\Model\Entity\BarBar $entity, array $options = [])
+ * @method \TestApp\Model\Entity\BarBar saveOrFail(\TestApp\Model\Entity\BarBar $entity, array $options = [])
+ * @method \Cake\Datasource\ResultSetInterface<\TestApp\Model\Entity\BarBar>|false saveMany(iterable<\TestApp\Model\Entity\BarBar> $entities, array $options = [])
+ * @method \Cake\Datasource\ResultSetInterface<\TestApp\Model\Entity\BarBar> saveManyOrFail(iterable<\TestApp\Model\Entity\BarBar> $entities, array $options = [])
+ * @method \Cake\Datasource\ResultSetInterface<\TestApp\Model\Entity\BarBar>|false deleteMany(iterable<\TestApp\Model\Entity\BarBar> $entities, array $options = [])
+ * @method \Cake\Datasource\ResultSetInterface<\TestApp\Model\Entity\BarBar> deleteManyOrFail(iterable<\TestApp\Model\Entity\BarBar> $entities, array $options = [])
+ * @method bool delete(\TestApp\Model\Entity\BarBar $entity, array $options = [])
+ * @method bool deleteOrFail(\TestApp\Model\Entity\BarBar $entity, array $options = [])
+ * @method \TestApp\Model\Entity\BarBar|array<\TestApp\Model\Entity\BarBar> loadInto(\TestApp\Model\Entity\BarBar|array<\TestApp\Model\Entity\BarBar> $entities, array $contain)
+ *
+ * @mixin \Cake\ORM\Behavior\TimestampBehavior
+ * @mixin \MyNamespace\MyPlugin\Model\Behavior\MyBehavior
+ */
+class BarBarsTable extends Table {
+
+	/**
+	 * @param array $config
+	 * @return void
+	 */
+	public function initialize(array $config): void {
+		parent::initialize($config);
+
+		$this->belongsTo('Foos');
+		$this->belongsToMany('Houses', [
+			'className' => 'Awesome.Houses',
+			'through' => 'Awesome.Windows',
+		]);
+		$this->addBehavior('Timestamp');
+		$this->addBehavior('MyNamespace/MyPlugin.My');
+	}
+
+}

--- a/tests/test_files/Model/Table/Specific/BarBarsStrictTable.php
+++ b/tests/test_files/Model/Table/Specific/BarBarsStrictTable.php
@@ -1,0 +1,48 @@
+<?php
+namespace TestApp\Model\Table;
+
+use Cake\ORM\Table;
+
+/**
+ * @property \Cake\ORM\Association\BelongsTo<\TestApp\Model\Table\FoosTable> $Foos
+ * @property \Cake\ORM\Association\BelongsToMany<\Awesome\Model\Table\HousesTable> $Houses
+ *
+ * @method \TestApp\Model\Entity\BarBar newEmptyEntity()
+ * @method \TestApp\Model\Entity\BarBar newEntity(array<mixed> $data, array<string, mixed> $options = [])
+ * @method \TestApp\Model\Entity\BarBar[] newEntities(array<mixed> $data, array<string, mixed> $options = [])
+ * @method \TestApp\Model\Entity\BarBar get(mixed $primaryKey, array|string $finder = 'all', \Psr\SimpleCache\CacheInterface|string|null $cache = null, \Closure|string|null $cacheKey = null, mixed ...$args)
+ * @method \TestApp\Model\Entity\BarBar findOrCreate(\Cake\ORM\Query\SelectQuery|callable|array $search, ?callable $callback = null, array<string, mixed> $options = [])
+ * @method \TestApp\Model\Entity\BarBar patchEntity(\TestApp\Model\Entity\BarBar $entity, array<mixed> $data, array<string, mixed> $options = [])
+ * @method \TestApp\Model\Entity\BarBar[] patchEntities(iterable<\TestApp\Model\Entity\BarBar> $entities, array<mixed> $data, array<string, mixed> $options = [])
+ * @method \TestApp\Model\Entity\BarBar|false save(\TestApp\Model\Entity\BarBar $entity, array<string, mixed> $options = [])
+ * @method \TestApp\Model\Entity\BarBar saveOrFail(\TestApp\Model\Entity\BarBar $entity, array<string, mixed> $options = [])
+ * @method \Cake\Datasource\ResultSetInterface<\TestApp\Model\Entity\BarBar>|false saveMany(iterable<\TestApp\Model\Entity\BarBar> $entities, array<string, mixed> $options = [])
+ * @method \Cake\Datasource\ResultSetInterface<\TestApp\Model\Entity\BarBar> saveManyOrFail(iterable<\TestApp\Model\Entity\BarBar> $entities, array<string, mixed> $options = [])
+ * @method \Cake\Datasource\ResultSetInterface<\TestApp\Model\Entity\BarBar>|false deleteMany(iterable<\TestApp\Model\Entity\BarBar> $entities, array<string, mixed> $options = [])
+ * @method \Cake\Datasource\ResultSetInterface<\TestApp\Model\Entity\BarBar> deleteManyOrFail(iterable<\TestApp\Model\Entity\BarBar> $entities, array<string, mixed> $options = [])
+ * @method bool delete(\TestApp\Model\Entity\BarBar $entity, array<string, mixed> $options = [])
+ * @method bool deleteOrFail(\TestApp\Model\Entity\BarBar $entity, array<string, mixed> $options = [])
+ * @method \TestApp\Model\Entity\BarBar|array<\TestApp\Model\Entity\BarBar> loadInto(\TestApp\Model\Entity\BarBar|array<\TestApp\Model\Entity\BarBar> $entities, array $contain)
+ *
+ * @mixin \Cake\ORM\Behavior\TimestampBehavior
+ * @mixin \MyNamespace\MyPlugin\Model\Behavior\MyBehavior
+ */
+class BarBarsTable extends Table {
+
+	/**
+	 * @param array $config
+	 * @return void
+	 */
+	public function initialize(array $config): void {
+		parent::initialize($config);
+
+		$this->belongsTo('Foos');
+		$this->belongsToMany('Houses', [
+			'className' => 'Awesome.Houses',
+			'through' => 'Awesome.Windows',
+		]);
+		$this->addBehavior('Timestamp');
+		$this->addBehavior('MyNamespace/MyPlugin.My');
+	}
+
+}


### PR DESCRIPTION
## Summary

Mirror the existing `genericsInParam` tri-state pattern by extending `concreteEntitiesInParam` from a boolean to `false | true | 'strict'`. The new `'strict'` tier is purely additive over `true` and gives PHPStan more to work with.

In `'strict'` mode:

- Iterable params on `patchEntities` / `saveMany` / `saveManyOrFail` / `deleteMany` / `deleteManyOrFail` are narrowed to `iterable<TEntity>` even when `genericsInParam` is left at the default `false`.
- `delete()`, `deleteOrFail()`, and `loadInto()` get explicit method doc-block lines typed with the concrete entity class. They are not generated in the looser modes.

The motivation is to provide a static-analysis-time equivalent of the runtime guard proposed upstream in cakephp/cakephp#19428: a `Table::delete($order)` call against an `InvoicesTable` is rejected by PHPStan instead of silently deleting from the wrong table at runtime.

## Generated output (strict, `genericsInParam=false`)

```php
/**
 * @method \App\Model\Entity\User patchEntity(\App\Model\Entity\User $entity, array $data, array $options = [])
 * @method \App\Model\Entity\User[] patchEntities(iterable<\App\Model\Entity\User> $entities, array $data, array $options = [])
 * @method bool delete(\App\Model\Entity\User $entity, array $options = [])
 * @method bool deleteOrFail(\App\Model\Entity\User $entity, array $options = [])
 * @method \App\Model\Entity\User|array<\App\Model\Entity\User> loadInto(\App\Model\Entity\User|array<\App\Model\Entity\User> $entities, array $contain)
 */
```

Pair with `genericsInParam` at `true` or `'detailed'` for fully typed params throughout.

## Notes

- Both `DocBlockHelper` (used by the bake template) and `ModelAnnotator` share the new branch so freshly-baked and re-annotated output stay aligned.
- Existing `true` users see no change; the tier is opt-in.
- Draft because the upstream PR (cakephp/cakephp#19428) is still under discussion — I'd like to confirm naming (`'strict'`) and signature shape, especially for `loadInto`, before un-drafting. Happy to rename or split into a separate flag if preferred.

## Out of scope (deliberate)

Association methods (`link`, `unlink`, `replaceLinks`, etc.) are not touched here. Upstream PR cakephp/cakephp#19428 doesn't cover them either, and tightening association params is a judgment call I'd rather make in a follow-up.
