### PR TITLE
Group strict-mode delete methods with their batch variants

### DIFF
--- a/src/Annotator/ModelAnnotator.php
+++ b/src/Annotator/ModelAnnotator.php
@@ -249,12 +249,14 @@ class ModelAnnotator extends AbstractAnnotator {
 			$annotations[] = "@method {$resultSetInterfaceCollection}|false saveMany({$iterable} \$entities, {$optionsType} \$options = [])";
 			$annotations[] = "@method {$resultSetInterfaceCollection} saveManyOrFail({$iterable} \$entities, {$optionsType} \$options = [])";
 
+			if ($strict) {
+				$annotations[] = "@method bool delete({$fullClassName} \$entity, {$optionsType} \$options = [])";
+				$annotations[] = "@method bool deleteOrFail({$fullClassName} \$entity, {$optionsType} \$options = [])";
+			}
 			$annotations[] = "@method {$resultSetInterfaceCollection}|false deleteMany({$iterable} \$entities, {$optionsType} \$options = [])";
 			$annotations[] = "@method {$resultSetInterfaceCollection} deleteManyOrFail({$iterable} \$entities, {$optionsType} \$options = [])";
 
 			if ($strict) {
-				$annotations[] = "@method bool delete({$fullClassName} \$entity, {$optionsType} \$options = [])";
-				$annotations[] = "@method bool deleteOrFail({$fullClassName} \$entity, {$optionsType} \$options = [])";
 				$annotations[] = "@method {$fullClassName}|array<{$fullClassName}> loadInto({$fullClassName}|array<{$fullClassName}> \$entities, array \$contain)";
 			}
 		}

