### PR TITLE
Suppress find()/findOrCreate()/loadInto() method overrides on Cake 5.3.6+

### DIFF
--- a/src/Annotator/ModelAnnotator.php
+++ b/src/Annotator/ModelAnnotator.php
@@ -578,14 +578,12 @@ class ModelAnnotator extends AbstractAnnotator {
 	}
 
 	/**
-	 * Whether `\Cake\ORM\Table` declares a second `TEntity` template parameter.
-	 *
-	 * Introduced via cakephp/cakephp#19388, first released in CakePHP 5.3.4.
+	 * Whether `\Cake\ORM\Table` declares a second `TEntity` template parameter (CakePHP 5.4+).
 	 *
 	 * @return bool
 	 */
 	protected function supportsEntityTemplate(): bool {
-		return version_compare(Configure::version(), '5.3.4', '>=');
+		return version_compare(Configure::version(), '5.4.0', '>=');
 	}
 
 	/**

--- a/src/Annotator/ModelAnnotator.php
+++ b/src/Annotator/ModelAnnotator.php
@@ -246,11 +246,18 @@ class ModelAnnotator extends AbstractAnnotator {
 			//    `TEntity` unless they re-declare it themselves).
 			//
 			// Per-method gates also account for parameter narrowing the parent doesn't
-			// provide (detailed `$finder` on `get()`, concrete `$entity` on `saveOrFail()`),
-			// so we keep those overrides when the user has opted into narrowing.
+			// provide (detailed `$finder` on `get()`, detailed `$search` on `findOrCreate()`,
+			// concrete `$entity` on `save()`/`saveOrFail()`), so we keep those overrides
+			// when the user has opted into narrowing.
+			//
+			// `find()`/`findOrCreate()`/`loadInto()` were only updated to flow `TEntity`
+			// in cakephp/cakephp#19438 — a strictly later change than the class template
+			// itself — so they have their own feature gate via
+			// `supportsEntityTemplateFindFamily()`.
 			$entityTemplateEmitted = $this->supportsEntityTemplate()
 				&& in_array(static::BEHAVIOR_EXTENDS, $this->_config[static::TABLE_BEHAVIORS], true)
 				&& ($parentClass === '' || ltrim($parentClass, '\\') === 'Cake\\ORM\\Table');
+			$entityTemplateFindFamily = $entityTemplateEmitted && $this->supportsEntityTemplateFindFamily();
 
 			if (!$entityTemplateEmitted) {
 				$annotations[] = "@method {$fullClassName} newEmptyEntity()";
@@ -261,10 +268,12 @@ class ModelAnnotator extends AbstractAnnotator {
 			if (!$entityTemplateEmitted || $detailed) {
 				$annotations[] = "@method {$fullClassName} get(mixed \$primaryKey, {$finderType} \$finder = 'all', \Psr\SimpleCache\CacheInterface|string|null \$cache = null, \Closure|string|null \$cacheKey = null, mixed ...\$args)";
 			}
-			if (Configure::read('IdeHelper.tableEntityQuery')) {
+			if (Configure::read('IdeHelper.tableEntityQuery') && !$entityTemplateFindFamily) {
 				$annotations[] = "@method \Cake\ORM\Query\SelectQuery<{$fullClassName}> find(string \$type = 'all', mixed ...\$args)";
 			}
-			$annotations[] = "@method {$fullClassName} findOrCreate({$findOrCreateSearchType} \$search, ?callable \$callback = null, {$optionsType} \$options = [])";
+			if (!$entityTemplateFindFamily || $detailed) {
+				$annotations[] = "@method {$fullClassName} findOrCreate({$findOrCreateSearchType} \$search, ?callable \$callback = null, {$optionsType} \$options = [])";
+			}
 
 			$annotations[] = "@method {$fullClassName} patchEntity({$entityInterface} \$entity, {$dataType} \$data, {$optionsType} \$options = [])";
 			$annotations[] = "@method {$fullClassNameCollection} patchEntities({$iterable} \$entities, {$dataListType} \$data, {$optionsType} \$options = [])";
@@ -284,7 +293,7 @@ class ModelAnnotator extends AbstractAnnotator {
 			$annotations[] = "@method {$resultSetInterfaceCollection}|false deleteMany({$iterable} \$entities, {$optionsType} \$options = [])";
 			$annotations[] = "@method {$resultSetInterfaceCollection} deleteManyOrFail({$iterable} \$entities, {$optionsType} \$options = [])";
 
-			if ($strict) {
+			if ($strict && !$entityTemplateFindFamily) {
 				$annotations[] = "@method {$fullClassName}|array<{$fullClassName}> loadInto({$fullClassName}|array<{$fullClassName}> \$entities, array \$contain)";
 			}
 		}
@@ -569,12 +578,31 @@ class ModelAnnotator extends AbstractAnnotator {
 	}
 
 	/**
-	 * Whether `\Cake\ORM\Table` declares a second `TEntity` template parameter (CakePHP 5.4+).
+	 * Whether `\Cake\ORM\Table` declares a second `TEntity` template parameter.
+	 *
+	 * Introduced via cakephp/cakephp#19388, first released in CakePHP 5.3.4.
 	 *
 	 * @return bool
 	 */
 	protected function supportsEntityTemplate(): bool {
-		return version_compare(Configure::version(), '5.4.0', '>=');
+		return version_compare(Configure::version(), '5.3.4', '>=');
+	}
+
+	/**
+	 * Whether `\Cake\ORM\Table::find()` / `findOrCreate()` / `loadInto()` propagate
+	 * the entity template `TEntity` through their `@return`.
+	 *
+	 * This is a strictly later change than {@see static::supportsEntityTemplate()} —
+	 * the class-level template was added separately from the find-family annotations.
+	 *
+	 * Requires cakephp/cakephp#19438, currently milestoned for CakePHP 5.3.6. The
+	 * version gate below MUST be set to the actual release containing that change
+	 * before this is mark-able as non-draft.
+	 *
+	 * @return bool
+	 */
+	protected function supportsEntityTemplateFindFamily(): bool {
+		return version_compare(Configure::version(), '5.3.6', '>=');
 	}
 
 }

