### PR TITLE
Color the outdated summary + fail CI mode on stale annotations

### DIFF
--- a/src/Annotator/AbstractAnnotator.php
+++ b/src/Annotator/AbstractAnnotator.php
@@ -122,6 +122,15 @@ abstract class AbstractAnnotator {
 
 	public static bool $output = false;
 
+	/**
+	 * True once any run detected outdated (removable) annotations, even when
+	 * nothing was written. Lets CI mode fail on stale docblocks without
+	 * requiring --remove. Reset per command run alongside $output.
+	 *
+	 * @var bool
+	 */
+	public static bool $stale = false;
+
 	protected Io $_io;
 
 	/**
@@ -392,6 +401,7 @@ abstract class AbstractAnnotator {
 			if (!$remove) {
 				// Report-only: count and (verbose) name what `-r` would prune.
 				$this->_counter[static::COUNT_REMOVABLE]++;
+				static::$stale = true;
 				if ($this->getConfig(static::CONFIG_VERBOSE)) {
 					$this->_io->warn('   Outdated annotation (run with -r to remove): ' . (string)$annotation);
 				}

--- a/src/Annotator/AbstractAnnotator.php
+++ b/src/Annotator/AbstractAnnotator.php
@@ -921,16 +921,19 @@ abstract class AbstractAnnotator {
 		if ($skipped) {
 			$out[] = $skipped . ' ' . ($skipped === 1 ? 'annotation' : 'annotations') . ' skipped';
 		}
+
+		if ($out) {
+			$this->_io->success('   -> ' . implode(', ', $out) . '.');
+		}
+
+		// Outdated lines signal "action recommended", not success — emit
+		// them on their own attention-coloured line (matches the verbose
+		// per-annotation warn() above), never folded into the green
+		// success summary.
 		$removable = !empty($this->_counter[static::COUNT_REMOVABLE]) ? $this->_counter[static::COUNT_REMOVABLE] : 0;
 		if ($removable) {
-			$out[] = $removable . ' ' . ($removable === 1 ? 'annotation' : 'annotations') . ' outdated (run with -r to remove)';
+			$this->_io->warn('   -> ' . $removable . ' ' . ($removable === 1 ? 'annotation' : 'annotations') . ' outdated (run with -r to remove)');
 		}
-
-		if (!$out) {
-			return;
-		}
-
-		$this->_io->success('   -> ' . implode(', ', $out) . '.');
 	}
 
 	/**
@@ -945,11 +948,8 @@ abstract class AbstractAnnotator {
 			$out[] = $skipped . ' ' . ($skipped === 1 ? 'annotation' : 'annotations') . ' skipped';
 		}
 		$removable = !empty($this->_counter[static::COUNT_REMOVABLE]) ? $this->_counter[static::COUNT_REMOVABLE] : 0;
-		if ($removable) {
-			$out[] = $removable . ' ' . ($removable === 1 ? 'annotation' : 'annotations') . ' outdated (run with -r to remove)';
-		}
 
-		if (!$out) {
+		if (!$out && !$removable) {
 			return;
 		}
 
@@ -957,7 +957,12 @@ abstract class AbstractAnnotator {
 			$this->_io->out('-> ' . str_replace(ROOT . DS, '', $path));
 		}
 
-		$this->_io->out('   -> ' . implode(', ', $out));
+		if ($out) {
+			$this->_io->out('   -> ' . implode(', ', $out));
+		}
+		if ($removable) {
+			$this->_io->warn('   -> ' . $removable . ' ' . ($removable === 1 ? 'annotation' : 'annotations') . ' outdated (run with -r to remove)');
+		}
 	}
 
 	/**

--- a/src/Command/AnnotateCommand.php
+++ b/src/Command/AnnotateCommand.php
@@ -66,6 +66,7 @@ abstract class AnnotateCommand extends Command {
 		}
 
 		AbstractAnnotator::$output = false;
+		AbstractAnnotator::$stale = false;
 	}
 
 	/**
@@ -100,7 +101,7 @@ abstract class AnnotateCommand extends Command {
 				'default' => null,
 			],
 			'ci' => [
-				'help' => 'Enable CI mode (requires dry-run). This will return an error code ' . static::CODE_CHANGES . ' if changes are necessary.',
+				'help' => 'Enable CI mode (requires dry-run). This will return an error code ' . static::CODE_CHANGES . ' if changes are necessary or outdated annotations are present.',
 				'boolean' => true,
 			],
 			'interactive' => [
@@ -198,10 +199,15 @@ abstract class AnnotateCommand extends Command {
 	}
 
 	/**
+	 * CI predicate: true when the codebase is not in the annotator's desired
+	 * state — either files were (would be) changed, or outdated/removable
+	 * annotations were detected. The latter makes `--ci` fail on stale
+	 * docblocks without needing the destructive `-r`.
+	 *
 	 * @return bool
 	 */
 	protected function _annotatorMadeChanges(): bool {
-		return AbstractAnnotator::$output !== false;
+		return AbstractAnnotator::$output !== false || AbstractAnnotator::$stale;
 	}
 
 }