--- a/src/View/Helper/DocBlockHelper.php
+++ b/src/View/Helper/DocBlockHelper.php
@@ -195,12 +195,14 @@ class DocBlockHelper extends BakeDocBlockHelper {
 		$resultSet = $detailed ? "\Cake\Datasource\ResultSetInterface<int, {$class}>" : "{$classes}|\Cake\Datasource\ResultSetInterface<{$class}>";
 		$annotations[] = "@method {$resultSet}|false saveMany({$itterable} \$entities, {$optionsType} \$options = [])";
 		$annotations[] = "@method {$resultSet} saveManyOrFail({$itterable} \$entities, {$optionsType} \$options = [])";
+		if ($strict) {
+			$annotations[] = "@method bool delete({$class} \$entity, {$optionsType} \$options = [])";
+			$annotations[] = "@method bool deleteOrFail({$class} \$entity, {$optionsType} \$options = [])";
+		}
 		$annotations[] = "@method {$resultSet}|false deleteMany({$itterable} \$entities, {$optionsType} \$options = [])";
 		$annotations[] = "@method {$resultSet} deleteManyOrFail({$itterable} \$entities, {$optionsType} \$options = [])";
 
 		if ($strict) {
-			$annotations[] = "@method bool delete({$class} \$entity, {$optionsType} \$options = [])";
-			$annotations[] = "@method bool deleteOrFail({$class} \$entity, {$optionsType} \$options = [])";
 			$annotations[] = "@method {$class}|array<{$class}> loadInto({$class}|array<{$class}> \$entities, array \$contain)";
 		}
 

--- a/tests/test_files/Model/Table/Specific/BarBarsStrictBareTable.php
+++ b/tests/test_files/Model/Table/Specific/BarBarsStrictBareTable.php
@@ -18,10 +18,10 @@ use Cake\ORM\Table;
  * @method \TestApp\Model\Entity\BarBar saveOrFail(\TestApp\Model\Entity\BarBar $entity, array $options = [])
  * @method \Cake\Datasource\ResultSetInterface<\TestApp\Model\Entity\BarBar>|false saveMany(iterable<\TestApp\Model\Entity\BarBar> $entities, array $options = [])
  * @method \Cake\Datasource\ResultSetInterface<\TestApp\Model\Entity\BarBar> saveManyOrFail(iterable<\TestApp\Model\Entity\BarBar> $entities, array $options = [])
- * @method \Cake\Datasource\ResultSetInterface<\TestApp\Model\Entity\BarBar>|false deleteMany(iterable<\TestApp\Model\Entity\BarBar> $entities, array $options = [])
- * @method \Cake\Datasource\ResultSetInterface<\TestApp\Model\Entity\BarBar> deleteManyOrFail(iterable<\TestApp\Model\Entity\BarBar> $entities, array $options = [])
  * @method bool delete(\TestApp\Model\Entity\BarBar $entity, array $options = [])
  * @method bool deleteOrFail(\TestApp\Model\Entity\BarBar $entity, array $options = [])
+ * @method \Cake\Datasource\ResultSetInterface<\TestApp\Model\Entity\BarBar>|false deleteMany(iterable<\TestApp\Model\Entity\BarBar> $entities, array $options = [])
+ * @method \Cake\Datasource\ResultSetInterface<\TestApp\Model\Entity\BarBar> deleteManyOrFail(iterable<\TestApp\Model\Entity\BarBar> $entities, array $options = [])
  * @method \TestApp\Model\Entity\BarBar|array<\TestApp\Model\Entity\BarBar> loadInto(\TestApp\Model\Entity\BarBar|array<\TestApp\Model\Entity\BarBar> $entities, array $contain)
  *
  * @mixin \Cake\ORM\Behavior\TimestampBehavior

--- a/tests/test_files/Model/Table/Specific/BarBarsStrictTable.php
+++ b/tests/test_files/Model/Table/Specific/BarBarsStrictTable.php
@@ -18,10 +18,10 @@ use Cake\ORM\Table;
  * @method \TestApp\Model\Entity\BarBar saveOrFail(\TestApp\Model\Entity\BarBar $entity, array<string, mixed> $options = [])
  * @method \Cake\Datasource\ResultSetInterface<\TestApp\Model\Entity\BarBar>|false saveMany(iterable<\TestApp\Model\Entity\BarBar> $entities, array<string, mixed> $options = [])
  * @method \Cake\Datasource\ResultSetInterface<\TestApp\Model\Entity\BarBar> saveManyOrFail(iterable<\TestApp\Model\Entity\BarBar> $entities, array<string, mixed> $options = [])
- * @method \Cake\Datasource\ResultSetInterface<\TestApp\Model\Entity\BarBar>|false deleteMany(iterable<\TestApp\Model\Entity\BarBar> $entities, array<string, mixed> $options = [])
- * @method \Cake\Datasource\ResultSetInterface<\TestApp\Model\Entity\BarBar> deleteManyOrFail(iterable<\TestApp\Model\Entity\BarBar> $entities, array<string, mixed> $options = [])
  * @method bool delete(\TestApp\Model\Entity\BarBar $entity, array<string, mixed> $options = [])
  * @method bool deleteOrFail(\TestApp\Model\Entity\BarBar $entity, array<string, mixed> $options = [])
+ * @method \Cake\Datasource\ResultSetInterface<\TestApp\Model\Entity\BarBar>|false deleteMany(iterable<\TestApp\Model\Entity\BarBar> $entities, array<string, mixed> $options = [])
+ * @method \Cake\Datasource\ResultSetInterface<\TestApp\Model\Entity\BarBar> deleteManyOrFail(iterable<\TestApp\Model\Entity\BarBar> $entities, array<string, mixed> $options = [])
  * @method \TestApp\Model\Entity\BarBar|array<\TestApp\Model\Entity\BarBar> loadInto(\TestApp\Model\Entity\BarBar|array<\TestApp\Model\Entity\BarBar> $entities, array $contain)
  *
  * @mixin \Cake\ORM\Behavior\TimestampBehavior


### PR DESCRIPTION
## Summary

In strict mode the recently-added `delete()` and `deleteOrFail()` were appended *after* `deleteMany()` / `deleteManyOrFail()` simply because the strict block sat at the bottom of the builder. That breaks the convention the same builder already uses elsewhere — `save()` / `saveOrFail()` come before `saveMany()` / `saveManyOrFail()`. Reorder so the four delete methods read top-to-bottom in increasing scope:

```
delete, deleteOrFail, deleteMany, deleteManyOrFail
```

`loadInto()` stays last — it's the only entity-loading method here, not a delete operation, and grouping it with delete just because both are strict-only would mislead.

## Diff (strict mode, generated)

```php
// Before
/**
 * ...
 * @method ResultSetInterface<User>|false deleteMany(...)
 * @method ResultSetInterface<User> deleteManyOrFail(...)
 * @method bool delete(\App\Model\Entity\User $entity, ...)
 * @method bool deleteOrFail(\App\Model\Entity\User $entity, ...)
 * @method User|array<User> loadInto(...)
 */

// After
/**
 * ...
 * @method bool delete(\App\Model\Entity\User $entity, ...)
 * @method bool deleteOrFail(\App\Model\Entity\User $entity, ...)
 * @method ResultSetInterface<User>|false deleteMany(...)
 * @method ResultSetInterface<User> deleteManyOrFail(...)
 * @method User|array<User> loadInto(...)
 */
```

## Tests

Both strict-mode fixtures under `tests/test_files/Model/Table/Specific` updated. Full suite green; phpstan and phpcs clean.

`DocBlockHelper` (used by the bake template) reordered the same way so freshly-baked and re-annotated output stay aligned.
