### PR TITLE
Prune orphan extends-annotation lines when the extends behavior is on

### DIFF
--- a/src/Annotator/AbstractAnnotator.php
+++ b/src/Annotator/AbstractAnnotator.php
@@ -313,9 +313,7 @@ abstract class AbstractAnnotator {
 	protected function appendToExistingDocBlock(File $file, int $docBlockCloseIndex, array &$annotations): string {
 		$existingAnnotations = $this->parseExistingAnnotations($file, $docBlockCloseIndex);
 
-		$generatedTags = array_unique(array_map(static function ($annotation) {
-			return $annotation::TAG;
-		}, $annotations));
+		$generatedTags = $this->managedTags($annotations);
 
 		$replacingAnnotations = [];
 		$addingAnnotations = [];
@@ -436,6 +434,27 @@ abstract class AbstractAnnotator {
 		}
 
 		return $index;
+	}
+
+	/**
+	 * Tag types this run considers managed for orphan-pruning purposes.
+	 *
+	 * Defaults to the set of tags actually generated this pass — a tag type that
+	 * appears in an existing doc-block but not in the generated set is left
+	 * alone (we assume the human added it deliberately). Subclasses can widen
+	 * this when a tag type is conceptually owned by the annotator regardless
+	 * of whether the current run emitted one — e.g. ModelAnnotator owns the
+	 * extends tag whenever the extends behavior is configured, so an orphan
+	 * line left over from a previous configuration gets pruned even when this
+	 * pass emits none.
+	 *
+	 * @param array<\IdeHelper\Annotation\AbstractAnnotation> $annotations
+	 * @return array<string>
+	 */
+	protected function managedTags(array $annotations): array {
+		return array_unique(array_map(static function ($annotation) {
+			return $annotation::TAG;
+		}, $annotations));
 	}
 
 	/**

--- a/src/Annotator/ModelAnnotator.php
+++ b/src/Annotator/ModelAnnotator.php
@@ -607,6 +607,24 @@ class ModelAnnotator extends AbstractAnnotator {
 	}
 
 	/**
+	 * Treat the extends tag as managed whenever the extends behavior is configured,
+	 * so an orphan line left over from a previous run (e.g. before the parent-genericness
+	 * gate was added) gets pruned by `-r` even when the current pass emits no extends.
+	 *
+	 * @param array<\IdeHelper\Annotation\AbstractAnnotation> $annotations
+	 * @return array<string>
+	 */
+	protected function managedTags(array $annotations): array {
+		$tags = parent::managedTags($annotations);
+
+		if (in_array(static::BEHAVIOR_EXTENDS, $this->_config[static::TABLE_BEHAVIORS], true) && !in_array(ExtendsAnnotation::TAG, $tags, true)) {
+			$tags[] = ExtendsAnnotation::TAG;
+		}
+
+		return $tags;
+	}
+
+	/**
 	 * Whether the given parent class declares template parameters and can therefore
 	 * be parameterized via `@extends`.
 	 *

--- a/tests/TestCase/Annotator/ModelAnnotatorTest.php
+++ b/tests/TestCase/Annotator/ModelAnnotatorTest.php
@@ -521,6 +521,61 @@ class ModelAnnotatorTest extends TestCase {
 	}
 
 	/**
+	 * Regression: an orphan extends-annotation left in a consumer file by a previous
+	 * run (e.g. before the parent-genericness gate was added) must get pruned on the
+	 * next `-r` run, not silently outlive the annotator's own emission gate.
+	 *
+	 * @return void
+	 */
+	public function testAnnotateRemovesOrphanExtendsForNonGenericParent() {
+		$tmpPath = TMP . 'BarBarsAbstractTableOrphanExtends.php';
+		$orphan = <<<'PHP'
+			<?php
+			namespace TestApp\Model\Table;
+
+			/**
+			 * @extends \TestApp\Model\Table\AbstractTable<array{Timestamp: \Cake\ORM\Behavior\TimestampBehavior}, \TestApp\Model\Entity\BarBarsAbstract>
+			 */
+			class BarBarsAbstractTable extends AbstractTable {
+
+				/**
+				 * @param array $config
+				 * @return void
+				 */
+				public function initialize(array $config): void {
+					parent::initialize($config);
+
+					$this->setTable('bar_bars');
+					$this->belongsTo('Foos');
+					$this->addBehavior('MyMy', [
+						'className' => 'MyNamespace/MyPlugin.My',
+					]);
+				}
+
+			}
+			PHP;
+		file_put_contents($tmpPath, $orphan);
+
+		try {
+			$annotator = $this->_getAnnotatorMock([]);
+
+			$capture = '';
+			$annotator->method('storeFile')
+				->with($this->anything(), $this->callback(function ($value) use (&$capture) {
+					$capture = $value;
+
+					return true;
+				}));
+
+			$annotator->annotate($tmpPath);
+
+			$this->assertStringNotContainsString('@extends', $capture, 'Orphan extends line was not pruned.');
+		} finally {
+			@unlink($tmpPath);
+		}
+	}
+
+	/**
 	 * Regression: when the parent IS `\Cake\ORM\Table` (the canonical generic parent),
 	 * `@extends Cake\ORM\Table<...>` must still be emitted so consumers benefit from
 	 * the parent's template propagation. Guards against an over-eager skip in


### PR DESCRIPTION
Follow-up to #450.

## Summary

#450 stopped the annotator from emitting a parameterized extends-annotation for non-generic parents (which would otherwise trigger PHPStan's `generics.notGeneric` on every consumer). It deliberately punted on cleaning up orphan lines already present in consumer files — those stayed in place because the orphan-pruning pass in `AbstractAnnotator::appendToExistingDocBlock()` only deletes tags whose type matches a tag the current run actually generated. When the annotator now emits zero extends-annotation lines, the existing one isn't in the generated-tag set and gets unset from the removal queue.

## Approach

Add a `managedTags()` hook in `AbstractAnnotator`:

- Default behavior unchanged — returns the set of tags actually generated this pass.
- Subclasses can widen it with tag types they own regardless of whether the current pass produced one.

`ModelAnnotator` overrides it to include `ExtendsAnnotation::TAG` whenever the `tableBehaviors` config includes `extends`. So in any project that has the extends behavior on, an orphan extends-annotation line — whether left over from a previous run, an old config, or copy-pasted by hand — is now reported as outdated on a plain run and pruned by `-r` on the next run.

Projects that explicitly hand-wrote an extends-annotation against a non-Cake parent are unaffected if they've disabled the extends behavior (the `tableBehaviors` config check gates the widening).

## Verification

Plugin-level:
- `vendor/bin/phpunit` — 301 tests, 944 assertions, all green (+1 new regression test over master)
- `composer stan` — no errors
- `composer cs-check` — no errors

New regression test `testAnnotateRemovesOrphanExtendsForNonGenericParent` writes a tmp fixture with an orphan extends line pointing at the non-generic `AbstractTable`, runs the annotator with the remove flag on, and asserts the line is gone.

Downstream verification in `dereuromark/cakephp-sandbox`:
- Restored the orphan extends-annotation in `SandboxRatingsTable.php`
- Dropped the patched annotator into vendor, re-ran `bin/cake annotate models -p Sandbox -r -v --filter SandboxRatings`
- Output: `-> 1 annotation removed.` — orphan line stripped, file now clean