--- a/tests/TestCase/Command/AnnotateCommandTest.php
+++ b/tests/TestCase/Command/AnnotateCommandTest.php
@@ -5,8 +5,11 @@ namespace IdeHelper\Test\TestCase\Command;
 use Cake\Console\TestSuite\ConsoleIntegrationTestTrait;
 use Cake\Core\Configure;
 use Cake\TestSuite\TestCase;
+use IdeHelper\Annotator\AbstractAnnotator;
+use IdeHelper\Command\Annotate\ModelsCommand;
 use IdeHelper\Command\AnnotateCommand;
 use PHPUnit\Framework\Attributes\DataProvider;
+use ReflectionMethod;
 
 class AnnotateCommandTest extends TestCase {
 
@@ -203,6 +206,28 @@ class AnnotateCommandTest extends TestCase {
 		$this->exec('annotate ' . $subcommand . ' -d -v --ci');
 
 		$this->assertExitCode(AnnotateCommand::CODE_CHANGES, $this->_out->output());
+	}
+
+	/**
+	 * The CI predicate must fail when only outdated (removable) annotations
+	 * were detected, even though nothing was written and `-r` was not used.
+	 *
+	 * @return void
+	 */
+	public function testCiPredicateFailsOnStaleWithoutRemove(): void {
+		$command = new ModelsCommand();
+		$method = new ReflectionMethod($command, '_annotatorMadeChanges');
+		$method->setAccessible(true);
+
+		AbstractAnnotator::$output = false;
+		AbstractAnnotator::$stale = false;
+		$this->assertFalse($method->invoke($command));
+
+		AbstractAnnotator::$stale = true;
+		$this->assertTrue($method->invoke($command));
+
+		AbstractAnnotator::$output = false;
+		AbstractAnnotator::$stale = false;
 	}
 
 }


### PR DESCRIPTION
Follow-up to #448 (report outdated annotations on a plain run). Two related refinements to that feature.

## 1. Color the outdated summary as a warning, not green success

The removable count was concatenated into the shared summary string, so it rendered inside the green `success()` line in one path and plain/uncoloured in the other. "Outdated, action recommended" should not read as success, and the two paths disagreed. It is now emitted on its own `warn()` line in both `report()` and `reportSkipped()`, matching the verbose per-annotation `warn()` styling. Only printed when the count is non-zero.

## 2. Fail CI mode on outdated annotations without requiring -r

Previously `--ci` only failed when files would be added/updated, or removed via `-r`. Stale (removable) annotations on a plain `--ci` run were reported but exited 0 — a codebase accumulating outdated docblocks still passed CI unless someone opted into the destructive `-r`.

A run that detects removable annotations now sets a static `$stale` flag (reset per command run alongside `$output`). The CI predicate ORs it in, so `--ci` returns `CODE_CHANGES` on stale docblocks **independent of `-r`** and **independent of the add/update path**. Non-CI behaviour is unchanged: a plain run still only reports and writes nothing.

This tightens `--ci` semantics deliberately: `--ci` means "the codebase is not in the annotator's desired state", and stale docblocks are part of that — consistent with how `--ci` already fails on missing/outdated additions. The `--ci` help text is updated accordingly.

## Why no false positives

Existing CI-mode "no changes" tests (`testAllCiModeNoChanges` / `testIndividualSubcommandCiModeNoChanges` against the pre-annotated `Awesome` plugin) stay green: those fixtures contain no annotations the current generator considers removable, so `$stale` stays false and they still `ExitSuccess`. Verified by the full suite.

## Tests

- `AbstractAnnotatorTest::testReportSurfacesRemovableCount` — report output (coloring path).
- `AnnotateCommandTest::testCiPredicateFailsOnStaleWithoutRemove` — the CI predicate returns true when only `$stale` is set, false otherwise.
- Full suite green (298), `composer stan` clean, `composer cs-check` clean.

Branched off the updated master (post-#448) and cherry-picked the coloring commit there per the squash-merged-branch convention (the original branch was squash-merged so it is not reused).