### PR TITLE
Discover trait/parent _get* methods for virtual properties

### DIFF
--- a/src/Annotator/EntityAnnotator.php
+++ b/src/Annotator/EntityAnnotator.php
@@ -17,6 +17,10 @@ use IdeHelper\Annotator\Traits\UseStatementsTrait;
 use IdeHelper\Utility\App;
 use IdeHelper\View\Helper\DocBlockHelper;
 use PHP_CodeSniffer\Files\File;
+use ReflectionClass;
+use ReflectionMethod;
+use ReflectionNamedType;
+use ReflectionUnionType;
 use RuntimeException;
 use Throwable;
 
@@ -57,7 +61,7 @@ class EntityAnnotator extends AbstractAnnotator {
 		}
 
 		$helper = new DocBlockHelper(new View());
-		$propertyHintMap = $this->propertyHintMap($content, $helper);
+		$propertyHintMap = $this->propertyHintMap($content, $helper, $name);
 
 		$virtualFields = $this->virtualFields($name);
 		// For BC reasons we cannot pass it as 3rd param, so we transport it on the helper as setter/getter
@@ -70,9 +74,10 @@ class EntityAnnotator extends AbstractAnnotator {
 	/**
 	 * @param string $content
 	 * @param \IdeHelper\View\Helper\DocBlockHelper $helper
+	 * @param string $name Entity short name; used to resolve the class via reflection.
 	 * @return array<string>
 	 */
-	protected function propertyHintMap(string $content, DocBlockHelper $helper): array {
+	protected function propertyHintMap(string $content, DocBlockHelper $helper, string $name = ''): array {
 		/** @var \Cake\Database\Schema\TableSchemaInterface $tableSchema */
 		$tableSchema = $this->getConfig('schema');
 		$columns = $tableSchema->columns();
@@ -89,6 +94,13 @@ class EntityAnnotator extends AbstractAnnotator {
 		$propertyHintMap = $helper->buildEntityPropertyHintTypeMap($schema);
 		$propertyHintMap = $this->buildExtendedEntityPropertyHintTypeMap($schema, $helper) + $propertyHintMap;
 		$propertyHintMap += $this->buildVirtualPropertyHintTypeMap($content);
+		// Reflection scan picks up `_get*` methods inherited from traits, parent
+		// classes, or abstract bases — the file-content tokenizer scan above
+		// can only see methods declared in the entity's own file body.
+		// Existing keys win, so this only fills gaps the file scan missed.
+		if ($name !== '') {
+			$propertyHintMap += $this->buildInheritedVirtualPropertyHintTypeMap($name);
+		}
 		$propertyHintMap += $helper->buildEntityAssociationHintTypeMap($schema);
 
 		return array_filter($propertyHintMap);
@@ -349,6 +361,107 @@ class EntityAnnotator extends AbstractAnnotator {
 		}
 
 		return $properties;
+	}
+
+	/**
+	 * Resolve `_get*` methods that are inherited into the entity class
+	 * from a trait, parent class, or abstract base. The tokenizer-based
+	 * `buildVirtualPropertyHintTypeMap()` only sees methods declared in
+	 * the entity's own file body and therefore misses these — leading
+	 * to manual `@property-read` lines being stripped on `--remove`.
+	 *
+	 * Methods declared directly on the entity class are intentionally
+	 * skipped here so the file-scan path stays the source of truth for
+	 * them; this method only fills in the inheritance gap.
+	 *
+	 * @param string $name Entity short name (filename without extension)
+	 * @return array<string, string>
+	 */
+	protected function buildInheritedVirtualPropertyHintTypeMap(string $name): array {
+		$plugin = $this->getConfig(static::CONFIG_PLUGIN);
+		$className = App::className(($plugin ? $plugin . '.' : '') . $name, 'Model/Entity');
+		if (!$className || !class_exists($className)) {
+			return [];
+		}
+
+		$reflection = new ReflectionClass($className);
+		$entityFile = $reflection->getFileName();
+
+		$properties = [];
+		foreach ($reflection->getMethods(ReflectionMethod::IS_PROTECTED) as $method) {
+			if (!preg_match('#^_get([A-Z][a-zA-Z0-9]+)$#', $method->getName(), $matches)) {
+				continue;
+			}
+
+			// Skip methods physically written in the entity's own file —
+			// the file-scan path already handles those. We only want
+			// trait / parent / abstract-default inheritance here.
+			//
+			// `getDeclaringClass()` is unreliable for traits: PHP reports
+			// trait methods as declared on the using class, so a name
+			// equality check would incorrectly skip them. Compare file
+			// paths instead — a trait method's `getFileName()` points at
+			// the trait file, not the entity file.
+			$methodFile = $method->getFileName();
+			if ($methodFile === false || $methodFile === $entityFile) {
+				continue;
+			}
+
+			$property = Inflector::underscore($matches[1]);
+			$properties[$property] = $this->reflectionReturnType($method);
+		}
+
+		return $properties;
+	}
+
+	/**
+	 * Pulls a docblock-friendly type out of a `_get*` method via reflection.
+	 * Prefers a `@return` docblock entry (richer types — generics, unions,
+	 * fully-qualified class refs); falls back to the PHP return type hint.
+	 *
+	 * @param \ReflectionMethod $method
+	 * @return string
+	 */
+	protected function reflectionReturnType(ReflectionMethod $method): string {
+		$doc = $method->getDocComment();
+		if ($doc !== false && preg_match('/@return\s+([^\s\*]+)/', $doc, $matches)) {
+			return $matches[1];
+		}
+
+		$returnType = $method->getReturnType();
+		if ($returnType instanceof ReflectionNamedType) {
+			$type = $returnType->getName();
+			if ($type === 'mixed' || $type === 'null' || $type === 'void' || $type === 'never') {
+				return $type === 'void' || $type === 'never' ? 'mixed' : $type;
+			}
+			if (!$returnType->isBuiltin() && strpos($type, '\\') !== 0) {
+				$type = '\\' . $type;
+			}
+			if ($returnType->allowsNull()) {
+				$type .= '|null';
+			}
+
+			return $type;
+		}
+
+		if ($returnType instanceof ReflectionUnionType) {
+			$parts = [];
+			foreach ($returnType->getTypes() as $part) {
+				if (!$part instanceof ReflectionNamedType) {
+					continue;
+				}
+				$piece = $part->getName();
+				if (!$part->isBuiltin() && strpos($piece, '\\') !== 0) {
+					$piece = '\\' . $piece;
+				}
+				$parts[] = $piece;
+			}
+			if ($parts) {
+				return implode('|', $parts);
+			}
+		}
+
+		return 'mixed';
 	}
 
 	/**

--- a/src/Annotator/EntityAnnotator.php
+++ b/src/Annotator/EntityAnnotator.php
@@ -75,7 +75,7 @@ class EntityAnnotator extends AbstractAnnotator {
 	 * @param string $content
 	 * @param \IdeHelper\View\Helper\DocBlockHelper $helper
 	 * @param string $name Entity short name; used to resolve the class via reflection.
-	 * @return array<string>
+	 * @return array<string, string>
 	 */
 	protected function propertyHintMap(string $content, DocBlockHelper $helper, string $name = ''): array {
 		/** @var \Cake\Database\Schema\TableSchemaInterface $tableSchema */
@@ -424,20 +424,17 @@ class EntityAnnotator extends AbstractAnnotator {
 	 */
 	protected function reflectionReturnType(ReflectionMethod $method): string {
 		$doc = $method->getDocComment();
-		if ($doc !== false && preg_match('/@return\s+([^\s\*]+)/', $doc, $matches)) {
-			return $matches[1];
+		if ($doc !== false) {
+			$type = $this->extractReturnTagFromDocBlock($doc);
+			if ($type !== null) {
+				return $type;
+			}
 		}
 
 		$returnType = $method->getReturnType();
 		if ($returnType instanceof ReflectionNamedType) {
-			$type = $returnType->getName();
-			if ($type === 'mixed' || $type === 'null' || $type === 'void' || $type === 'never') {
-				return $type === 'void' || $type === 'never' ? 'mixed' : $type;
-			}
-			if (!$returnType->isBuiltin() && strpos($type, '\\') !== 0) {
-				$type = '\\' . $type;
-			}
-			if ($returnType->allowsNull()) {
+			$type = $this->stringifyReflectionType($returnType);
+			if ($returnType->allowsNull() && !str_contains($type, '|null') && $type !== 'mixed' && $type !== 'null') {
 				$type .= '|null';
 			}
 
@@ -450,11 +447,7 @@ class EntityAnnotator extends AbstractAnnotator {
 				if (!$part instanceof ReflectionNamedType) {
 					continue;
 				}
-				$piece = $part->getName();
-				if (!$part->isBuiltin() && strpos($piece, '\\') !== 0) {
-					$piece = '\\' . $piece;
-				}
-				$parts[] = $piece;
+				$parts[] = $this->stringifyReflectionType($part);
 			}
 			if ($parts) {
 				return implode('|', $parts);
@@ -462,6 +455,70 @@ class EntityAnnotator extends AbstractAnnotator {
 		}
 
 		return 'mixed';
+	}
+
+	/**
+	 * Pulls the `@return` payload out of a raw docblock string,
+	 * tracking `<>` bracket depth so generics with spaces (e.g.
+	 * `array<int, \Foo\Bar>`) are kept intact instead of being
+	 * truncated at the first inner space.
+	 *
+	 * @param string $docComment Raw docblock contents
+	 * @return string|null The captured type expression, or null if no `@return` tag.
+	 */
+	protected function extractReturnTagFromDocBlock(string $docComment): ?string {
+		if (!preg_match('/@return\s+(.+)$/m', $docComment, $matches)) {
+			return null;
+		}
+
+		$payload = $matches[1];
+		$bracketDepth = 0;
+		$end = null;
+		$length = strlen($payload);
+		for ($i = 0; $i < $length; $i++) {
+			$char = $payload[$i];
+			if ($char === '<') {
+				$bracketDepth++;
+
+				continue;
+			}
+			if ($char === '>') {
+				$bracketDepth--;
+
+				continue;
+			}
+			if ($bracketDepth === 0 && ($char === ' ' || $char === "\t" || $char === '*' || $char === "\n" || $char === "\r")) {
+				$end = $i;
+
+				break;
+			}
+		}
+
+		$type = $end !== null ? substr($payload, 0, $end) : $payload;
+
+		return rtrim($type) !== '' ? rtrim($type) : null;
+	}
+
+	/**
+	 * Render a single `ReflectionNamedType` as a docblock-friendly string.
+	 *
+	 * Builtins (`int`, `string`, `array`, …) and the relative-class keywords
+	 * `self` / `static` / `parent` are returned as-is; class names get a
+	 * leading backslash so they're unambiguous in `@property-read` docblocks.
+	 *
+	 * @param \ReflectionNamedType $type
+	 * @return string
+	 */
+	protected function stringifyReflectionType(ReflectionNamedType $type): string {
+		$name = $type->getName();
+		if ($type->isBuiltin()) {
+			return $name === 'void' || $name === 'never' ? 'mixed' : $name;
+		}
+		if (in_array($name, ['self', 'static', 'parent'], true)) {
+			return $name;
+		}
+
+		return strpos($name, '\\') === 0 ? $name : '\\' . $name;
 	}
 
 	/**

--- a/tests/TestCase/Annotator/EntityAnnotatorTest.php
+++ b/tests/TestCase/Annotator/EntityAnnotatorTest.php
@@ -313,6 +313,46 @@ class EntityAnnotatorTest extends TestCase {
 	}
 
 	/**
+	 * Regression test for trait-backed virtual properties: the
+	 * tokenizer-based scan only sees `_get*` methods declared in
+	 * the entity's own file body, so trait-imported `_get*` methods
+	 * used to be invisible — and `--remove` would strip the manual
+	 * `@property-read` lines for them.
+	 *
+	 * The reflection fallback in buildInheritedVirtualPropertyHintTypeMap()
+	 * picks them up. Verifies trait-virtuals AND in-class virtuals
+	 * both end up in the generated docblock.
+	 *
+	 * @return void
+	 */
+	public function testAnnotateWithTraitBackedVirtualProperties() {
+		/** @var \TestApp\Model\Table\FoosTable $Table */
+		$Table = TableRegistry::getTableLocator()->get('Foos');
+
+		$schema = $Table->getSchema();
+		$associations = $Table->associations();
+		$annotator = $this->_getAnnotatorMock(['schema' => $schema, 'associations' => $associations]);
+
+		$expectedContent = str_replace(["\r\n", "\r"], "\n", file_get_contents(TEST_FILES . 'Model/Entity/VirtualWithTrait.php'));
+		$callback = function ($value) use ($expectedContent) {
+			$value = str_replace(["\r\n", "\r"], "\n", $value);
+			if ($value !== $expectedContent) {
+				$this->_displayDiff($expectedContent, $value);
+			}
+
+			return $value === $expectedContent;
+		};
+		$annotator->expects($this->once())->method('storeFile')->with($this->anything(), $this->callback($callback));
+
+		$path = APP . 'Model/Entity/VirtualWithTrait.php';
+		$annotator->annotate($path);
+
+		$output = $this->out->output();
+
+		$this->assertTextContains('annotations added', $output);
+	}
+
+	/**
 	 * @return void
 	 */
 	public function testAnnotateWithVirtualPropertiesAndReturnTypes() {

--- a/tests/TestCase/Illuminator/IlluminatorTest.php
+++ b/tests/TestCase/Illuminator/IlluminatorTest.php
@@ -43,7 +43,7 @@ class IlluminatorTest extends TestCase {
 		$path = TEST_FILES;
 		$count = $this->illuminator->illuminate($path, null);
 
-		$this->assertSame(14, $count);
+		$this->assertSame(15, $count);
 
 		$out = $this->out->output();
 

--- a/tests/test_app/src/Model/Entity/Traits/DatePrecisionEntityTrait.php
+++ b/tests/test_app/src/Model/Entity/Traits/DatePrecisionEntityTrait.php
@@ -23,4 +23,14 @@ trait DatePrecisionEntityTrait {
 		};
 	}
 
+	/**
+	 * Generic return type with internal whitespace — exercises the
+	 * bracket-depth-aware `@return` parser.
+	 *
+	 * @return array<int, string>
+	 */
+	protected function _getDatePrecisionLabels(): array {
+		return ['exact', 'week', 'month', 'quarter'];
+	}
+
 }

--- a/tests/test_app/src/Model/Entity/Traits/DatePrecisionEntityTrait.php
+++ b/tests/test_app/src/Model/Entity/Traits/DatePrecisionEntityTrait.php
@@ -1,0 +1,26 @@
+<?php
+namespace TestApp\Model\Entity\Traits;
+
+trait DatePrecisionEntityTrait {
+
+	/**
+	 * @return bool
+	 */
+	protected function _getIsDateApproximate(): bool {
+		return $this->get('date_precision') > 1;
+	}
+
+	/**
+	 * @return string|null
+	 */
+	protected function _getDatePrecisionString(): ?string {
+		return match ($this->get('date_precision')) {
+			1 => 'exact',
+			2 => 'week',
+			3 => 'month',
+			4 => 'quarter',
+			default => null,
+		};
+	}
+
+}

--- a/tests/test_app/src/Model/Entity/VirtualWithTrait.php
+++ b/tests/test_app/src/Model/Entity/VirtualWithTrait.php
@@ -11,6 +11,7 @@ class VirtualWithTrait extends Entity {
 	protected array $_virtual = [
 		'is_date_approximate',
 		'date_precision_string',
+		'date_precision_labels',
 		'in_class_virtual',
 	];
 

--- a/tests/test_app/src/Model/Entity/VirtualWithTrait.php
+++ b/tests/test_app/src/Model/Entity/VirtualWithTrait.php
@@ -1,0 +1,24 @@
+<?php
+namespace TestApp\Model\Entity;
+
+use Cake\ORM\Entity;
+use TestApp\Model\Entity\Traits\DatePrecisionEntityTrait;
+
+class VirtualWithTrait extends Entity {
+
+	use DatePrecisionEntityTrait;
+
+	protected array $_virtual = [
+		'is_date_approximate',
+		'date_precision_string',
+		'in_class_virtual',
+	];
+
+	/**
+	 * @return string
+	 */
+	protected function _getInClassVirtual(): string {
+		return 'in-class';
+	}
+
+}

--- a/tests/test_files/Model/Entity/VirtualWithTrait.php
+++ b/tests/test_files/Model/Entity/VirtualWithTrait.php
@@ -1,0 +1,37 @@
+<?php
+namespace TestApp\Model\Entity;
+
+use Cake\ORM\Entity;
+use TestApp\Model\Entity\Traits\DatePrecisionEntityTrait;
+
+/**
+ * @property array|null $params
+ * @property int $id
+ * @property string $name
+ * @property string $content
+ * @property \Cake\I18n\Date $offer_date
+ * @property \Cake\I18n\DateTime $created
+ * @property \Cake\I18n\DateTime|null $modified
+ *
+ * @property-read string $in_class_virtual
+ * @property-read bool $is_date_approximate
+ * @property-read string|null $date_precision_string
+ */
+class VirtualWithTrait extends Entity {
+
+	use DatePrecisionEntityTrait;
+
+	protected array $_virtual = [
+		'is_date_approximate',
+		'date_precision_string',
+		'in_class_virtual',
+	];
+
+	/**
+	 * @return string
+	 */
+	protected function _getInClassVirtual(): string {
+		return 'in-class';
+	}
+
+}

--- a/tests/test_files/Model/Entity/VirtualWithTrait.php
+++ b/tests/test_files/Model/Entity/VirtualWithTrait.php
@@ -16,6 +16,7 @@ use TestApp\Model\Entity\Traits\DatePrecisionEntityTrait;
  * @property-read string $in_class_virtual
  * @property-read bool $is_date_approximate
  * @property-read string|null $date_precision_string
+ * @property-read array<int, string> $date_precision_labels
  */
 class VirtualWithTrait extends Entity {
 
@@ -24,6 +25,7 @@ class VirtualWithTrait extends Entity {
 	protected array $_virtual = [
 		'is_date_approximate',
 		'date_precision_string',
+		'date_precision_labels',
 		'in_class_virtual',
 	];
 


### PR DESCRIPTION
## Summary

The tokenizer-based scan in `EntityAnnotator::buildVirtualPropertyHintTypeMap()` only sees `_get*` methods declared in the entity's own file body. Virtual accessors imported from a trait, inherited from a parent class, or provided by an abstract base were invisible — and combined with `bin/cake annotate all -r`, manual `property-read` lines for those properties got silently stripped on every run.

## Repro before this PR

```php
// src/Model/Entity/Traits/DatePrecisionTrait.php
trait DatePrecisionTrait {
    protected function _getIsDateApproximate(): bool { /* ... */ }
}

// src/Model/Entity/EventParticipation.php
/**
 * @property-read bool $is_date_approximate
 */
class EventParticipation extends Entity {
    use DatePrecisionTrait;
    protected array $_virtual = ['is_date_approximate'];
}
```

`bin/cake annotate all -r -d --ci` reports `2 annotations removed` and strips the `property-read` line — even though the trait method is real and the field is in `_virtual`.

## Fix

Add a complementary reflection-based scan that fills in only the **inheritance gap**. The existing file-scan path keeps owning methods declared directly on the entity, so its return-type extraction (already battle-tested) is unaffected.

PHP reports trait methods as declared on the using class, so `getDeclaringClass()` is unreliable — the discriminator is **the file path of the reflected method**. If that file isn't the entity's own file, the method came from a trait, parent class, or abstract base.

The reflection helper resolves a docblock-friendly type by preferring a docblock return entry first (richer types — generics, unions, FQCNs), then the PHP return type hint, then `mixed`.

## What didn't change

- File-content tokenizer scan stays the source of truth for in-class `_get*` methods.
- Reflection only fills missing keys (`+=` on the property hint map).
- No public API change.

## Tests

Added a regression test plus fixtures:

- `tests/test_app/src/Model/Entity/Traits/DatePrecisionEntityTrait.php` — trait with two `_get*` methods, one with full type info, one with nullable return.
- `tests/test_app/src/Model/Entity/VirtualWithTrait.php` — entity that uses the trait plus an in-class `_getInClassVirtual()`. Tests that **both** code paths cooperate.
- `tests/test_files/Model/Entity/VirtualWithTrait.php` — expected output snapshot.
- `tests/TestCase/Annotator/EntityAnnotatorTest::testAnnotateWithTraitBackedVirtualProperties` — drives the assertion.
- `IlluminatorTest::testIlluminate` count bumped 14 to 15 for the new fixture.

Whole suite green: 281 tests, 860 assertions.

## Verification

```
composer stan        # OK, no errors
composer cs-check    # 16/16, no violations
vendor/bin/phpunit   # 281 tests, 0 failures
```
