### PR TITLE
Report outdated annotations on a plain run, not only with --remove

### DIFF
--- a/src/Annotator/AbstractAnnotator.php
+++ b/src/Annotator/AbstractAnnotator.php
@@ -89,6 +89,11 @@ abstract class AbstractAnnotator {
 	/**
 	 * @var string
 	 */
+	public const COUNT_REMOVABLE = 'removable';
+
+	/**
+	 * @var string
+	 */
 	public const COUNT_UPDATED = 'updated';
 
 	/**
@@ -359,35 +364,47 @@ abstract class AbstractAnnotator {
 			$fixer->addContent($lastTagIndexOfPreviousLine, $annotationString);
 		}
 
-		if ($this->getConfig(static::CONFIG_REMOVE)) {
-			foreach ($existingAnnotations as $key => $existingAnnotation) {
-				if ($existingAnnotation->isInUse()) {
-					unset($existingAnnotations[$key]);
+		// Outdated-annotation detection always runs: --remove deletes them,
+		// a plain run just reports the count so cruft is discoverable
+		// without the destructive flag.
+		foreach ($existingAnnotations as $key => $existingAnnotation) {
+			if ($existingAnnotation->isInUse()) {
+				unset($existingAnnotations[$key]);
 
-					continue;
-				}
-
-				if ($existingAnnotation->getDescription() !== '') {
-					$this->_counter[static::COUNT_SKIPPED]++;
-					unset($existingAnnotations[$key]);
-
-					continue;
-				}
-
-				if ($generatedTags && !in_array($existingAnnotation::TAG, $generatedTags, true)) {
-					unset($existingAnnotations[$key]);
-				}
+				continue;
 			}
 
-			$removingAnnotations = $existingAnnotations;
-			foreach ($removingAnnotations as $annotation) {
-				$lastWhitespaceOfPreviousLine = $this->getLastWhitespaceOfPreviousLine($tokens, $annotation->getIndex());
-				$index = $annotation->getIndex();
-				for ($i = $lastWhitespaceOfPreviousLine; $i <= $index; $i++) {
-					$fixer->replaceToken($i, '');
-				}
-				$this->_counter[static::COUNT_REMOVED]++;
+			if ($existingAnnotation->getDescription() !== '') {
+				$this->_counter[static::COUNT_SKIPPED]++;
+				unset($existingAnnotations[$key]);
+
+				continue;
 			}
+
+			if ($generatedTags && !in_array($existingAnnotation::TAG, $generatedTags, true)) {
+				unset($existingAnnotations[$key]);
+			}
+		}
+
+		$removingAnnotations = $existingAnnotations;
+		$remove = (bool)$this->getConfig(static::CONFIG_REMOVE);
+		foreach ($removingAnnotations as $annotation) {
+			if (!$remove) {
+				// Report-only: count and (verbose) name what `-r` would prune.
+				$this->_counter[static::COUNT_REMOVABLE]++;
+				if ($this->getConfig(static::CONFIG_VERBOSE)) {
+					$this->_io->warn('   Outdated annotation (run with -r to remove): ' . (string)$annotation);
+				}
+
+				continue;
+			}
+
+			$lastWhitespaceOfPreviousLine = $this->getLastWhitespaceOfPreviousLine($tokens, $annotation->getIndex());
+			$index = $annotation->getIndex();
+			for ($i = $lastWhitespaceOfPreviousLine; $i <= $index; $i++) {
+				$fixer->replaceToken($i, '');
+			}
+			$this->_counter[static::COUNT_REMOVED]++;
 		}
 
 		$fixer->endChangeset();
@@ -558,18 +575,17 @@ abstract class AbstractAnnotator {
 			}
 
 			$annotation = AnnotationFactory::createOrFail($tag, $typeString, $content, $classNameIndex);
-			if ($this->getConfig(static::CONFIG_REMOVE) && $tag === VariableAnnotation::TAG && $this->varInUse($tokens, $closeTagIndex, $content)) {
+			if ($tag === VariableAnnotation::TAG && $this->varInUse($tokens, $closeTagIndex, $content)) {
 				$annotation->setInUse();
 			}
-			if ($this->getConfig(static::CONFIG_REMOVE) && $tag === PropertyAnnotation::TAG && $this->propertyInUse($tokens, $closeTagIndex, $content)) {
+			if ($tag === PropertyAnnotation::TAG && $this->propertyInUse($tokens, $closeTagIndex, $content)) {
 				$annotation->setInUse();
 			}
-			if ($this->getConfig(static::CONFIG_REMOVE) && $tag === PropertyReadAnnotation::TAG && $this->propertyInUse($tokens, $closeTagIndex, $content)) {
+			if ($tag === PropertyReadAnnotation::TAG && $this->propertyInUse($tokens, $closeTagIndex, $content)) {
 				$annotation->setInUse();
 			}
 			if (
-				$this->getConfig(static::CONFIG_REMOVE)
-				&& $tag === MethodAnnotation::TAG
+				$tag === MethodAnnotation::TAG
 				&& !$this->methodSupersededByParent($content)
 				&& $this->methodInUse($tokens, $closeTagIndex, $content)
 			) {
@@ -905,6 +921,10 @@ abstract class AbstractAnnotator {
 		if ($skipped) {
 			$out[] = $skipped . ' ' . ($skipped === 1 ? 'annotation' : 'annotations') . ' skipped';
 		}
+		$removable = !empty($this->_counter[static::COUNT_REMOVABLE]) ? $this->_counter[static::COUNT_REMOVABLE] : 0;
+		if ($removable) {
+			$out[] = $removable . ' ' . ($removable === 1 ? 'annotation' : 'annotations') . ' outdated (run with -r to remove)';
+		}
 
 		if (!$out) {
 			return;
@@ -923,6 +943,10 @@ abstract class AbstractAnnotator {
 		$skipped = !empty($this->_counter[static::COUNT_SKIPPED]) ? $this->_counter[static::COUNT_SKIPPED] : 0;
 		if ($skipped) {
 			$out[] = $skipped . ' ' . ($skipped === 1 ? 'annotation' : 'annotations') . ' skipped';
+		}
+		$removable = !empty($this->_counter[static::COUNT_REMOVABLE]) ? $this->_counter[static::COUNT_REMOVABLE] : 0;
+		if ($removable) {
+			$out[] = $removable . ' ' . ($removable === 1 ? 'annotation' : 'annotations') . ' outdated (run with -r to remove)';
 		}
 
 		if (!$out) {
@@ -944,6 +968,7 @@ abstract class AbstractAnnotator {
 			static::COUNT_ADDED => 0,
 			static::COUNT_UPDATED => 0,
 			static::COUNT_REMOVED => 0,
+			static::COUNT_REMOVABLE => 0,
 			static::COUNT_SKIPPED => 0,
 		];
 	}

--- a/tests/TestCase/Annotator/AbstractAnnotatorTest.php
+++ b/tests/TestCase/Annotator/AbstractAnnotatorTest.php
@@ -9,6 +9,7 @@ use IdeHelper\Annotator\AbstractAnnotator;
 use IdeHelper\Annotator\ModelAnnotator;
 use IdeHelper\Console\Io;
 use ReflectionMethod;
+use ReflectionProperty;
 use Shim\TestSuite\ConsoleOutput;
 
 class AbstractAnnotatorTest extends TestCase {
@@ -21,6 +22,46 @@ class AbstractAnnotatorTest extends TestCase {
 		$io = new Io(new ConsoleIo(new ConsoleOutput(), new ConsoleOutput()));
 
 		return new ModelAnnotator($io, $params);
+	}
+
+	/**
+	 * Build an annotator together with the ConsoleOutput it writes to, so
+	 * report() output can be asserted.
+	 *
+	 * @param array<string, mixed> $params
+	 * @return array{0: \IdeHelper\Annotator\ModelAnnotator, 1: \Shim\TestSuite\ConsoleOutput}
+	 */
+	protected function annotatorWithOutput(array $params): array {
+		$out = new ConsoleOutput();
+		$annotator = new ModelAnnotator(new Io(new ConsoleIo($out, $out)), $params);
+
+		return [$annotator, $out];
+	}
+
+	/**
+	 * report() surfaces the removable count so a plain run (no -r) makes
+	 * outdated annotations discoverable instead of silently ignoring them.
+	 *
+	 * @return void
+	 */
+	public function testReportSurfacesRemovableCount() {
+		[$annotator, $out] = $this->annotatorWithOutput([]);
+
+		$counter = new ReflectionProperty($annotator, '_counter');
+		$counter->setAccessible(true);
+		$counter->setValue($annotator, [
+			AbstractAnnotator::COUNT_ADDED => 0,
+			AbstractAnnotator::COUNT_UPDATED => 0,
+			AbstractAnnotator::COUNT_REMOVED => 0,
+			AbstractAnnotator::COUNT_REMOVABLE => 3,
+			AbstractAnnotator::COUNT_SKIPPED => 0,
+		]);
+
+		$report = new ReflectionMethod($annotator, 'report');
+		$report->setAccessible(true);
+		$report->invoke($annotator);
+
+		$this->assertStringContainsString('3 annotations outdated (run with -r to remove)', $out->output());
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Outdated-annotation detection was gated entirely behind `--remove`. A normal `annotate` run therefore silently ignored stale docblock lines — users only discovered cruft if they happened to run the destructive flag (and then it was deleted, not reported).

This makes detection always run:

- `--remove` — unchanged: deletes the outdated lines.
- plain run — counts what `-r` would prune and prints `-> N annotations outdated (run with -r to remove)`; verbose (`-v`) names each line.

No file is modified and the exit code is unchanged on a plain run, so it is purely additive and non-breaking. Clean projects stay silent — the line is only emitted when the count is non-zero.

## Why no opt-in flag

The first iteration added a `--warn-stale` flag. Dropped it: a flag defeats discoverability (users who do not know to pass it never see the cruft, which is the whole point), and the output is non-destructive informational text. Making it the default is the useful behaviour — analogous to how `git status` always surfaces untracked files. The only cost is that in-use detection now runs on plain runs too; acceptable for a dev/CI tool where "helpful and correct" beats micro-perf.

## Truthfulness

The in-use and parent-superseded checks are no longer conditional on `--remove` either. The report must apply the *exact same* filter chain (in-use heuristic, description-skip, generated-tag set, and the parent-superseded bypass) as actual removal — otherwise it would cry wolf about lines `-r` would in fact keep.

## Tests

- `AbstractAnnotatorTest::testReportSurfacesRemovableCount` asserts `report()` emits the count.
- Full suite green (297), `composer stan` clean, `composer cs-check` clean.
- Verified end-to-end on a real app: a plain `annotate models` over a table carrying stale overrides prints `-> 7 annotations outdated (run with -r to remove)` (and `-v` lists each), leaving the file untouched; `-r` still deletes them.

## Possible follow-ups (not in this PR)

- A CI gate (extend `--ci` to fail when removable orphans exist) so teams can block on docblock cruft without ever running destructive removal.
- Per-line provenance in the verbose listing (e.g. "not in generated set" vs "superseded by parent generic").
