### PR TITLE
Skip method overrides resolved by the parent's TEntity template

### DIFF
--- a/src/Annotator/ModelAnnotator.php
+++ b/src/Annotator/ModelAnnotator.php
@@ -230,11 +230,37 @@ class ModelAnnotator extends AbstractAnnotator {
 			 *
 			 * @link \Bake\View\Helper\DocBlockHelper::buildTableAnnotations()
 			 */
-			$annotations[] = "@method {$fullClassName} newEmptyEntity()";
+			// On CakePHP 5.4+, `\Cake\ORM\Table` declares an entity template
+			// (`@template TEntity`). When we emit `@extends \Cake\ORM\Table<..., TEntity>`,
+			// PHPStan resolves entity-returning methods from the parent on its own AND
+			// preserves the parent's `@throws` declarations — so re-emitting `@method`
+			// overrides for those methods would only strip `@throws`, producing false
+			// `catch.neverThrown` errors.
+			//
+			// Gates (all must hold to consider an override redundant):
+			//  - Cake supports the entity template;
+			//  - `IdeHelper.tableBehaviors` includes `extends` (otherwise `@extends`
+			//    isn't emitted by addBehaviorExtends() and the parent generic is absent);
+			//  - the table's direct parent is `\Cake\ORM\Table` (intermediate base
+			//    classes such as `AbstractTable extends Table` don't propagate
+			//    `TEntity` unless they re-declare it themselves).
+			//
+			// Per-method gates also account for parameter narrowing the parent doesn't
+			// provide (detailed `$finder` on `get()`, concrete `$entity` on `saveOrFail()`),
+			// so we keep those overrides when the user has opted into narrowing.
+			$entityTemplateEmitted = $this->supportsEntityTemplate()
+				&& in_array(static::BEHAVIOR_EXTENDS, $this->_config[static::TABLE_BEHAVIORS], true)
+				&& ($parentClass === '' || ltrim($parentClass, '\\') === 'Cake\\ORM\\Table');
+
+			if (!$entityTemplateEmitted) {
+				$annotations[] = "@method {$fullClassName} newEmptyEntity()";
+			}
 			$annotations[] = "@method {$fullClassName} newEntity({$dataType} \$data, {$optionsType} \$options = [])";
 			$annotations[] = "@method {$fullClassNameCollection} newEntities({$dataListType} \$data, {$optionsType} \$options = [])";
 
-			$annotations[] = "@method {$fullClassName} get(mixed \$primaryKey, {$finderType} \$finder = 'all', \Psr\SimpleCache\CacheInterface|string|null \$cache = null, \Closure|string|null \$cacheKey = null, mixed ...\$args)";
+			if (!$entityTemplateEmitted || $detailed) {
+				$annotations[] = "@method {$fullClassName} get(mixed \$primaryKey, {$finderType} \$finder = 'all', \Psr\SimpleCache\CacheInterface|string|null \$cache = null, \Closure|string|null \$cacheKey = null, mixed ...\$args)";
+			}
 			if (Configure::read('IdeHelper.tableEntityQuery')) {
 				$annotations[] = "@method \Cake\ORM\Query\SelectQuery<{$fullClassName}> find(string \$type = 'all', mixed ...\$args)";
 			}
@@ -243,8 +269,10 @@ class ModelAnnotator extends AbstractAnnotator {
 			$annotations[] = "@method {$fullClassName} patchEntity({$entityInterface} \$entity, {$dataType} \$data, {$optionsType} \$options = [])";
 			$annotations[] = "@method {$fullClassNameCollection} patchEntities({$iterable} \$entities, {$dataListType} \$data, {$optionsType} \$options = [])";
 
-			$annotations[] = "@method {$fullClassName}|false save({$entityInterface} \$entity, {$optionsType} \$options = [])";
-			$annotations[] = "@method {$fullClassName} saveOrFail({$entityInterface} \$entity, {$optionsType} \$options = [])";
+			if (!$entityTemplateEmitted || $concrete) {
+				$annotations[] = "@method {$fullClassName}|false save({$entityInterface} \$entity, {$optionsType} \$options = [])";
+				$annotations[] = "@method {$fullClassName} saveOrFail({$entityInterface} \$entity, {$optionsType} \$options = [])";
+			}
 
 			$annotations[] = "@method {$resultSetInterfaceCollection}|false saveMany({$iterable} \$entities, {$optionsType} \$options = [])";
 			$annotations[] = "@method {$resultSetInterfaceCollection} saveManyOrFail({$iterable} \$entities, {$optionsType} \$options = [])";

--- a/tests/TestCase/Annotator/ModelAnnotatorTest.php
+++ b/tests/TestCase/Annotator/ModelAnnotatorTest.php
@@ -111,6 +111,8 @@ class ModelAnnotatorTest extends TestCase {
 		Configure::delete('IdeHelper.assocsAsGenerics');
 		Configure::delete('IdeHelper.tableEntityQuery');
 		Configure::delete('IdeHelper.tableBehaviors');
+		Configure::delete('IdeHelper.concreteEntitiesInParam');
+		Configure::delete('IdeHelper.genericsInParam');
 	}
 
 	/**
@@ -393,7 +395,119 @@ class ModelAnnotatorTest extends TestCase {
 		$annotator->annotate($path);
 
 		$output = $this->out->output();
-		$this->assertTextContains('  -> 18 annotations added', $output);
+		$this->assertTextContains('  -> 14 annotations added', $output);
+	}
+
+	/**
+	 * Regression: even when CakePHP supports `TEntity`, the @method overrides must
+	 * still be emitted if `IdeHelper.tableBehaviors` excludes `extends`. Without an
+	 * `@extends Table<..., TEntity>` annotation there is no parent generic for PHPStan
+	 * to resolve from, so suppressing the overrides would lose the concrete types.
+	 *
+	 * @return void
+	 */
+	public function testAnnotateWithEntityTemplateKeepsOverridesWhenExtendsDisabled() {
+		Configure::write('IdeHelper.tableBehaviors', 'mixin');
+
+		$annotator = $this->_getEntityTemplateAnnotatorMock([]);
+
+		$capture = '';
+		$annotator->expects($this->once())
+			->method('storeFile')
+			->with($this->anything(), $this->callback(function ($value) use (&$capture) {
+				$capture = $value;
+
+				return true;
+			}));
+
+		$annotator->annotate(APP . 'Model/Table/BarBarsTable.php');
+
+		$this->assertStringContainsString('save(', $capture);
+		$this->assertStringContainsString('saveOrFail(', $capture);
+		$this->assertStringContainsString('newEmptyEntity()', $capture);
+		$this->assertStringContainsString(' get(mixed $primaryKey', $capture);
+	}
+
+	/**
+	 * Regression: when the immediate parent is a custom base table (not `\Cake\ORM\Table`),
+	 * we cannot assume the parent re-declares the entity template, so the @method
+	 * overrides must still be emitted even on CakePHP 5.4+.
+	 *
+	 * @return void
+	 */
+	public function testAnnotateWithEntityTemplateKeepsOverridesForCustomParent() {
+		$annotator = $this->_getEntityTemplateAnnotatorMock([]);
+
+		$capture = '';
+		$annotator->method('storeFile')
+			->with($this->anything(), $this->callback(function ($value) use (&$capture) {
+				$capture = $value;
+
+				return true;
+			}));
+
+		$annotator->annotate(APP . 'Model/Table/BarBarsAbstractTable.php');
+
+		$this->assertStringContainsString('save(', $capture);
+		$this->assertStringContainsString('saveOrFail(', $capture);
+		$this->assertStringContainsString('newEmptyEntity()', $capture);
+		$this->assertStringContainsString(' get(mixed $primaryKey', $capture);
+	}
+
+	/**
+	 * Regression: in `concreteEntitiesInParam` mode the `save()` and `saveOrFail()`
+	 * overrides narrow `$entity` to the concrete entity class, which the parent's
+	 * `EntityInterface` param does not provide. Keep the overrides when this
+	 * narrowing is requested.
+	 *
+	 * @return void
+	 */
+	public function testAnnotateWithEntityTemplateKeepsSaveOverridesWhenConcreteEntitiesInParam() {
+		Configure::write('IdeHelper.concreteEntitiesInParam', true);
+
+		$annotator = $this->_getEntityTemplateAnnotatorMock([]);
+
+		$capture = '';
+		$annotator->expects($this->once())
+			->method('storeFile')
+			->with($this->anything(), $this->callback(function ($value) use (&$capture) {
+				$capture = $value;
+
+				return true;
+			}));
+
+		$annotator->annotate(APP . 'Model/Table/BarBarsTable.php');
+
+		$this->assertStringContainsString('save(\TestApp\Model\Entity\BarBar $entity', $capture);
+		$this->assertStringContainsString('saveOrFail(\TestApp\Model\Entity\BarBar $entity', $capture);
+		// `newEmptyEntity` remains suppressed because it has no parameters to narrow.
+		$this->assertStringNotContainsString('newEmptyEntity()', $capture);
+	}
+
+	/**
+	 * Regression: in `genericsInParam=detailed` mode the `get()` override narrows
+	 * `$finder` to `array<string, mixed>|string`, narrower than the parent's
+	 * `array|string`. Keep the override when this narrowing is requested.
+	 *
+	 * @return void
+	 */
+	public function testAnnotateWithEntityTemplateKeepsGetWhenDetailedGenerics() {
+		Configure::write('IdeHelper.genericsInParam', 'detailed');
+
+		$annotator = $this->_getEntityTemplateAnnotatorMock([]);
+
+		$capture = '';
+		$annotator->expects($this->once())
+			->method('storeFile')
+			->with($this->anything(), $this->callback(function ($value) use (&$capture) {
+				$capture = $value;
+
+				return true;
+			}));
+
+		$annotator->annotate(APP . 'Model/Table/BarBarsTable.php');
+
+		$this->assertStringContainsString('get(mixed $primaryKey, array<string, mixed>|string', $capture);
 	}
 
 }

--- a/tests/test_files/Model/Table/BarBarsEntityTemplateTable.php
+++ b/tests/test_files/Model/Table/BarBarsEntityTemplateTable.php
@@ -9,15 +9,11 @@ use Cake\ORM\Table;
  * @property \Cake\ORM\Association\BelongsTo<\TestApp\Model\Table\FoosTable> $Foos
  * @property \Cake\ORM\Association\BelongsToMany<\Awesome\Model\Table\HousesTable> $Houses
  *
- * @method \TestApp\Model\Entity\BarBar newEmptyEntity()
  * @method \TestApp\Model\Entity\BarBar newEntity(array $data, array $options = [])
  * @method \TestApp\Model\Entity\BarBar[] newEntities(array $data, array $options = [])
- * @method \TestApp\Model\Entity\BarBar get(mixed $primaryKey, array|string $finder = 'all', \Psr\SimpleCache\CacheInterface|string|null $cache = null, \Closure|string|null $cacheKey = null, mixed ...$args)
  * @method \TestApp\Model\Entity\BarBar findOrCreate(\Cake\ORM\Query\SelectQuery|callable|array $search, ?callable $callback = null, array $options = [])
  * @method \TestApp\Model\Entity\BarBar patchEntity(\Cake\Datasource\EntityInterface $entity, array $data, array $options = [])
  * @method \TestApp\Model\Entity\BarBar[] patchEntities(iterable $entities, array $data, array $options = [])
- * @method \TestApp\Model\Entity\BarBar|false save(\Cake\Datasource\EntityInterface $entity, array $options = [])
- * @method \TestApp\Model\Entity\BarBar saveOrFail(\Cake\Datasource\EntityInterface $entity, array $options = [])
  * @method \TestApp\Model\Entity\BarBar[]|\Cake\Datasource\ResultSetInterface<\TestApp\Model\Entity\BarBar>|false saveMany(iterable $entities, array $options = [])
  * @method \TestApp\Model\Entity\BarBar[]|\Cake\Datasource\ResultSetInterface<\TestApp\Model\Entity\BarBar> saveManyOrFail(iterable $entities, array $options = [])
  * @method \TestApp\Model\Entity\BarBar[]|\Cake\Datasource\ResultSetInterface<\TestApp\Model\Entity\BarBar>|false deleteMany(iterable $entities, array $options = [])


### PR DESCRIPTION
## Summary

On CakePHP 5.4+, `Cake\ORM\Table` declares `extends TBehaviors, TEntity` and methods like `get()` / `newEmptyEntity()` / `save()` / `saveOrFail()` annotate `return TEntity`. IdeHelper already emits the matching `extends Table<TBehaviors, TEntity>` line on the user's Table class, so the entity return type is resolved by the parent generic.

The remaining problem: re-emitting `method` overrides for those same methods strips the parent's `throws` annotations (`PersistenceFailedException`, `RecordNotFoundException`, `InvalidPrimaryKeyException`, `RolledbackTransactionException`), because phpDoc `method` has no `throws` slot. The result is PHPStan reporting `catch.neverThrown` for ordinary code like:

```php
try {
    $entity = $table->saveOrFail($entity);
} catch (PersistenceFailedException $e) {
    // …
}
```

This PR suppresses those four redundant overrides when all of the following hold:

- CakePHP supports the entity template (≥ 5.4.0)
- `IdeHelper.tableBehaviors` includes `extends` so the `extends` annotation is actually emitted
- the immediate parent is `Cake\ORM\Table` (intermediate base classes do not propagate `TEntity` unless they re-declare it)

Per-method narrowing is preserved when requested via existing config:

- `get()` is kept when `IdeHelper.genericsInParam = 'detailed'` (the override narrows `finder`)
- `save()` / `saveOrFail()` are kept when `IdeHelper.concreteEntitiesInParam` is on (the override narrows `entity` to the concrete entity class)

## Out of scope (deliberate)

These also strip parent `throws` but each has a parent-`return` mismatch that would regress concrete typing if suppressed today — they need a coordinated upstream change first:

- `findOrCreate()` → parent's `return` is `Cake\Datasource\EntityInterface`, not `TEntity`
- `saveManyOrFail()` / `deleteManyOrFail()` → parent's `return` is plain `iterable<T>`, not `ResultSetInterface<T>`
- `find()` (when `IdeHelper.tableEntityQuery` is on) → parent's `return` is `SelectQuery<EntityInterface|array>`, not `SelectQuery<TEntity>`

A follow-up Cake PR proposing TEntity-aware annotations on these methods would unlock the rest.

Bake's `DocBlockHelper::buildTableAnnotations()` is intentionally left untouched: Bake does not currently emit `extends` for newly baked tables, so suppressing overrides there would be a net regression. That's a separate change (emit `extends` in Bake, then mirror the suppression).

## Context

Related discussion: <https://github.com/CakeDC/cakephp-phpstan/issues/47>

## Verification

- `vendor/bin/phpunit` — 286 / 286 green (added 3 regression tests covering custom base table, `concreteEntitiesInParam`, `genericsInParam=detailed`, and a fourth for `tableBehaviors=mixin`)
- `composer stan` — clean
- `composer cs-check` — clean
