### PR TITLE
Skip extends-annotation generation when parent class isn't generic

### DIFF
--- a/src/Annotator/ModelAnnotator.php
+++ b/src/Annotator/ModelAnnotator.php
@@ -593,11 +593,49 @@ class ModelAnnotator extends AbstractAnnotator {
 		if (!$parentClass) {
 			$parentClass = '\\Cake\\ORM\\Table';
 		}
+		if (!$this->parentSupportsGenerics($parentClass)) {
+			// A bare `@extends` adds no information beyond PHP's own `extends` clause,
+			// and emitting `@extends NonGenericParent<...>` would trigger PHPStan's
+			// `generics.notGeneric` error on every consumer.
+			return $result;
+		}
 		// Prepend so @extends sits at the top of the class doc-block, matching the
 		// classOrder defined by php-collective/code-sniffer DocBlockTagOrderSniff.
 		array_unshift($result, AnnotationFactory::createOrFail(ExtendsAnnotation::TAG, '\\' . $parentClass . '<array{' . $list . '}' . $entityTemplate . '>'));
 
 		return $result;
+	}
+
+	/**
+	 * Whether the given parent class declares template parameters and can therefore
+	 * be parameterized via `@extends`.
+	 *
+	 * A class is generic iff its own docblock contains an `@template` tag — inheriting
+	 * from a generic parent without declaring `@template` on the subclass does NOT
+	 * make the subclass generic (PHPStan would report `generics.notGeneric` for any
+	 * `@extends Subclass<...>` annotation in consumers).
+	 *
+	 * @param string $parentClass
+	 * @return bool
+	 */
+	protected function parentSupportsGenerics(string $parentClass): bool {
+		if ($parentClass === '' || ltrim($parentClass, '\\') === Table::class) {
+			// `\Cake\ORM\Table` declares `@template TBehaviors` (long-standing) and
+			// `@template TEntity` (from 5.3.4). Either makes the parent generic.
+			return true;
+		}
+
+		$fqcn = ltrim($parentClass, '\\');
+		if (!class_exists($fqcn)) {
+			return false;
+		}
+
+		$doc = (new ReflectionClass($fqcn))->getDocComment();
+		if ($doc === false) {
+			return false;
+		}
+
+		return preg_match('/^\s*\*\s*@template\s/m', $doc) === 1;
 	}
 
 	/**

--- a/tests/TestCase/Annotator/ModelAnnotatorTest.php
+++ b/tests/TestCase/Annotator/ModelAnnotatorTest.php
@@ -339,7 +339,7 @@ class ModelAnnotatorTest extends TestCase {
 		$annotator->annotate($path);
 
 		$output = $this->out->output();
-		$this->assertTextContains('  -> 18 annotations added', $output);
+		$this->assertTextContains('  -> 17 annotations added', $output);
 	}
 
 	/**
@@ -492,6 +492,56 @@ class ModelAnnotatorTest extends TestCase {
 		$this->assertStringContainsString('findOrCreate(', $capture);
 		$this->assertStringContainsString('newEntity(', $capture);
 		$this->assertStringContainsString('patchEntity(', $capture);
+	}
+
+	/**
+	 * Regression: when the parent base table declares no `@template` of its own
+	 * (i.e. is not a generic class), emitting `@extends Parent<...>` would trigger
+	 * PHPStan's `generics.notGeneric` error in every consumer. The annotation must
+	 * be skipped entirely for non-generic parents — the PHP `extends` clause is
+	 * sufficient and a bare `@extends` adds no information.
+	 *
+	 * @return void
+	 */
+	public function testAnnotateSkipsExtendsForNonGenericParent() {
+		$annotator = $this->_getEntityTemplateAnnotatorMock([]);
+
+		$capture = '';
+		$annotator->method('storeFile')
+			->with($this->anything(), $this->callback(function ($value) use (&$capture) {
+				$capture = $value;
+
+				return true;
+			}));
+
+		$annotator->annotate(APP . 'Model/Table/BarBarsAbstractTable.php');
+
+		$this->assertStringNotContainsString('@extends \TestApp\Model\Table\AbstractTable', $capture);
+		$this->assertStringNotContainsString('@extends', $capture);
+	}
+
+	/**
+	 * Regression: when the parent IS `\Cake\ORM\Table` (the canonical generic parent),
+	 * `@extends Cake\ORM\Table<...>` must still be emitted so consumers benefit from
+	 * the parent's template propagation. Guards against an over-eager skip in
+	 * `parentSupportsGenerics()`.
+	 *
+	 * @return void
+	 */
+	public function testAnnotateEmitsExtendsForGenericCakeTableParent() {
+		$annotator = $this->_getEntityTemplateAnnotatorMock([]);
+
+		$capture = '';
+		$annotator->method('storeFile')
+			->with($this->anything(), $this->callback(function ($value) use (&$capture) {
+				$capture = $value;
+
+				return true;
+			}));
+
+		$annotator->annotate(APP . 'Model/Table/BarBarsTable.php');
+
+		$this->assertStringContainsString('@extends \Cake\ORM\Table<', $capture);
 	}
 
 	/**

--- a/tests/test_files/Model/Table/BarBarsAbstractTable.php
+++ b/tests/test_files/Model/Table/BarBarsAbstractTable.php
@@ -2,8 +2,6 @@
 namespace TestApp\Model\Table;
 
 /**
- * @extends \TestApp\Model\Table\AbstractTable<array{MyMy: \MyNamespace\MyPlugin\Model\Behavior\MyBehavior, Timestamp: \Cake\ORM\Behavior\TimestampBehavior}>
- *
  * @property \Cake\ORM\Association\BelongsTo<\TestApp\Model\Table\FoosTable> $Foos
  * @property \Cake\ORM\Association\BelongsToMany<\Awesome\Model\Table\HousesTable> $Houses
  *


### PR DESCRIPTION
## Summary

The extends-emission path in `ModelAnnotator::addBehaviorExtends()` unconditionally writes an extends-annotation pointing at the parent (with the behavior-array and entity-type templates) for every table whose parent has a behavior list or entity to project — regardless of whether the parent class actually declares any template of its own.

When the parent **isn't generic** (typical case: a Cake plugin's base table written before the 5.3.4 generics, e.g. `Ratings\Model\Table\RatingsTable` from `dereuromark/cakephp-ratings`), the resulting annotation breaks the consumer's build with PHPStan's `generics.notGeneric` error.

Example breakage in a downstream project:

```
SandboxRatingsTable.php
Line 28: PHPDoc tag @extends contains generic type
         Ratings\Model\Table\RatingsTable<array{}, Sandbox\Model\Entity\SandboxRating>
         but class Ratings\Model\Table\RatingsTable is not generic.
         generics.notGeneric
```

The line was emitted by `composer annotate` so the user can't avoid regenerating it short of deleting it after every run.

## Approach

Gate the emission on a new `parentSupportsGenerics()` helper:

- `\Cake\ORM\Table` (long-standing TBehaviors template, plus TEntity template from 5.3.4) is treated as generic unconditionally.
- Any other parent is reflected and considered generic **iff its own docblock declares a template tag of its own**. Inheriting from a generic ancestor without re-declaring the template doesn't make the subclass generic itself — PHPStan would still report `generics.notGeneric` on any consumer's extends annotation pointing at the subclass.
- A bare extends-annotation without generic params is genuinely redundant with PHP's own `extends` clause, so non-generic parents get **no extends-annotation line at all** rather than a parameter-less placeholder.

## Test changes

- `testAnnotateProtectedParent` — fixture loses its extends-annotation line referencing `TestApp\Model\Table\AbstractTable` (which declares no template tag) and the snapshot annotation count drops 18 → 17.
- New `testAnnotateSkipsExtendsForNonGenericParent` asserts the negative branch via the existing `BarBarsAbstractTable` fixture.
- New `testAnnotateEmitsExtendsForGenericCakeTableParent` asserts the positive branch via `BarBarsTable` (parent is `\Cake\ORM\Table`, which is generic) — guards against an over-eager skip.

## Migration note (why this is a draft)

Orphan extends-annotation lines in **already-annotated** consumer files are NOT removed automatically by this change. The orphan-pruning pass in `AbstractAnnotator::appendToExistingDocBlock()` only considers tag types the current run also generates — when we now emit zero extends-annotation for non-generic parents, the existing line is left untouched.

Consumers therefore need either:

1. A one-time manual cleanup of the orphan extends-annotation line, or
2. Upstreaming a template tag to their custom base class so this annotator re-emits and replaces the line.

If we'd rather have option (1) automated, a follow-up could extend the comparison to treat the extends tag type as always-managed when `tableBehaviors` includes `extends`. Happy to roll that in if you prefer it bundled.

## Verification

Plugin-level:
- `vendor/bin/phpunit` — 300 tests, 943 assertions, all green
- `composer stan` — no errors
- `composer cs-check` — no errors

Downstream verification in a real consumer (`dereuromark/cakephp-sandbox`, which loads `cakephp-ratings`):
- Drop the patched annotator into vendor, re-run `bin/cake annotate models -p Sandbox` — `SandboxRatingsTable.php` no longer regenerates the broken line
- `composer stan` in the sandbox: green (previously failed with `generics.notGeneric` on this exact line)