### PR TITLE
Cluster delete() variants in canonical CRUD order

### DIFF
--- a/src/Annotator/ModelAnnotator.php
+++ b/src/Annotator/ModelAnnotator.php
@@ -249,12 +249,14 @@ class ModelAnnotator extends AbstractAnnotator {
 			$annotations[] = "@method {$resultSetInterfaceCollection}|false saveMany({$iterable} \$entities, {$optionsType} \$options = [])";
 			$annotations[] = "@method {$resultSetInterfaceCollection} saveManyOrFail({$iterable} \$entities, {$optionsType} \$options = [])";
 
+			if ($strict) {
+				$annotations[] = "@method bool delete({$fullClassName} \$entity, {$optionsType} \$options = [])";
+				$annotations[] = "@method bool deleteOrFail({$fullClassName} \$entity, {$optionsType} \$options = [])";
+			}
 			$annotations[] = "@method {$resultSetInterfaceCollection}|false deleteMany({$iterable} \$entities, {$optionsType} \$options = [])";
 			$annotations[] = "@method {$resultSetInterfaceCollection} deleteManyOrFail({$iterable} \$entities, {$optionsType} \$options = [])";
 
 			if ($strict) {
-				$annotations[] = "@method bool delete({$fullClassName} \$entity, {$optionsType} \$options = [])";
-				$annotations[] = "@method bool deleteOrFail({$fullClassName} \$entity, {$optionsType} \$options = [])";
 				$annotations[] = "@method {$fullClassName}|array<{$fullClassName}> loadInto({$fullClassName}|array<{$fullClassName}> \$entities, array \$contain)";
 			}
 		}