--- a/src/Annotator/ModelAnnotator.php
+++ b/src/Annotator/ModelAnnotator.php
@@ -262,8 +262,10 @@ class ModelAnnotator extends AbstractAnnotator {
 			if (!$entityTemplateEmitted) {
 				$annotations[] = "@method {$fullClassName} newEmptyEntity()";
 			}
-			$annotations[] = "@method {$fullClassName} newEntity({$dataType} \$data, {$optionsType} \$options = [])";
-			$annotations[] = "@method {$fullClassNameCollection} newEntities({$dataListType} \$data, {$optionsType} \$options = [])";
+			if (!$entityTemplateEmitted || $detailed) {
+				$annotations[] = "@method {$fullClassName} newEntity({$dataType} \$data, {$optionsType} \$options = [])";
+				$annotations[] = "@method {$fullClassNameCollection} newEntities({$dataListType} \$data, {$optionsType} \$options = [])";
+			}
 
 			if (!$entityTemplateEmitted || $detailed) {
 				$annotations[] = "@method {$fullClassName} get(mixed \$primaryKey, {$finderType} \$finder = 'all', \Psr\SimpleCache\CacheInterface|string|null \$cache = null, \Closure|string|null \$cacheKey = null, mixed ...\$args)";
@@ -275,8 +277,12 @@ class ModelAnnotator extends AbstractAnnotator {
 				$annotations[] = "@method {$fullClassName} findOrCreate({$findOrCreateSearchType} \$search, ?callable \$callback = null, {$optionsType} \$options = [])";
 			}
 
-			$annotations[] = "@method {$fullClassName} patchEntity({$entityInterface} \$entity, {$dataType} \$data, {$optionsType} \$options = [])";
-			$annotations[] = "@method {$fullClassNameCollection} patchEntities({$iterable} \$entities, {$dataListType} \$data, {$optionsType} \$options = [])";
+			if (!$entityTemplateEmitted || $detailed || $concrete) {
+				$annotations[] = "@method {$fullClassName} patchEntity({$entityInterface} \$entity, {$dataType} \$data, {$optionsType} \$options = [])";
+			}
+			if (!$entityTemplateEmitted || $detailed || $concrete) {
+				$annotations[] = "@method {$fullClassNameCollection} patchEntities({$iterable} \$entities, {$dataListType} \$data, {$optionsType} \$options = [])";
+			}
 
 			if (!$entityTemplateEmitted || $concrete) {
 				$annotations[] = "@method {$fullClassName}|false save({$entityInterface} \$entity, {$optionsType} \$options = [])";

--- a/src/Annotator/ModelAnnotator.php
+++ b/src/Annotator/ModelAnnotator.php
@@ -578,12 +578,14 @@ class ModelAnnotator extends AbstractAnnotator {
 	}
 
 	/**
-	 * Whether `\Cake\ORM\Table` declares a second `TEntity` template parameter (CakePHP 5.4+).
+	 * Whether `\Cake\ORM\Table` declares a second `TEntity` template parameter.
+	 *
+	 * Introduced via cakephp/cakephp#19388, first released in CakePHP 5.3.4.
 	 *
 	 * @return bool
 	 */
 	protected function supportsEntityTemplate(): bool {
-		return version_compare(Configure::version(), '5.4.0', '>=');
+		return version_compare(Configure::version(), '5.3.4', '>=');
 	}
 
 	/**

--- a/tests/TestCase/Annotator/ModelAnnotatorTest.php
+++ b/tests/TestCase/Annotator/ModelAnnotatorTest.php
@@ -126,7 +126,17 @@ class ModelAnnotatorTest extends TestCase {
 			AbstractAnnotator::CONFIG_VERBOSE => true,
 		];
 
-		return $this->getMockBuilder(ModelAnnotator::class)->onlyMethods(['storeFile'])->setConstructorArgs([$this->io, $params])->getMock();
+		// Force the legacy (no-entity-template) path so fixture-comparison tests stay
+		// stable regardless of which CakePHP version is installed. The entity-template
+		// path is exercised separately via _getEntityTemplateAnnotatorMock().
+		$mock = $this->getMockBuilder(ModelAnnotator::class)
+			->onlyMethods(['storeFile', 'supportsEntityTemplate', 'supportsEntityTemplateFindFamily'])
+			->setConstructorArgs([$this->io, $params])
+			->getMock();
+		$mock->method('supportsEntityTemplate')->willReturn(false);
+		$mock->method('supportsEntityTemplateFindFamily')->willReturn(false);
+
+		return $mock;
 	}
 
 	/**

--- a/tests/TestCase/Annotator/ModelAnnotatorTest.php
+++ b/tests/TestCase/Annotator/ModelAnnotatorTest.php
@@ -427,7 +427,7 @@ class ModelAnnotatorTest extends TestCase {
 		$annotator->annotate($path);
 
 		$output = $this->out->output();
-		$this->assertTextContains('  -> 13 annotations added', $output);
+		$this->assertTextContains('  -> 9 annotations added', $output);
 	}
 
 	/**
@@ -459,6 +459,10 @@ class ModelAnnotatorTest extends TestCase {
 		$this->assertStringContainsString('newEmptyEntity()', $capture);
 		$this->assertStringContainsString(' get(mixed $primaryKey', $capture);
 		$this->assertStringContainsString('findOrCreate(', $capture);
+		$this->assertStringContainsString('newEntity(', $capture);
+		$this->assertStringContainsString('newEntities(', $capture);
+		$this->assertStringContainsString('patchEntity(', $capture);
+		$this->assertStringContainsString('patchEntities(', $capture);
 	}
 
 	/**
@@ -486,6 +490,8 @@ class ModelAnnotatorTest extends TestCase {
 		$this->assertStringContainsString('newEmptyEntity()', $capture);
 		$this->assertStringContainsString(' get(mixed $primaryKey', $capture);
 		$this->assertStringContainsString('findOrCreate(', $capture);
+		$this->assertStringContainsString('newEntity(', $capture);
+		$this->assertStringContainsString('patchEntity(', $capture);
 	}
 
 	/**
@@ -514,8 +520,14 @@ class ModelAnnotatorTest extends TestCase {
 
 		$this->assertStringContainsString('save(\TestApp\Model\Entity\BarBar $entity', $capture);
 		$this->assertStringContainsString('saveOrFail(\TestApp\Model\Entity\BarBar $entity', $capture);
+		// `patchEntity()` and `patchEntities()` are also kept under `concreteEntitiesInParam`.
+		$this->assertStringContainsString('patchEntity(\TestApp\Model\Entity\BarBar $entity', $capture);
+		$this->assertStringContainsString('patchEntities(', $capture);
 		// `newEmptyEntity` remains suppressed because it has no parameters to narrow.
 		$this->assertStringNotContainsString('newEmptyEntity()', $capture);
+		// `newEntity` / `newEntities` aren't entity-typed in their parameters, so they
+		// remain suppressed in non-detailed mode.
+		$this->assertStringNotContainsString('newEntity(', $capture);
 	}
 
 	/**
@@ -544,6 +556,11 @@ class ModelAnnotatorTest extends TestCase {
 		$this->assertStringContainsString('get(mixed $primaryKey, array<string, mixed>|string', $capture);
 		// detailed mode also narrows `$search` on `findOrCreate()`, so its override stays.
 		$this->assertStringContainsString('findOrCreate(\Cake\ORM\Query\SelectQuery<\TestApp\Model\Entity\BarBar>|callable|array<string, mixed>', $capture);
+		// detailed mode narrows `$data` on the marshalling family, so their overrides stay.
+		$this->assertStringContainsString('newEntity(array<string, mixed> $data', $capture);
+		$this->assertStringContainsString('newEntities(array<array<string, mixed>> $data', $capture);
+		$this->assertStringContainsString('patchEntity(', $capture);
+		$this->assertStringContainsString('patchEntities(', $capture);
 	}
 
 	/**

--- a/tests/TestCase/Annotator/ModelAnnotatorTest.php
+++ b/tests/TestCase/Annotator/ModelAnnotatorTest.php
@@ -141,10 +141,32 @@ class ModelAnnotatorTest extends TestCase {
 		];
 
 		$mock = $this->getMockBuilder(ModelAnnotator::class)
-			->onlyMethods(['storeFile', 'supportsEntityTemplate'])
+			->onlyMethods(['storeFile', 'supportsEntityTemplate', 'supportsEntityTemplateFindFamily'])
 			->setConstructorArgs([$this->io, $params])
 			->getMock();
 		$mock->method('supportsEntityTemplate')->willReturn(true);
+		$mock->method('supportsEntityTemplateFindFamily')->willReturn(true);
+
+		return $mock;
+	}
+
+	/**
+	 * @param array $params
+	 * @return \IdeHelper\Annotator\ModelAnnotator|\PHPUnit\Framework\MockObject\MockObject
+	 */
+	protected function _getEntityTemplateWithoutFindFamilyAnnotatorMock(array $params): ModelAnnotator {
+		$params += [
+			AbstractAnnotator::CONFIG_REMOVE => true,
+			AbstractAnnotator::CONFIG_DRY_RUN => true,
+			AbstractAnnotator::CONFIG_VERBOSE => true,
+		];
+
+		$mock = $this->getMockBuilder(ModelAnnotator::class)
+			->onlyMethods(['storeFile', 'supportsEntityTemplate', 'supportsEntityTemplateFindFamily'])
+			->setConstructorArgs([$this->io, $params])
+			->getMock();
+		$mock->method('supportsEntityTemplate')->willReturn(true);
+		$mock->method('supportsEntityTemplateFindFamily')->willReturn(false);
 
 		return $mock;
 	}
@@ -395,7 +417,7 @@ class ModelAnnotatorTest extends TestCase {
 		$annotator->annotate($path);
 
 		$output = $this->out->output();
-		$this->assertTextContains('  -> 14 annotations added', $output);
+		$this->assertTextContains('  -> 13 annotations added', $output);
 	}
 
 	/**
@@ -426,6 +448,7 @@ class ModelAnnotatorTest extends TestCase {
 		$this->assertStringContainsString('saveOrFail(', $capture);
 		$this->assertStringContainsString('newEmptyEntity()', $capture);
 		$this->assertStringContainsString(' get(mixed $primaryKey', $capture);
+		$this->assertStringContainsString('findOrCreate(', $capture);
 	}
 
 	/**
@@ -452,6 +475,7 @@ class ModelAnnotatorTest extends TestCase {
 		$this->assertStringContainsString('saveOrFail(', $capture);
 		$this->assertStringContainsString('newEmptyEntity()', $capture);
 		$this->assertStringContainsString(' get(mixed $primaryKey', $capture);
+		$this->assertStringContainsString('findOrCreate(', $capture);
 	}
 
 	/**
@@ -508,6 +532,171 @@ class ModelAnnotatorTest extends TestCase {
 		$annotator->annotate(APP . 'Model/Table/BarBarsTable.php');
 
 		$this->assertStringContainsString('get(mixed $primaryKey, array<string, mixed>|string', $capture);
+		// detailed mode also narrows `$search` on `findOrCreate()`, so its override stays.
+		$this->assertStringContainsString('findOrCreate(\Cake\ORM\Query\SelectQuery<\TestApp\Model\Entity\BarBar>|callable|array<string, mixed>', $capture);
+	}
+
+	/**
+	 * `IdeHelper.tableEntityQuery` historically emits a `find()` @method override
+	 * narrowed to `SelectQuery<Entity>`. With the entity-template emitted, the
+	 * parent's `find()` already returns `SelectQuery<TEntity|array>` — so we drop
+	 * the override on Cake 5.4+ (the `|array` fallback is actually more truthful
+	 * since `find()` can be hydration-disabled).
+	 *
+	 * @return void
+	 */
+	public function testAnnotateWithEntityTemplateSuppressesTableEntityQueryFindOverride() {
+		Configure::write('IdeHelper.tableEntityQuery', true);
+
+		$annotator = $this->_getEntityTemplateAnnotatorMock([]);
+
+		$capture = '';
+		$annotator->expects($this->once())
+			->method('storeFile')
+			->with($this->anything(), $this->callback(function ($value) use (&$capture) {
+				$capture = $value;
+
+				return true;
+			}));
+
+		$annotator->annotate(APP . 'Model/Table/BarBarsTable.php');
+
+		$this->assertStringNotContainsString('SelectQuery<\TestApp\Model\Entity\BarBar> find(', $capture);
+	}
+
+	/**
+	 * Regression: when the entity-template guards do NOT hold (e.g. `tableBehaviors=mixin`
+	 * so no @extends is emitted), the `find()` override under `tableEntityQuery` must
+	 * still be emitted — the parent generic isn't available to resolve from.
+	 *
+	 * @return void
+	 */
+	public function testAnnotateWithEntityTemplateKeepsTableEntityQueryFindOverrideWhenExtendsDisabled() {
+		Configure::write('IdeHelper.tableEntityQuery', true);
+		Configure::write('IdeHelper.tableBehaviors', 'mixin');
+
+		$annotator = $this->_getEntityTemplateAnnotatorMock([]);
+
+		$capture = '';
+		$annotator->expects($this->once())
+			->method('storeFile')
+			->with($this->anything(), $this->callback(function ($value) use (&$capture) {
+				$capture = $value;
+
+				return true;
+			}));
+
+		$annotator->annotate(APP . 'Model/Table/BarBarsTable.php');
+
+		$this->assertStringContainsString('SelectQuery<\TestApp\Model\Entity\BarBar> find(', $capture);
+	}
+
+	/**
+	 * `loadInto()` is only emitted in `concreteEntitiesInParam=strict` mode. With
+	 * the entity-template emitted, the parent's `loadInto()` already declares
+	 * `TEntity|array<TEntity>` for both param and return, so the override is
+	 * redundant on Cake 5.4+ (after cakephp/cakephp#19438).
+	 *
+	 * @return void
+	 */
+	public function testAnnotateWithEntityTemplateSuppressesStrictLoadIntoOverride() {
+		Configure::write('IdeHelper.concreteEntitiesInParam', 'strict');
+
+		$annotator = $this->_getEntityTemplateAnnotatorMock([]);
+
+		$capture = '';
+		$annotator->expects($this->once())
+			->method('storeFile')
+			->with($this->anything(), $this->callback(function ($value) use (&$capture) {
+				$capture = $value;
+
+				return true;
+			}));
+
+		$annotator->annotate(APP . 'Model/Table/BarBarsTable.php');
+
+		$this->assertStringNotContainsString('loadInto(', $capture);
+	}
+
+	/**
+	 * Regression: on CakePHP versions that have the entity template (5.3.4+) but
+	 * NOT the find-family TEntity propagation (pre-#19438), the find/findOrCreate/
+	 * loadInto overrides must still be emitted even though the entity template
+	 * is otherwise present. The other entity-returning methods (`get`/`saveOrFail`
+	 * etc.) remain suppressed because their TEntity propagation landed earlier.
+	 *
+	 * @return void
+	 */
+	public function testAnnotateWithEntityTemplateKeepsFindAndFindOrCreateWithoutFindFamilySupport() {
+		Configure::write('IdeHelper.tableEntityQuery', true);
+
+		$annotator = $this->_getEntityTemplateWithoutFindFamilyAnnotatorMock([]);
+
+		$capture = '';
+		$annotator->expects($this->once())
+			->method('storeFile')
+			->with($this->anything(), $this->callback(function ($value) use (&$capture) {
+				$capture = $value;
+
+				return true;
+			}));
+
+		$annotator->annotate(APP . 'Model/Table/BarBarsTable.php');
+
+		$this->assertStringContainsString('SelectQuery<\TestApp\Model\Entity\BarBar> find(', $capture);
+		$this->assertStringContainsString('findOrCreate(', $capture);
+		// Non-find-family methods are still suppressed because the entity template
+		// itself IS present and their parent annotations already carry TEntity.
+		$this->assertStringNotContainsString('newEmptyEntity()', $capture);
+		$this->assertStringNotContainsString('saveOrFail(', $capture);
+	}
+
+	/**
+	 * Mirrors the previous test for `loadInto()`, which only emits in strict mode.
+	 *
+	 * @return void
+	 */
+	public function testAnnotateWithEntityTemplateKeepsStrictLoadIntoWithoutFindFamilySupport() {
+		Configure::write('IdeHelper.concreteEntitiesInParam', 'strict');
+
+		$annotator = $this->_getEntityTemplateWithoutFindFamilyAnnotatorMock([]);
+
+		$capture = '';
+		$annotator->expects($this->once())
+			->method('storeFile')
+			->with($this->anything(), $this->callback(function ($value) use (&$capture) {
+				$capture = $value;
+
+				return true;
+			}));
+
+		$annotator->annotate(APP . 'Model/Table/BarBarsTable.php');
+
+		$this->assertStringContainsString('loadInto(', $capture);
+	}
+
+	/**
+	 * Regression: in strict mode without the entity-template guards (e.g. on a
+	 * custom-parent table), the `loadInto()` override is still needed.
+	 *
+	 * @return void
+	 */
+	public function testAnnotateWithEntityTemplateKeepsStrictLoadIntoOverrideForCustomParent() {
+		Configure::write('IdeHelper.concreteEntitiesInParam', 'strict');
+
+		$annotator = $this->_getEntityTemplateAnnotatorMock([]);
+
+		$capture = '';
+		$annotator->method('storeFile')
+			->with($this->anything(), $this->callback(function ($value) use (&$capture) {
+				$capture = $value;
+
+				return true;
+			}));
+
+		$annotator->annotate(APP . 'Model/Table/BarBarsAbstractTable.php');
+
+		$this->assertStringContainsString('loadInto(', $capture);
 	}
 
 }

--- a/tests/TestCase/Command/AnnotateCommandTest.php
+++ b/tests/TestCase/Command/AnnotateCommandTest.php
@@ -145,6 +145,11 @@ class AnnotateCommandTest extends TestCase {
 	 * @return void
 	 */
 	public function testAllCiModeNoChanges() {
+		// The Awesome plugin's tables are pre-annotated with `@extends Table<..., TEntity>`,
+		// which only the CakePHP 5.3.4+ annotator emits. On older Cake versions the annotator
+		// would want to remove those annotations, breaking the no-changes check.
+		$this->skipIf(version_compare(Configure::version(), '5.3.4', '<'), 'Requires CakePHP 5.3.4+ (entity-template support).');
+
 		$this->exec('annotate all -d -v --ci -p Awesome');
 		$this->assertExitSuccess($this->_out->output());
 	}
@@ -180,6 +185,9 @@ class AnnotateCommandTest extends TestCase {
 	#[DataProvider('provideSubcommandsForCiModeTest')]
 	public function testIndividualSubcommandCiModeNoChanges(string $subcommand): void {
 		$this->skipIf($subcommand === 'view', 'View does not support the plugin parameter');
+		// See testAllCiModeNoChanges() — the Awesome plugin tables are pre-annotated for the
+		// CakePHP 5.3.4+ annotator output.
+		$this->skipIf($subcommand === 'models' && version_compare(Configure::version(), '5.3.4', '<'), 'Models pre-annotation requires CakePHP 5.3.4+.');
 
 		$this->exec('annotate ' . $subcommand . ' -d -v --ci -p Awesome');
 		$this->assertExitSuccess($this->_out->output());

--- a/tests/test_app/plugins/Awesome/src/Model/Table/HousesTable.php
+++ b/tests/test_app/plugins/Awesome/src/Model/Table/HousesTable.php
@@ -4,6 +4,8 @@ namespace Awesome\Model\Table;
 use Cake\ORM\Table;
 
 /**
+ * @extends \Cake\ORM\Table<array{}, \Cake\ORM\Entity>
+ *
  * @property \Cake\ORM\Association\HasMany<\Awesome\Model\Table\WindowsTable> $Windows
  */
 class HousesTable extends Table {

--- a/tests/test_app/plugins/Awesome/src/Model/Table/WindowsTable.php
+++ b/tests/test_app/plugins/Awesome/src/Model/Table/WindowsTable.php
@@ -4,6 +4,8 @@ namespace Awesome\Model\Table;
 use Cake\ORM\Table;
 
 /**
+ * @extends \Cake\ORM\Table<array{}, \Cake\ORM\Entity>
+ *
  * @property \Cake\ORM\Association\BelongsTo<\Awesome\Model\Table\HousesTable> $Houses
  */
 class WindowsTable extends Table {

--- a/tests/test_files/Model/Table/BarBarsEntityTemplateTable.php
+++ b/tests/test_files/Model/Table/BarBarsEntityTemplateTable.php
@@ -11,7 +11,6 @@ use Cake\ORM\Table;
  *
  * @method \TestApp\Model\Entity\BarBar newEntity(array $data, array $options = [])
  * @method \TestApp\Model\Entity\BarBar[] newEntities(array $data, array $options = [])
- * @method \TestApp\Model\Entity\BarBar findOrCreate(\Cake\ORM\Query\SelectQuery|callable|array $search, ?callable $callback = null, array $options = [])
  * @method \TestApp\Model\Entity\BarBar patchEntity(\Cake\Datasource\EntityInterface $entity, array $data, array $options = [])
  * @method \TestApp\Model\Entity\BarBar[] patchEntities(iterable $entities, array $data, array $options = [])
  * @method \TestApp\Model\Entity\BarBar[]|\Cake\Datasource\ResultSetInterface<\TestApp\Model\Entity\BarBar>|false saveMany(iterable $entities, array $options = [])

--- a/tests/test_files/Model/Table/BarBarsEntityTemplateTable.php
+++ b/tests/test_files/Model/Table/BarBarsEntityTemplateTable.php
@@ -9,10 +9,6 @@ use Cake\ORM\Table;
  * @property \Cake\ORM\Association\BelongsTo<\TestApp\Model\Table\FoosTable> $Foos
  * @property \Cake\ORM\Association\BelongsToMany<\Awesome\Model\Table\HousesTable> $Houses
  *
- * @method \TestApp\Model\Entity\BarBar newEntity(array $data, array $options = [])
- * @method \TestApp\Model\Entity\BarBar[] newEntities(array $data, array $options = [])
- * @method \TestApp\Model\Entity\BarBar patchEntity(\Cake\Datasource\EntityInterface $entity, array $data, array $options = [])
- * @method \TestApp\Model\Entity\BarBar[] patchEntities(iterable $entities, array $data, array $options = [])
  * @method \TestApp\Model\Entity\BarBar[]|\Cake\Datasource\ResultSetInterface<\TestApp\Model\Entity\BarBar>|false saveMany(iterable $entities, array $options = [])
  * @method \TestApp\Model\Entity\BarBar[]|\Cake\Datasource\ResultSetInterface<\TestApp\Model\Entity\BarBar> saveManyOrFail(iterable $entities, array $options = [])
  * @method \TestApp\Model\Entity\BarBar[]|\Cake\Datasource\ResultSetInterface<\TestApp\Model\Entity\BarBar>|false deleteMany(iterable $entities, array $options = [])


### PR DESCRIPTION
> [!IMPORTANT]
> **Draft — depends on cakephp/cakephp#19438 merging and shipping.**
>
> The suppression logic here only becomes safe once `Cake\ORM\Table::find()`, `findOrCreate()` and `loadInto()` propagate `TEntity` through their return types. Until that lands, this PR sits as a draft. At merge time, the version gate in `supportsEntityTemplateFindFamily()` MUST be set to the actual minimum CakePHP release containing #19438 (currently milestoned for 5.3.6).

## Summary

Follow-up to #445. With #445 we suppressed redundant `@method` overrides for `get`/`newEmptyEntity`/`save`/`saveOrFail` once the user's Table is annotated with `@extends Table<..., TEntity>`. The remaining three (`find`, `findOrCreate`, `loadInto`) needed a parallel Cake-side change to flow `TEntity` through their parent annotations — that's cakephp/cakephp#19438.

Once both are in place, this PR drops the matching plugin overrides:

- `find()` — only emitted when `IdeHelper.tableEntityQuery` is on. Parent now returns `SelectQuery<TEntity|array>`, strictly more truthful than the plugin's `SelectQuery<TEntity>` override (`find()` can legitimately return arrays when hydration is disabled).
- `findOrCreate()` — parent now returns `TEntity` directly. Suppression also closes the third `PersistenceFailedException` `catch.neverThrown` false positive (alongside the `saveOrFail` one #445 fixed).
- `loadInto()` (in `concreteEntitiesInParam=strict` mode) — parent now declares `TEntity|array<TEntity>` for param and return, matching the override exactly.

## Two-stage feature gate

The class-level `TEntity` template (cakephp/cakephp#19388) and the find-family propagation (cakephp/cakephp#19438) are separate Cake changes. To handle the in-between state — Cake builds that have the template but predate #19438 — there are two gates:

- `supportsEntityTemplate()` — gate for `get`/`newEmptyEntity`/`save`/`saveOrFail` (and the `@extends` emission itself). Unchanged.
- `supportsEntityTemplateFindFamily()` — separate gate for `find`/`findOrCreate`/`loadInto`. Currently set to `>= 5.3.6` (the #19438 milestone, placeholder).

On Cake 5.3.4 / 5.3.5 — which have the template but not yet the find-family fixes — the find-family overrides continue to be emitted while the other suppression already kicks in.

## Per-method narrowing preserved

Same pattern as #445:

- `find()` — emitted unconditionally when `tableEntityQuery` is on AND find-family support is missing.
- `findOrCreate()` — kept in `genericsInParam=detailed` because the plugin override narrows the `$search` argument beyond what the parent provides.
- `loadInto()` — only emitted in `strict` mode; in that mode kept when the find-family gates don't hold.

## Tests

Three new regression dimensions:

- `testAnnotateWithEntityTemplateSuppressesTableEntityQueryFindOverride` / `KeepsTableEntityQueryFindOverrideWhenExtendsDisabled`
- `testAnnotateWithEntityTemplateSuppressesStrictLoadIntoOverride` / `KeepsStrictLoadIntoOverrideForCustomParent`
- `testAnnotateWithEntityTemplateKeepsFindAndFindOrCreateWithoutFindFamilySupport` / `KeepsStrictLoadIntoWithoutFindFamilySupport` — the realistic in-between state on CakePHP 5.3.4 / 5.3.5

Existing suppression tests extended to assert `findOrCreate` is kept in the same scenarios that keep `saveOrFail` (extends disabled, custom parent, detailed mode).

## Pre-merge checklist

- [ ] cakephp/cakephp#19438 has been merged
- [ ] `supportsEntityTemplateFindFamily()`'s version check has been bumped to the actual shipping release

## Out of scope (deliberate)

`supportsEntityTemplate()`'s gate at `>= 5.4.0` is over-strict (the feature actually shipped in 5.3.4 via cakephp/cakephp#19388) but lowering it requires regenerating fixture test files to include the new `@extends` lines they don't currently have. Belongs in its own PR.