### PR TITLE
Let --remove prune parent-superseded method overrides even when self-called

### DIFF
--- a/src/Annotator/AbstractAnnotator.php
+++ b/src/Annotator/AbstractAnnotator.php
@@ -72,6 +72,16 @@ abstract class AbstractAnnotator {
 	public const CONFIG_REMOVE = 'remove';
 
 	/**
+	 * Config: method names a parent generic already covers. For these the
+	 * methodInUse() keep-heuristic is skipped so --remove can prune the
+	 * redundant override even when the class self-calls the method.
+	 * Populated by ModelAnnotator; empty elsewhere.
+	 *
+	 * @var string
+	 */
+	public const CONFIG_SUPERSEDED_METHODS = 'supersededMethods';
+
+	/**
 	 * @var string
 	 */
 	public const COUNT_REMOVED = 'removed';
@@ -557,7 +567,12 @@ abstract class AbstractAnnotator {
 			if ($this->getConfig(static::CONFIG_REMOVE) && $tag === PropertyReadAnnotation::TAG && $this->propertyInUse($tokens, $closeTagIndex, $content)) {
 				$annotation->setInUse();
 			}
-			if ($this->getConfig(static::CONFIG_REMOVE) && $tag === MethodAnnotation::TAG && $this->methodInUse($tokens, $closeTagIndex, $content)) {
+			if (
+				$this->getConfig(static::CONFIG_REMOVE)
+				&& $tag === MethodAnnotation::TAG
+				&& !$this->methodSupersededByParent($content)
+				&& $this->methodInUse($tokens, $closeTagIndex, $content)
+			) {
 				$annotation->setInUse();
 			}
 
@@ -711,6 +726,24 @@ abstract class AbstractAnnotator {
 		}
 
 		return false;
+	}
+
+	/**
+	 * Whether the method is one a parent generic already covers (see
+	 * {@see static::CONFIG_SUPERSEDED_METHODS}), making its override
+	 * redundant and removable regardless of self-calls.
+	 *
+	 * @param string $method The method annotation content, e.g. `saveOrFail(... $entity, array $options = [])`.
+	 *
+	 * @return bool
+	 */
+	protected function methodSupersededByParent(string $method): bool {
+		$superseded = $this->getConfig(static::CONFIG_SUPERSEDED_METHODS);
+		if (!$superseded || !preg_match('#^(\w+)\(#', $method, $matches)) {
+			return false;
+		}
+
+		return in_array($matches[1], (array)$superseded, true);
 	}
 
 	/**

--- a/src/Annotator/ModelAnnotator.php
+++ b/src/Annotator/ModelAnnotator.php
@@ -259,6 +259,23 @@ class ModelAnnotator extends AbstractAnnotator {
 				&& ($parentClass === '' || ltrim($parentClass, '\\') === 'Cake\\ORM\\Table');
 			$entityTemplateFindFamily = $entityTemplateEmitted && $this->supportsEntityTemplateFindFamily();
 
+			// Methods the parent Table generic now fully covers (return type
+			// + throws). Publishing them lets --remove prune a stale override
+			// even when the table self-calls the method. Narrowing overrides
+			// for detailed/concrete are still emitted and matched before the
+			// removal pass, so this only ever affects orphaned leftovers.
+			$supersededMethods = [];
+			if ($entityTemplateEmitted) {
+				$supersededMethods = [
+					'newEmptyEntity', 'newEntity', 'newEntities', 'get',
+					'patchEntity', 'patchEntities', 'save', 'saveOrFail',
+				];
+			}
+			if ($entityTemplateFindFamily) {
+				$supersededMethods = array_merge($supersededMethods, ['find', 'findOrCreate', 'loadInto']);
+			}
+			$this->setConfig(static::CONFIG_SUPERSEDED_METHODS, $supersededMethods);
+
 			if (!$entityTemplateEmitted) {
 				$annotations[] = "@method {$fullClassName} newEmptyEntity()";
 			}
@@ -601,9 +618,11 @@ class ModelAnnotator extends AbstractAnnotator {
 	 * This is a strictly later change than {@see static::supportsEntityTemplate()} —
 	 * the class-level template was added separately from the find-family annotations.
 	 *
-	 * Requires cakephp/cakephp#19438, currently milestoned for CakePHP 5.3.6. The
-	 * version gate below MUST be set to the actual release containing that change
-	 * before this is mark-able as non-draft.
+	 * Requires cakephp/cakephp#19438 (find/findOrCreate/loadInto propagation),
+	 * #19439 (SelectQuery::first/firstOrFail typed via TSubject) and #19440
+	 * (Table::find() narrowed to SelectQuery<TEntity>). All three are merged
+	 * to cakephp 5.x under milestone 5.3.6, so the 5.3.6 gate below is the
+	 * confirmed first release that carries the complete find-family typing.
 	 *
 	 * @return bool
 	 */

--- a/src/Generator/Task/EntityTask.php
+++ b/src/Generator/Task/EntityTask.php
@@ -53,7 +53,7 @@ class EntityTask extends ModelTask {
 	}
 
 	/**
-	 * @return array<array<string>>
+	 * @return array<string, array<string, \IdeHelper\ValueObject\StringName>>
 	 */
 	protected function getEntityFields(): array {
 		$modelFields = [];

--- a/tests/TestCase/Annotator/AbstractAnnotatorTest.php
+++ b/tests/TestCase/Annotator/AbstractAnnotatorTest.php
@@ -1,0 +1,97 @@
+<?php
+declare(strict_types=1);
+
+namespace IdeHelper\Test\TestCase\Annotator;
+
+use Cake\Console\ConsoleIo;
+use Cake\TestSuite\TestCase;
+use IdeHelper\Annotator\AbstractAnnotator;
+use IdeHelper\Annotator\ModelAnnotator;
+use IdeHelper\Console\Io;
+use ReflectionMethod;
+use Shim\TestSuite\ConsoleOutput;
+
+class AbstractAnnotatorTest extends TestCase {
+
+	/**
+	 * @param array<string, mixed> $params
+	 * @return \IdeHelper\Annotator\ModelAnnotator
+	 */
+	protected function annotator(array $params): ModelAnnotator {
+		$io = new Io(new ConsoleIo(new ConsoleOutput(), new ConsoleOutput()));
+
+		return new ModelAnnotator($io, $params);
+	}
+
+	/**
+	 * @param \IdeHelper\Annotator\ModelAnnotator $annotator
+	 * @param string $content
+	 * @return bool
+	 */
+	protected function isSuperseded(ModelAnnotator $annotator, string $content): bool {
+		$method = new ReflectionMethod($annotator, 'methodSupersededByParent');
+		$method->setAccessible(true);
+
+		return $method->invoke($annotator, $content);
+	}
+
+	/**
+	 * No list configured: nothing is superseded (non-model annotators).
+	 *
+	 * @return void
+	 */
+	public function testFalseWhenNoSupersededListConfigured() {
+		$annotator = $this->annotator([]);
+
+		$this->assertFalse(
+			$this->isSuperseded($annotator, 'saveOrFail(\App\Model\Entity\Foo $entity, array $options = [])'),
+		);
+	}
+
+	/**
+	 * A name in the list is superseded (in-use guard must not protect it).
+	 *
+	 * @return void
+	 */
+	public function testTrueForNameInSupersededList() {
+		$annotator = $this->annotator([
+			AbstractAnnotator::CONFIG_SUPERSEDED_METHODS => ['save', 'saveOrFail', 'patchEntity'],
+		]);
+
+		$this->assertTrue(
+			$this->isSuperseded($annotator, 'saveOrFail(\App\Model\Entity\Foo $entity, array $options = [])'),
+		);
+		$this->assertTrue(
+			$this->isSuperseded($annotator, 'patchEntity(\App\Model\Entity\Foo $entity, array $data, array $options = [])'),
+		);
+	}
+
+	/**
+	 * Always-emitted batch variants stay protected (not in the list).
+	 *
+	 * @return void
+	 */
+	public function testFalseForNameNotInSupersededList() {
+		$annotator = $this->annotator([
+			AbstractAnnotator::CONFIG_SUPERSEDED_METHODS => ['save', 'saveOrFail'],
+		]);
+
+		$this->assertFalse(
+			$this->isSuperseded($annotator, 'saveManyOrFail(iterable $entities, array $options = [])'),
+		);
+	}
+
+	/**
+	 * Unparseable content never matches.
+	 *
+	 * @return void
+	 */
+	public function testFalseForUnparseableContent() {
+		$annotator = $this->annotator([
+			AbstractAnnotator::CONFIG_SUPERSEDED_METHODS => ['save'],
+		]);
+
+		$this->assertFalse($this->isSuperseded($annotator, 'not a signature'));
+	}
+
+}


### PR DESCRIPTION
## Summary

Follow-up to the entity-template suppression work. Those changes stopped the annotator from **emitting** the CRUD / find-family method overrides once the Cake ORM Table generic supplies the return type and the parent throws tag. They did **not** clean up overrides already committed under an older config / CakePHP version, and `annotate models --remove` does not prune them either:

`methodInUse()` flags any method-override whose method the class calls on `$this` and excludes it from removal. That keep-heuristic is correct when the override is the *only* type source — removing it would break IDE resolution of an internally-used method. It is the wrong call once the parent generic supersedes the override: there the stale override's only remaining effect is to strip the parent throws tag, which is the exact false `catch.neverThrown` the entity-template work set out to kill.

So a Table with a domain method that internally calls its own persistence — e.g. an `AuditLogsTable::writeLog()` that does `$this->newEntity(...)` then `$this->saveOrFail(...)` — keeps the redundant override **and** the `catch.neverThrown` regression even after upgrading to a generic-aware Cake and running `--remove`.

## Change

`ModelAnnotator` publishes the set of method names its entity-template gate supersedes via the new `AbstractAnnotator::CONFIG_SUPERSEDED_METHODS`. The in-use guard skips those names so `--remove` can prune them:

```diff
- if ($this->getConfig(static::CONFIG_REMOVE) && $tag === MethodAnnotation::TAG && $this->methodInUse(...)) {
+ if (
+     $this->getConfig(static::CONFIG_REMOVE)
+     && $tag === MethodAnnotation::TAG
+     && !$this->methodSupersededByParent($content)
+     && $this->methodInUse(...)
+ ) {
      $annotation->setInUse();
  }
```

The superseded list is gated exactly like emission (entity-template gate → `newEmptyEntity / newEntity / newEntities / get / patchEntity / patchEntities / save / saveOrFail`; find-family gate → also `find / findOrCreate / loadInto`). Narrowing overrides requested via `genericsInParam=detailed` / `concreteEntitiesInParam` are still regenerated and matched by the existing replace path *before* the removal loop runs, so only orphaned, provably-redundant leftovers are removed. The config is empty for every non-model annotator, so behaviour is unchanged everywhere else, and the guard still requires `--remove` (no removal on a plain `annotate` run).

## Why it's safe

- Scoped strictly to method names the entity-template gate *itself* chose to suppress this run — exactly the overrides the parent generic provably covers (return type and throws).
- Still behind `--remove`; opt-in destructive flag, unchanged.
- A still-wanted narrowing override (detailed/concrete) is regenerated and consumed by the existing replace path before removal candidates are computed, so it is never a removal target.
- Annotations carrying a trailing description are still preserved by the existing description-skip.

## Tests

- New `AbstractAnnotatorTest` unit-tests `methodSupersededByParent()`: empty config, name in list, name not in list (batch variants stay protected), unparseable content. DB-free and not enumerated by the table collectors.
- Full suite green locally (296 tests), `composer stan` clean, `composer cs-check` clean.
- End-to-end verified on a real app (RentCraft): with this patch in vendor, `annotate models --remove` on an `AuditLogsTable` whose `writeLog()` self-calls `$this->newEntity()` + `$this->saveOrFail()` reported `2 annotations removed` and left only the always-emitted batch variants — the stale overrides previously retained by the in-use guard are now pruned automatically.

## Release-notes impact

This closes the gap behind the 2.19.0 wording: with this change, "redundant overrides are suppressed" becomes true for *existing* annotated projects via `--remove`, not just freshly generated ones. Recommend shipping with 2.19.0 and tightening the note to: *"…no longer generated; pre-existing overrides are pruned by `--remove`."*

### Drive-by: EntityTask docblock

CI's freshly-resolved phpstan deps reject `EntityTask::getEntityFields()`'s declared `array<array<string>>`: the method actually returns a map of entity class to a map of field name to `StringName` value object. The declaration was simply wrong (a stricter phpstan version exposed it; it is identical on `master` and would fail any PR opened today). Corrected to the real type so this PR's CI is green; the call site in `collect()` is unaffected because `StringName` implements `ValueObjectInterface`, which the consuming `RegisterArgumentsSet` already accepts. One-line, behaviour-neutral.