--- a/src/View/Helper/DocBlockHelper.php
+++ b/src/View/Helper/DocBlockHelper.php
@@ -195,12 +195,14 @@ class DocBlockHelper extends BakeDocBlockHelper {
 		$resultSet = $detailed ? "\Cake\Datasource\ResultSetInterface<int, {$class}>" : "{$classes}|\Cake\Datasource\ResultSetInterface<{$class}>";
 		$annotations[] = "@method {$resultSet}|false saveMany({$itterable} \$entities, {$optionsType} \$options = [])";
 		$annotations[] = "@method {$resultSet} saveManyOrFail({$itterable} \$entities, {$optionsType} \$options = [])";
+		if ($strict) {
+			$annotations[] = "@method bool delete({$class} \$entity, {$optionsType} \$options = [])";
+			$annotations[] = "@method bool deleteOrFail({$class} \$entity, {$optionsType} \$options = [])";
+		}
 		$annotations[] = "@method {$resultSet}|false deleteMany({$itterable} \$entities, {$optionsType} \$options = [])";
 		$annotations[] = "@method {$resultSet} deleteManyOrFail({$itterable} \$entities, {$optionsType} \$options = [])";
 
 		if ($strict) {
-			$annotations[] = "@method bool delete({$class} \$entity, {$optionsType} \$options = [])";
-			$annotations[] = "@method bool deleteOrFail({$class} \$entity, {$optionsType} \$options = [])";
 			$annotations[] = "@method {$class}|array<{$class}> loadInto({$class}|array<{$class}> \$entities, array \$contain)";
 		}
 

--- a/tests/test_files/Model/Table/Specific/BarBarsStrictBareTable.php
+++ b/tests/test_files/Model/Table/Specific/BarBarsStrictBareTable.php
@@ -18,10 +18,10 @@ use Cake\ORM\Table;
  * @method \TestApp\Model\Entity\BarBar saveOrFail(\TestApp\Model\Entity\BarBar $entity, array $options = [])
  * @method \Cake\Datasource\ResultSetInterface<\TestApp\Model\Entity\BarBar>|false saveMany(iterable<\TestApp\Model\Entity\BarBar> $entities, array $options = [])
  * @method \Cake\Datasource\ResultSetInterface<\TestApp\Model\Entity\BarBar> saveManyOrFail(iterable<\TestApp\Model\Entity\BarBar> $entities, array $options = [])
- * @method \Cake\Datasource\ResultSetInterface<\TestApp\Model\Entity\BarBar>|false deleteMany(iterable<\TestApp\Model\Entity\BarBar> $entities, array $options = [])
- * @method \Cake\Datasource\ResultSetInterface<\TestApp\Model\Entity\BarBar> deleteManyOrFail(iterable<\TestApp\Model\Entity\BarBar> $entities, array $options = [])
  * @method bool delete(\TestApp\Model\Entity\BarBar $entity, array $options = [])
  * @method bool deleteOrFail(\TestApp\Model\Entity\BarBar $entity, array $options = [])
+ * @method \Cake\Datasource\ResultSetInterface<\TestApp\Model\Entity\BarBar>|false deleteMany(iterable<\TestApp\Model\Entity\BarBar> $entities, array $options = [])
+ * @method \Cake\Datasource\ResultSetInterface<\TestApp\Model\Entity\BarBar> deleteManyOrFail(iterable<\TestApp\Model\Entity\BarBar> $entities, array $options = [])
  * @method \TestApp\Model\Entity\BarBar|array<\TestApp\Model\Entity\BarBar> loadInto(\TestApp\Model\Entity\BarBar|array<\TestApp\Model\Entity\BarBar> $entities, array $contain)
  *
  * @mixin \Cake\ORM\Behavior\TimestampBehavior

--- a/tests/test_files/Model/Table/Specific/BarBarsStrictTable.php
+++ b/tests/test_files/Model/Table/Specific/BarBarsStrictTable.php
@@ -18,10 +18,10 @@ use Cake\ORM\Table;
  * @method \TestApp\Model\Entity\BarBar saveOrFail(\TestApp\Model\Entity\BarBar $entity, array<string, mixed> $options = [])
  * @method \Cake\Datasource\ResultSetInterface<\TestApp\Model\Entity\BarBar>|false saveMany(iterable<\TestApp\Model\Entity\BarBar> $entities, array<string, mixed> $options = [])
  * @method \Cake\Datasource\ResultSetInterface<\TestApp\Model\Entity\BarBar> saveManyOrFail(iterable<\TestApp\Model\Entity\BarBar> $entities, array<string, mixed> $options = [])
- * @method \Cake\Datasource\ResultSetInterface<\TestApp\Model\Entity\BarBar>|false deleteMany(iterable<\TestApp\Model\Entity\BarBar> $entities, array<string, mixed> $options = [])
- * @method \Cake\Datasource\ResultSetInterface<\TestApp\Model\Entity\BarBar> deleteManyOrFail(iterable<\TestApp\Model\Entity\BarBar> $entities, array<string, mixed> $options = [])
  * @method bool delete(\TestApp\Model\Entity\BarBar $entity, array<string, mixed> $options = [])
  * @method bool deleteOrFail(\TestApp\Model\Entity\BarBar $entity, array<string, mixed> $options = [])
+ * @method \Cake\Datasource\ResultSetInterface<\TestApp\Model\Entity\BarBar>|false deleteMany(iterable<\TestApp\Model\Entity\BarBar> $entities, array<string, mixed> $options = [])
+ * @method \Cake\Datasource\ResultSetInterface<\TestApp\Model\Entity\BarBar> deleteManyOrFail(iterable<\TestApp\Model\Entity\BarBar> $entities, array<string, mixed> $options = [])
  * @method \TestApp\Model\Entity\BarBar|array<\TestApp\Model\Entity\BarBar> loadInto(\TestApp\Model\Entity\BarBar|array<\TestApp\Model\Entity\BarBar> $entities, array $contain)
  *
  * @mixin \Cake\ORM\Behavior\TimestampBehavior


### PR DESCRIPTION
## Summary

Strict mode currently emits singular `delete()` / `deleteOrFail()` **after** `deleteMany()` / `deleteManyOrFail()`, which breaks the base → OrFail → Many → ManyOrFail cluster pattern that the `save*` block already follows. Reorder so the delete cluster mirrors save.

## Generated output (strict, before)

``` php
@method ... saveMany(...)
@method ... saveManyOrFail(...)
@method ... deleteMany(...)
@method ... deleteManyOrFail(...)
@method bool delete(...)
@method bool deleteOrFail(...)
@method ... loadInto(...)
```

## Generated output (strict, after)

``` php
@method ... saveMany(...)
@method ... saveManyOrFail(...)
@method bool delete(...)
@method bool deleteOrFail(...)
@method ... deleteMany(...)
@method ... deleteManyOrFail(...)
@method ... loadInto(...)
```

`loadInto` stays last (read-ish, additive). Non-strict mode is unchanged — singular `delete` / `deleteOrFail` aren't emitted there.

## Why

For consumers who are also pairing this with the upcoming `DocBlockTagOrder` class-level extension in php-collective/code-sniffer#59, the docblock should already arrive in canonical class order so a `composer cs-check` on freshly-baked / re-annotated output is a no-op rather than a churn pass. More broadly, the curated order is the project's own convention — `save*` follows it, `delete*` should too.

## Implementation

- `src/Annotator/ModelAnnotator.php` (re-annotate path) and `src/View/Helper/DocBlockHelper.php` (fresh-bake path) updated in lockstep so both surfaces stay aligned.
- Existing strict-mode fixtures `tests/test_files/Model/Table/Specific/BarBarsStrictTable.php` and `BarBarsStrictBareTable.php` updated to reflect the new order.
- Non-strict fixtures unaffected.
- Full test suite green: 280 tests, 856 assertions.