### PR TITLE
Emit extends tag first in generated table doc-blocks

### DIFF
--- a/src/Annotator/ModelAnnotator.php
+++ b/src/Annotator/ModelAnnotator.php
@@ -531,7 +531,9 @@ class ModelAnnotator extends AbstractAnnotator {
 		if (!$parentClass) {
 			$parentClass = '\\Cake\\ORM\\Table';
 		}
-		$result[] = AnnotationFactory::createOrFail(ExtendsAnnotation::TAG, '\\' . $parentClass . '<array{' . $list . '}' . $entityTemplate . '>');
+		// Prepend so @extends sits at the top of the class doc-block, matching the
+		// classOrder defined by php-collective/code-sniffer DocBlockTagOrderSniff.
+		array_unshift($result, AnnotationFactory::createOrFail(ExtendsAnnotation::TAG, '\\' . $parentClass . '<array{' . $list . '}' . $entityTemplate . '>'));
 
 		return $result;
 	}

--- a/tests/test_files/Model/Table/BarBarsAbstractTable.php
+++ b/tests/test_files/Model/Table/BarBarsAbstractTable.php
@@ -2,6 +2,8 @@
 namespace TestApp\Model\Table;
 
 /**
+ * @extends \TestApp\Model\Table\AbstractTable<array{MyMy: \MyNamespace\MyPlugin\Model\Behavior\MyBehavior, Timestamp: \Cake\ORM\Behavior\TimestampBehavior}>
+ *
  * @property \Cake\ORM\Association\BelongsTo<\TestApp\Model\Table\FoosTable> $Foos
  * @property \Cake\ORM\Association\BelongsToMany<\Awesome\Model\Table\HousesTable> $Houses
  *
@@ -21,8 +23,6 @@ namespace TestApp\Model\Table;
  *
  * @mixin \Cake\ORM\Behavior\TimestampBehavior
  * @mixin \MyNamespace\MyPlugin\Model\Behavior\MyBehavior
- *
- * @extends \TestApp\Model\Table\AbstractTable<array{MyMy: \MyNamespace\MyPlugin\Model\Behavior\MyBehavior, Timestamp: \Cake\ORM\Behavior\TimestampBehavior}>
  */
 class BarBarsAbstractTable extends AbstractTable {
 

--- a/tests/test_files/Model/Table/BarBarsDetailedTable.php
+++ b/tests/test_files/Model/Table/BarBarsDetailedTable.php
@@ -4,6 +4,8 @@ namespace TestApp\Model\Table;
 use Cake\ORM\Table;
 
 /**
+ * @extends \Cake\ORM\Table<array{My: \MyNamespace\MyPlugin\Model\Behavior\MyBehavior, Timestamp: \Cake\ORM\Behavior\TimestampBehavior}>
+ *
  * @property \Cake\ORM\Association\BelongsTo<\TestApp\Model\Table\FoosTable> $Foos
  * @property \Cake\ORM\Association\BelongsToMany<\Awesome\Model\Table\HousesTable> $Houses
  *
@@ -23,8 +25,6 @@ use Cake\ORM\Table;
  *
  * @mixin \Cake\ORM\Behavior\TimestampBehavior
  * @mixin \MyNamespace\MyPlugin\Model\Behavior\MyBehavior
- *
- * @extends \Cake\ORM\Table<array{My: \MyNamespace\MyPlugin\Model\Behavior\MyBehavior, Timestamp: \Cake\ORM\Behavior\TimestampBehavior}>
  */
 class BarBarsTable extends Table {
 

--- a/tests/test_files/Model/Table/BarBarsEntityTemplateTable.php
+++ b/tests/test_files/Model/Table/BarBarsEntityTemplateTable.php
@@ -4,6 +4,8 @@ namespace TestApp\Model\Table;
 use Cake\ORM\Table;
 
 /**
+ * @extends \Cake\ORM\Table<array{My: \MyNamespace\MyPlugin\Model\Behavior\MyBehavior, Timestamp: \Cake\ORM\Behavior\TimestampBehavior}, \TestApp\Model\Entity\BarBar>
+ *
  * @property \Cake\ORM\Association\BelongsTo<\TestApp\Model\Table\FoosTable> $Foos
  * @property \Cake\ORM\Association\BelongsToMany<\Awesome\Model\Table\HousesTable> $Houses
  *
@@ -23,8 +25,6 @@ use Cake\ORM\Table;
  *
  * @mixin \Cake\ORM\Behavior\TimestampBehavior
  * @mixin \MyNamespace\MyPlugin\Model\Behavior\MyBehavior
- *
- * @extends \Cake\ORM\Table<array{My: \MyNamespace\MyPlugin\Model\Behavior\MyBehavior, Timestamp: \Cake\ORM\Behavior\TimestampBehavior}, \TestApp\Model\Entity\BarBar>
  */
 class BarBarsTable extends Table {
 

--- a/tests/test_files/Model/Table/BarBarsTable.php
+++ b/tests/test_files/Model/Table/BarBarsTable.php
@@ -4,6 +4,8 @@ namespace TestApp\Model\Table;
 use Cake\ORM\Table;
 
 /**
+ * @extends \Cake\ORM\Table<array{My: \MyNamespace\MyPlugin\Model\Behavior\MyBehavior, Timestamp: \Cake\ORM\Behavior\TimestampBehavior}>
+ *
  * @property \Cake\ORM\Association\BelongsTo<\TestApp\Model\Table\FoosTable> $Foos
  * @property \Cake\ORM\Association\BelongsToMany<\Awesome\Model\Table\HousesTable> $Houses
  *
@@ -23,8 +25,6 @@ use Cake\ORM\Table;
  *
  * @mixin \Cake\ORM\Behavior\TimestampBehavior
  * @mixin \MyNamespace\MyPlugin\Model\Behavior\MyBehavior
- *
- * @extends \Cake\ORM\Table<array{My: \MyNamespace\MyPlugin\Model\Behavior\MyBehavior, Timestamp: \Cake\ORM\Behavior\TimestampBehavior}>
  */
 class BarBarsTable extends Table {
 

--- a/tests/test_files/Model/Table/WheelsTable.php
+++ b/tests/test_files/Model/Table/WheelsTable.php
@@ -5,6 +5,7 @@ use Cake\ORM\Table;
 
 /**
  * @method \TestApp\Model\Entity\Wheel newEntity(array $data, array $options = [])
+ * @extends \Cake\ORM\Table<array{Tree: \Cake\ORM\Behavior\TreeBehavior}>
  * @property \Cake\ORM\Association\BelongsTo<\TestApp\Model\Table\CarsTable> $Cars
  * @method \TestApp\Model\Entity\Wheel newEmptyEntity()
  * @method \TestApp\Model\Entity\Wheel[] newEntities(array $data, array $options = [])
@@ -19,7 +20,6 @@ use Cake\ORM\Table;
  * @method \TestApp\Model\Entity\Wheel[]|\Cake\Datasource\ResultSetInterface<\TestApp\Model\Entity\Wheel>|false deleteMany(iterable $entities, array $options = [])
  * @method \TestApp\Model\Entity\Wheel[]|\Cake\Datasource\ResultSetInterface<\TestApp\Model\Entity\Wheel> deleteManyOrFail(iterable $entities, array $options = [])
  * @mixin \Cake\ORM\Behavior\TreeBehavior
- * @extends \Cake\ORM\Table<array{Tree: \Cake\ORM\Behavior\TreeBehavior}>
  */
 class WheelsTable extends Table {
 


### PR DESCRIPTION
## Summary

Align the order of generated table doc-block tags with the class-level order proposed in php-collective/code-sniffer#59:

```
template, extends, implements, property, property-read, property-write, method, mixin
```

`addBehaviorExtends()` was appending its tag last, so freshly annotated tables ended with the extends line at the bottom — out of order vs. the upstream sniff. Switching that one call site from `$result[]` to `array_unshift()` lifts the extends tag to position 0; the rest of the existing sequence (property -> method -> mixin) was already aligned.

## Before / after

```php
// Before
/**
 * @property ...
 * @method  ...
 * @mixin   ...
 * @extends \Cake\ORM\Table<array{...}>
 */

// After
/**
 * @extends \Cake\ORM\Table<array{...}>
 *
 * @property ...
 * @method  ...
 * @mixin   ...
 */
```

## Scope

- Fresh annotation output (the `addNewDocBlock` path) is aligned by construction.
- The merge path (`appendToExistingDocBlock`) still appends new tags after the last existing tag — legacy doc-blocks rely on the sniff fixer for a full reorder. Reordering pre-existing tags inside the annotator would duplicate what the sniff already does and is out of scope here.

## Tests

The five `tests/test_files/Model/Table/*.php` fixtures that contained an extends tag were updated to reflect the new emission order. Full suite green; phpstan and phpcs clean.
