### PR TITLE
Add rector (conservative wins-only ruleset)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,3 +119,6 @@ jobs:
 
       - name: Run phpcs
         run: composer cs-check
+
+      - name: Run rector
+        run: composer rector-setup && composer rector

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,8 +117,8 @@ jobs:
       - name: Run phpstan
         run: vendor/bin/phpstan analyse --error-format=github
 
-      - name: Run phpcs
-        run: composer cs-check
-
       - name: Run rector
         run: composer rector-setup && composer rector
+
+      - name: Run phpcs
+        run: composer cs-check

--- a/composer.json
+++ b/composer.json
@@ -83,6 +83,9 @@
 		"stan": "phpstan analyze",
 		"stan-setup": "cp composer.json composer.backup && composer require --dev phpstan/phpstan:^2.0.0 && mv composer.backup composer.json",
 		"stan-tests": "phpstan analyze -c tests/phpstan.neon",
+		"rector": "rector process --dry-run",
+		"rector-fix": "rector process",
+		"rector-setup": "cp composer.json composer.backup && composer require --dev rector/rector:^2.0 && mv composer.backup composer.json",
 		"test": "phpunit",
 		"test-coverage": "phpunit --log-junit tmp/coverage/unitreport.xml --coverage-html tmp/coverage --coverage-clover tmp/coverage/coverage.xml"
 	}

--- a/composer.json
+++ b/composer.json
@@ -85,7 +85,7 @@
 		"stan-tests": "phpstan analyze -c tests/phpstan.neon",
 		"rector": "rector process --dry-run",
 		"rector-fix": "rector process",
-		"rector-setup": "cp composer.json composer.backup && composer require --dev rector/rector:^2.0 && mv composer.backup composer.json",
+		"rector-setup": "cp composer.json composer.backup && composer require --dev rector/rector:~2.4.0 && mv composer.backup composer.json",
 		"test": "phpunit",
 		"test-coverage": "phpunit --log-junit tmp/coverage/unitreport.xml --coverage-html tmp/coverage --coverage-clover tmp/coverage/coverage.xml"
 	}

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\CodeQuality\Rector\Class_\CompleteDynamicPropertiesRector;
+use Rector\CodeQuality\Rector\If_\ExplicitBoolCompareRector;
+use Rector\CodeQuality\Rector\Empty_\SimplifyEmptyCheckOnEmptyArrayRector;
+use Rector\CodingStyle\Rector\FuncCall\FunctionFirstClassCallableRector;
+use Rector\Config\RectorConfig;
+use Rector\DeadCode\Rector\ClassMethod\RemoveUselessParamTagRector;
+use Rector\DeadCode\Rector\ClassMethod\RemoveUselessReturnTagRector;
+use Rector\DeadCode\Rector\Node\RemoveNonExistingVarAnnotationRector;
+use Rector\DeadCode\Rector\Property\RemoveUselessVarTagRector;
+use Rector\Php55\Rector\String_\StringClassNameToClassConstantRector;
+use Rector\Php74\Rector\Closure\ClosureToArrowFunctionRector;
+use Rector\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector;
+use Rector\Php80\Rector\FuncCall\ClassOnObjectRector;
+use Rector\Strict\Rector\Empty_\DisallowedEmptyRuleFixerRector;
+use Rector\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector;
+
+return RectorConfig::configure()
+	->withPaths([
+		__DIR__ . '/src',
+		__DIR__ . '/tests',
+	])
+	->withSkip([
+		// Hand-crafted annotator inputs / generated code — must not be rewritten.
+		__DIR__ . '/tests/test_app',
+		__DIR__ . '/tests/test_files',
+
+		// Conflicts with house style: plugins deliberately omit declare(strict_types=1).
+		SafeDeclareStrictTypesRector::class,
+		// Conflicts with house style: we prefer `if ($var)` over explicit `!== null` / `!== 0`.
+		ExplicitBoolCompareRector::class,
+		DisallowedEmptyRuleFixerRector::class,
+
+		// Opinionated, large churn — revisit deliberately, not in a sweep.
+		ClassPropertyAssignToConstructorPromotionRector::class,
+		ClosureToArrowFunctionRector::class,
+		// Adds untyped `public $Foo;` properties (CS then wants a @var docblock); cake core skips it.
+		CompleteDynamicPropertiesRector::class,
+
+		// Docblock cleanup is a separate, deliberate pass — keep redundant tags for now.
+		RemoveUselessParamTagRector::class,
+		RemoveUselessReturnTagRector::class,
+		RemoveUselessVarTagRector::class,
+		RemoveNonExistingVarAnnotationRector::class,
+
+		// Broken / unsafe rules (see upstream issues):
+		// rectorphp/rector#9767 — converts a string callable to a namespace-relative
+		// first-class callable, turning working code into a fatal class-not-found.
+		FunctionFirstClassCallableRector::class,
+		// rectorphp/rector#9768 — rewrites empty() on a possibly-undefined variable to
+		// `=== []`, introducing an undefined-variable warning and flipping behavior.
+		SimplifyEmptyCheckOnEmptyArrayRector::class,
+		// Drops the leading backslash from class-name strings used as data (e.g. docblock
+		// fragments); the deprecated should_keep_pre_slash knob no longer prevents it.
+		StringClassNameToClassConstantRector::class,
+		// get_class() -> ::class invalidates existing phpstan ignore patterns; opt in per plugin.
+		ClassOnObjectRector::class,
+	])
+	->withPhpSets(php82: true)
+	->withPreparedSets(
+		deadCode: true,
+		codeQuality: true,
+	);

--- a/rector.php
+++ b/rector.php
@@ -7,6 +7,8 @@ use Rector\CodeQuality\Rector\If_\ExplicitBoolCompareRector;
 use Rector\CodeQuality\Rector\Empty_\SimplifyEmptyCheckOnEmptyArrayRector;
 use Rector\CodingStyle\Rector\FuncCall\FunctionFirstClassCallableRector;
 use Rector\Config\RectorConfig;
+use Rector\DeadCode\Rector\Assign\RemoveUnusedVariableAssignRector;
+use Rector\DeadCode\Rector\Cast\RecastingRemovalRector;
 use Rector\DeadCode\Rector\ClassMethod\RemoveUselessParamTagRector;
 use Rector\DeadCode\Rector\ClassMethod\RemoveUselessReturnTagRector;
 use Rector\DeadCode\Rector\Node\RemoveNonExistingVarAnnotationRector;
@@ -58,6 +60,11 @@ return RectorConfig::configure()
 		StringClassNameToClassConstantRector::class,
 		// get_class() -> ::class invalidates existing phpstan ignore patterns; opt in per plugin.
 		ClassOnObjectRector::class,
+		// Removes intentional/defensive (string) casts that coerce Stringable/mixed values
+		// to real strings, relying on phpstan's optimistic inference; cake core skips it too.
+		RecastingRemovalRector::class,
+		// Strips an unused assignment but leaves the call as a dead bare statement; cake core skips it.
+		RemoveUnusedVariableAssignRector::class,
 	])
 	->withPhpSets(php82: true)
 	->withPreparedSets(

--- a/rector.php
+++ b/rector.php
@@ -13,6 +13,7 @@ use Rector\DeadCode\Rector\ClassMethod\RemoveUselessParamTagRector;
 use Rector\DeadCode\Rector\ClassMethod\RemoveUselessReturnTagRector;
 use Rector\DeadCode\Rector\Node\RemoveNonExistingVarAnnotationRector;
 use Rector\DeadCode\Rector\Property\RemoveUselessVarTagRector;
+use Rector\DeadCode\Rector\Ternary\RemoveUselessTernaryRector;
 use Rector\Php55\Rector\String_\StringClassNameToClassConstantRector;
 use Rector\Php74\Rector\Closure\ClosureToArrowFunctionRector;
 use Rector\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector;
@@ -65,6 +66,9 @@ return RectorConfig::configure()
 		RecastingRemovalRector::class,
 		// Strips an unused assignment but leaves the call as a dead bare statement; cake core skips it.
 		RemoveUnusedVariableAssignRector::class,
+		// Removes defensive `expr ?: []` fallbacks; can change behavior on undefined/empty
+		// values (e.g. `$_SESSION ?: []`). Skipped on cakephp core's 2.4 bump too.
+		RemoveUselessTernaryRector::class,
 	])
 	->withPhpSets(php82: true)
 	->withPreparedSets(

--- a/src/Annotation/AbstractAnnotation.php
+++ b/src/Annotation/AbstractAnnotation.php
@@ -3,8 +3,9 @@
 namespace IdeHelper\Annotation;
 
 use RuntimeException;
+use Stringable;
 
-abstract class AbstractAnnotation implements AnnotationInterface, ReplacableAnnotationInterface {
+abstract class AbstractAnnotation implements AnnotationInterface, ReplacableAnnotationInterface, Stringable {
 
 	/**
 	 * @var string

--- a/src/Annotation/ExtendsAnnotation.php
+++ b/src/Annotation/ExtendsAnnotation.php
@@ -52,12 +52,8 @@ class ExtendsAnnotation extends AbstractAnnotation {
 	 * @return bool
 	 */
 	public function matches(AbstractAnnotation $annotation): bool {
-		if (!$annotation instanceof self) {
-			return false;
-		}
-
 		// Always matches as there can only be one per docblock
-		return true;
+		return $annotation instanceof self;
 	}
 
 	/**

--- a/src/Annotation/LinkAnnotation.php
+++ b/src/Annotation/LinkAnnotation.php
@@ -55,11 +55,8 @@ class LinkAnnotation extends AbstractAnnotation {
 		if (!$annotation instanceof self) {
 			return false;
 		}
-		if ($annotation->getType() !== $this->type) {
-			return false;
-		}
 
-		return true;
+		return $annotation->getType() === $this->type;
 	}
 
 	/**

--- a/src/Annotation/MethodAnnotation.php
+++ b/src/Annotation/MethodAnnotation.php
@@ -115,11 +115,8 @@ class MethodAnnotation extends AbstractAnnotation {
 			return false;
 		}
 		$methodName = substr($annotation->getMethod(), 0, strpos($annotation->getMethod(), '(') ?: 0);
-		if ($methodName !== substr($this->method, 0, strpos($this->method, '(') ?: 0)) {
-			return false;
-		}
 
-		return true;
+		return $methodName === substr($this->method, 0, strpos($this->method, '(') ?: 0);
 	}
 
 	/**

--- a/src/Annotation/MixinAnnotation.php
+++ b/src/Annotation/MixinAnnotation.php
@@ -51,11 +51,8 @@ class MixinAnnotation extends AbstractAnnotation {
 		if (!$annotation instanceof self) {
 			return false;
 		}
-		if ($annotation->getType() !== $this->type) {
-			return false;
-		}
 
-		return true;
+		return $annotation->getType() === $this->type;
 	}
 
 	/**

--- a/src/Annotation/ParamAnnotation.php
+++ b/src/Annotation/ParamAnnotation.php
@@ -62,11 +62,8 @@ class ParamAnnotation extends AbstractAnnotation {
 		if (!$annotation instanceof self) {
 			return false;
 		}
-		if ($annotation->getVariable() !== $this->variable) {
-			return false;
-		}
 
-		return true;
+		return $annotation->getVariable() === $this->variable;
 	}
 
 	/**

--- a/src/Annotation/PropertyAnnotation.php
+++ b/src/Annotation/PropertyAnnotation.php
@@ -65,11 +65,8 @@ class PropertyAnnotation extends AbstractAnnotation {
 		if (!$annotation instanceof self) {
 			return false;
 		}
-		if ($annotation->getProperty() !== $this->property) {
-			return false;
-		}
 
-		return true;
+		return $annotation->getProperty() === $this->property;
 	}
 
 	/**

--- a/src/Annotation/SeeAnnotation.php
+++ b/src/Annotation/SeeAnnotation.php
@@ -51,11 +51,8 @@ class SeeAnnotation extends AbstractAnnotation {
 		if (!$annotation instanceof self) {
 			return false;
 		}
-		if ($annotation->getType() !== $this->type) {
-			return false;
-		}
 
-		return true;
+		return $annotation->getType() === $this->type;
 	}
 
 	/**

--- a/src/Annotation/UsesAnnotation.php
+++ b/src/Annotation/UsesAnnotation.php
@@ -51,11 +51,8 @@ class UsesAnnotation extends AbstractAnnotation {
 		if (!$annotation instanceof self) {
 			return false;
 		}
-		if ($annotation->getType() !== $this->type) {
-			return false;
-		}
 
-		return true;
+		return $annotation->getType() === $this->type;
 	}
 
 	/**

--- a/src/Annotation/VariableAnnotation.php
+++ b/src/Annotation/VariableAnnotation.php
@@ -81,11 +81,8 @@ class VariableAnnotation extends AbstractAnnotation {
 		if (!$annotation instanceof self) {
 			return false;
 		}
-		if ($annotation->getVariable() !== $this->variable) {
-			return false;
-		}
 
-		return true;
+		return $annotation->getVariable() === $this->variable;
 	}
 
 	/**

--- a/src/Annotator/AbstractAnnotator.php
+++ b/src/Annotator/AbstractAnnotator.php
@@ -194,14 +194,14 @@ abstract class AbstractAnnotator {
 			$row = $array[$i];
 
 			$char = ' ';
-			$output = trim($row[0], "\n\r\0\x0B");
+			$output = trim((string)$row[0], "\n\r\0\x0B");
 
 			if ($row[1] === 1) {
 				$char = '+';
 				$this->_io->info('   | ' . $char . $output);
 			} elseif ($row[1] === 2) {
 				$char = '-';
-				$this->_io->out('<warning>' . '   | ' . $char . $output . '</warning>');
+				$this->_io->out('<warning>   | ' . $char . $output . '</warning>');
 			} else {
 				$this->_io->out('   | ' . $char . $output);
 			}
@@ -401,7 +401,7 @@ abstract class AbstractAnnotator {
 				$this->_counter[static::COUNT_REMOVABLE]++;
 				static::$stale = true;
 				if ($this->getConfig(static::CONFIG_VERBOSE)) {
-					$this->_io->warn('   Outdated annotation (run with -r to remove): ' . (string)$annotation);
+					$this->_io->warn('   Outdated annotation (run with -r to remove): ' . $annotation);
 				}
 
 				continue;
@@ -470,12 +470,10 @@ abstract class AbstractAnnotator {
 				return true;
 			}
 
-			if ($annotation instanceof PropertyAnnotation && $existingAnnotation instanceof PropertyAnnotation) {
-				if ($annotation->getProperty() === $existingAnnotation->getProperty() && $annotation->getType() === $existingAnnotation->getType()) {
-					unset($existingAnnotations[$key]);
+			if ($annotation instanceof PropertyAnnotation && $existingAnnotation instanceof PropertyAnnotation && ($annotation->getProperty() === $existingAnnotation->getProperty() && $annotation->getType() === $existingAnnotation->getType())) {
+				unset($existingAnnotations[$key]);
 
-					return true;
-				}
+				return true;
 			}
 
 			// Let's skip on existing ones that are only guessed.
@@ -596,11 +594,11 @@ abstract class AbstractAnnotator {
 			$typeString = $this->renderUnionTypes($returnTypes);
 
 			$tag = $tokens[$i]['content'];
-			$variablePos = strpos($content, ' $');
+			$variablePos = strpos((string)$content, ' $');
 			if (in_array($tag, [VariableAnnotation::TAG, PropertyAnnotation::TAG]) && $variablePos) {
-				$content = mb_substr($content, $variablePos + 1);
+				$content = mb_substr((string)$content, $variablePos + 1);
 			} else {
-				$content = mb_substr($content, mb_strlen($typeString) + 1);
+				$content = mb_substr((string)$content, mb_strlen($typeString) + 1);
 			}
 
 			$annotation = AnnotationFactory::createOrFail($tag, $typeString, $content, $classNameIndex);
@@ -875,7 +873,7 @@ abstract class AbstractAnnotator {
 			if ($tokens[$i]['code'] !== T_DOC_COMMENT_TAG) {
 				continue;
 			}
-			if (mb_strtolower($tokens[$i]['content']) === '@inheritdoc') {
+			if (mb_strtolower((string)$tokens[$i]['content']) === '@inheritdoc') {
 				return true;
 			}
 		}
@@ -934,19 +932,19 @@ abstract class AbstractAnnotator {
 	protected function report(): void {
 		$out = [];
 
-		$added = !empty($this->_counter[static::COUNT_ADDED]) ? $this->_counter[static::COUNT_ADDED] : 0;
+		$added = empty($this->_counter[static::COUNT_ADDED]) ? 0 : $this->_counter[static::COUNT_ADDED];
 		if ($added) {
 			$out[] = $added . ' ' . ($added === 1 ? 'annotation' : 'annotations') . ' added';
 		}
-		$updated = !empty($this->_counter[static::COUNT_UPDATED]) ? $this->_counter[static::COUNT_UPDATED] : 0;
+		$updated = empty($this->_counter[static::COUNT_UPDATED]) ? 0 : $this->_counter[static::COUNT_UPDATED];
 		if ($updated) {
 			$out[] = $updated . ' ' . ($updated === 1 ? 'annotation' : 'annotations') . ' updated';
 		}
-		$removed = !empty($this->_counter[static::COUNT_REMOVED]) ? $this->_counter[static::COUNT_REMOVED] : 0;
+		$removed = empty($this->_counter[static::COUNT_REMOVED]) ? 0 : $this->_counter[static::COUNT_REMOVED];
 		if ($removed) {
 			$out[] = $removed . ' ' . ($removed === 1 ? 'annotation' : 'annotations') . ' removed';
 		}
-		$skipped = !empty($this->_counter[static::COUNT_SKIPPED]) ? $this->_counter[static::COUNT_SKIPPED] : 0;
+		$skipped = empty($this->_counter[static::COUNT_SKIPPED]) ? 0 : $this->_counter[static::COUNT_SKIPPED];
 		if ($skipped) {
 			$out[] = $skipped . ' ' . ($skipped === 1 ? 'annotation' : 'annotations') . ' skipped';
 		}
@@ -959,7 +957,7 @@ abstract class AbstractAnnotator {
 		// them on their own attention-coloured line (matches the verbose
 		// per-annotation warn() above), never folded into the green
 		// success summary.
-		$removable = !empty($this->_counter[static::COUNT_REMOVABLE]) ? $this->_counter[static::COUNT_REMOVABLE] : 0;
+		$removable = empty($this->_counter[static::COUNT_REMOVABLE]) ? 0 : $this->_counter[static::COUNT_REMOVABLE];
 		if ($removable) {
 			$this->_io->warn('   -> ' . $removable . ' ' . ($removable === 1 ? 'annotation' : 'annotations') . ' outdated (run with -r to remove)');
 		}
@@ -972,11 +970,11 @@ abstract class AbstractAnnotator {
 	protected function reportSkipped(string $path): void {
 		$out = [];
 
-		$skipped = !empty($this->_counter[static::COUNT_SKIPPED]) ? $this->_counter[static::COUNT_SKIPPED] : 0;
+		$skipped = empty($this->_counter[static::COUNT_SKIPPED]) ? 0 : $this->_counter[static::COUNT_SKIPPED];
 		if ($skipped) {
 			$out[] = $skipped . ' ' . ($skipped === 1 ? 'annotation' : 'annotations') . ' skipped';
 		}
-		$removable = !empty($this->_counter[static::COUNT_REMOVABLE]) ? $this->_counter[static::COUNT_REMOVABLE] : 0;
+		$removable = empty($this->_counter[static::COUNT_REMOVABLE]) ? 0 : $this->_counter[static::COUNT_REMOVABLE];
 
 		if (!$out && !$removable) {
 			return;

--- a/src/Annotator/CallbackAnnotatorTask/AbstractCallbackAnnotatorTask.php
+++ b/src/Annotator/CallbackAnnotatorTask/AbstractCallbackAnnotatorTask.php
@@ -67,13 +67,11 @@ abstract class AbstractCallbackAnnotatorTask extends AbstractAnnotator {
 
 		$closeTagIndex = $this->findCloseTagIndex($file, $index);
 
-		$result = [
+		return [
 			'name' => $tokens[$nameIndex]['content'],
 			'docBlockStart' => $closeTagIndex ? $tokens[$closeTagIndex]['comment_opener'] : null,
 			'docBlockEnd' => $closeTagIndex ?: null,
 		];
-
-		return $result;
 	}
 
 	/**

--- a/src/Annotator/CallbackAnnotatorTask/TableCallbackAnnotatorTask.php
+++ b/src/Annotator/CallbackAnnotatorTask/TableCallbackAnnotatorTask.php
@@ -58,11 +58,7 @@ class TableCallbackAnnotatorTask extends AbstractCallbackAnnotatorTask implement
 		$entityClassName = $table->getEntityClass();
 		$this->entityClassName = $entityClassName;
 
-		if (!preg_match('#\bfunction (' . $this->generatePattern() . ')\b#', $this->content)) {
-			return false;
-		}
-
-		return true;
+		return (bool)preg_match('#\bfunction (' . $this->generatePattern() . ')\b#', $this->content);
 	}
 
 	/**
@@ -132,7 +128,7 @@ class TableCallbackAnnotatorTask extends AbstractCallbackAnnotatorTask implement
 	 */
 	protected function generatePattern(): string {
 		$pattern = [];
-		foreach ($this->callbacks as $key => $v) {
+		foreach (array_keys($this->callbacks) as $key) {
 			$pattern[] = preg_quote($key . '(');
 		}
 

--- a/src/Annotator/CallbackAnnotatorTask/VirtualFieldCallbackAnnotatorTask.php
+++ b/src/Annotator/CallbackAnnotatorTask/VirtualFieldCallbackAnnotatorTask.php
@@ -25,11 +25,7 @@ class VirtualFieldCallbackAnnotatorTask extends AbstractCallbackAnnotatorTask im
 	 * @return bool
 	 */
 	public function shouldRun(string $path): bool {
-		if (!preg_match('#/Model/Entity/\w+\.php$#', $path)) {
-			return false;
-		}
-
-		return true;
+		return (bool)preg_match('#/Model/Entity/\w+\.php$#', $path);
 	}
 
 	/**
@@ -50,7 +46,7 @@ class VirtualFieldCallbackAnnotatorTask extends AbstractCallbackAnnotatorTask im
 				continue;
 			}
 
-			$method['see'] = $namespace . '\\' . $class . '::$' . Inflector::underscore(substr($method['name'], 4));
+			$method['see'] = $namespace . '\\' . $class . '::$' . Inflector::underscore(substr((string)$method['name'], 4));
 
 			if (!$this->needsUpdate($file, $index, $method)) {
 				unset($methods[$index]);
@@ -161,7 +157,7 @@ class VirtualFieldCallbackAnnotatorTask extends AbstractCallbackAnnotatorTask im
 	 */
 	protected function isVirtualField(array $method): bool {
 		foreach ($this->methods as $regex) {
-			if (preg_match($regex, $method['name'])) {
+			if (preg_match($regex, (string)$method['name'])) {
 				return true;
 			}
 		}

--- a/src/Annotator/ClassAnnotatorTask/AbstractClassAnnotatorTask.php
+++ b/src/Annotator/ClassAnnotatorTask/AbstractClassAnnotatorTask.php
@@ -156,7 +156,7 @@ abstract class AbstractClassAnnotatorTask extends AbstractAnnotator {
 		}
 
 		$annotation = reset($annotations);
-		$annotationString = '/** ' . (string)$annotation . ' */';
+		$annotationString = '/** ' . $annotation . ' */';
 		if (PHP_EOL !== "\n") {
 			$annotationString = str_replace("\n", PHP_EOL, $annotationString);
 		}

--- a/src/Annotator/ClassAnnotatorTask/FormClassAnnotatorTask.php
+++ b/src/Annotator/ClassAnnotatorTask/FormClassAnnotatorTask.php
@@ -23,12 +23,12 @@ class FormClassAnnotatorTask extends AbstractClassAnnotatorTask implements Class
 			return false;
 		}
 
-		Configure::read('App.namespace') ?: 'App';
-		if (!preg_match('#\buse (\w+)\\\\Form\\\\(.+)Form\b#', $content, $matches)) {
+		$appNamespace = Configure::read('App.namespace') ?: 'App';
+		if (!preg_match('#\buse ' . preg_quote($appNamespace, '#') . '\\\\Form\\\\(.+)Form\b#', $content, $matches)) {
 			return false;
 		}
 
-		$varName = lcfirst($matches[2]) . 'Form';
+		$varName = lcfirst($matches[1]) . 'Form';
 
 		return (bool)preg_match('#\$' . preg_quote($varName, '#') . '->execute\(#', $content);
 	}
@@ -38,13 +38,12 @@ class FormClassAnnotatorTask extends AbstractClassAnnotatorTask implements Class
 	 * @return bool
 	 */
 	public function annotate(string $path): bool {
-		preg_match('#\buse (\w+)\\\\Form\\\\(.+)Form\b#', $this->content, $matches);
-		if (empty($matches[1]) || empty($matches[2])) {
+		$appNamespace = Configure::read('App.namespace') ?: 'App';
+		if (!preg_match('#\buse ' . preg_quote($appNamespace, '#') . '\\\\Form\\\\(.+)Form\b#', $this->content, $matches)) {
 			return false;
 		}
 
-		$appNamespace = $matches[1];
-		$name = $matches[2] . 'Form';
+		$name = $matches[1] . 'Form';
 
 		$varName = lcfirst($name);
 		$rows = explode(PHP_EOL, $this->content);

--- a/src/Annotator/ClassAnnotatorTask/FormClassAnnotatorTask.php
+++ b/src/Annotator/ClassAnnotatorTask/FormClassAnnotatorTask.php
@@ -23,17 +23,14 @@ class FormClassAnnotatorTask extends AbstractClassAnnotatorTask implements Class
 			return false;
 		}
 
-		$appNamespace = Configure::read('App.namespace') ?: 'App';
+		Configure::read('App.namespace') ?: 'App';
 		if (!preg_match('#\buse (\w+)\\\\Form\\\\(.+)Form\b#', $content, $matches)) {
 			return false;
 		}
 
 		$varName = lcfirst($matches[2]) . 'Form';
-		if (!preg_match('#\$' . preg_quote($varName, '#') . '->execute\(#', $content)) {
-			return false;
-		}
 
-		return true;
+		return (bool)preg_match('#\$' . preg_quote($varName, '#') . '->execute\(#', $content);
 	}
 
 	/**

--- a/src/Annotator/ClassAnnotatorTask/FormClassAnnotatorTask.php
+++ b/src/Annotator/ClassAnnotatorTask/FormClassAnnotatorTask.php
@@ -24,7 +24,7 @@ class FormClassAnnotatorTask extends AbstractClassAnnotatorTask implements Class
 		}
 
 		$appNamespace = Configure::read('App.namespace') ?: 'App';
-		if (!preg_match('#\buse ' . preg_quote($appNamespace, '#') . '\\\\Form\\\\(.+)Form\b#', $content, $matches)) {
+		if (!preg_match('#\buse ' . preg_quote((string)$appNamespace, '#') . '\\\\Form\\\\(.+)Form\b#', $content, $matches)) {
 			return false;
 		}
 
@@ -39,7 +39,7 @@ class FormClassAnnotatorTask extends AbstractClassAnnotatorTask implements Class
 	 */
 	public function annotate(string $path): bool {
 		$appNamespace = Configure::read('App.namespace') ?: 'App';
-		if (!preg_match('#\buse ' . preg_quote($appNamespace, '#') . '\\\\Form\\\\(.+)Form\b#', $this->content, $matches)) {
+		if (!preg_match('#\buse ' . preg_quote((string)$appNamespace, '#') . '\\\\Form\\\\(.+)Form\b#', $this->content, $matches)) {
 			return false;
 		}
 

--- a/src/Annotator/ClassAnnotatorTask/MailerClassAnnotatorTask.php
+++ b/src/Annotator/ClassAnnotatorTask/MailerClassAnnotatorTask.php
@@ -43,18 +43,14 @@ class MailerClassAnnotatorTask extends AbstractClassAnnotatorTask implements Cla
 		} else {
 			$class = $callMatches[1];
 			[$plugin, $name] = pluginSplit($class);
-			$varName = lcfirst($name) . 'Mailer';
+			$varName = lcfirst((string)$name) . 'Mailer';
 		}
 
 		if ($singleLine && !empty($callMatches)) {
 			return true;
 		}
 
-		if (!preg_match('#\$' . preg_quote($varName, '#') . '->send\(\'\w+\'#', $content)) {
-			return false;
-		}
-
-		return true;
+		return (bool)preg_match('#\$' . preg_quote($varName, '#') . '->send\(\'\w+\'#', $content);
 	}
 
 	/**
@@ -85,7 +81,7 @@ class MailerClassAnnotatorTask extends AbstractClassAnnotatorTask implements Cla
 		} else {
 			[$plugin, $name] = pluginSplit($callMatches[1]);
 			$appNamespace = $plugin ?: (Configure::read('App.namespace') ?: 'App');
-			$name = $name . 'Mailer';
+			$name .= 'Mailer';
 		}
 
 		$action = null;

--- a/src/Annotator/ClassAnnotatorTask/ModelAwareClassAnnotatorTask.php
+++ b/src/Annotator/ClassAnnotatorTask/ModelAwareClassAnnotatorTask.php
@@ -33,7 +33,7 @@ class ModelAwareClassAnnotatorTask extends AbstractClassAnnotatorTask implements
 
 		try {
 			return (new ReflectionClass($className))->hasMethod('fetchModel');
-		} catch (Throwable $exception) {
+		} catch (Throwable) {
 			return false;
 		}
 	}

--- a/src/Annotator/ClassAnnotatorTask/TableFindAnnotatorTask.php
+++ b/src/Annotator/ClassAnnotatorTask/TableFindAnnotatorTask.php
@@ -30,11 +30,7 @@ class TableFindAnnotatorTask extends AbstractClassAnnotatorTask implements Class
 			return false;
 		}
 
-		if (!preg_match('#->(first|firstOrFail)\(\)#', $content)) {
-			return false;
-		}
-
-		return true;
+		return (bool)preg_match('#->(first|firstOrFail)\(\)#', $content);
 	}
 
 	/**
@@ -71,7 +67,7 @@ class TableFindAnnotatorTask extends AbstractClassAnnotatorTask implements Class
 		$parser = (new ParserFactory())->createForHostVersion();
 		try {
 			$ast = $parser->parse($this->content);
-		} catch (Throwable $e) {
+		} catch (Throwable) {
 			return [];
 		}
 

--- a/src/Annotator/ClassAnnotatorTask/TableFindNodeVisitor.php
+++ b/src/Annotator/ClassAnnotatorTask/TableFindNodeVisitor.php
@@ -12,7 +12,7 @@ use PhpParser\NodeVisitorAbstract;
  */
 class TableFindNodeVisitor extends NodeVisitorAbstract {
 
-	private string $appNamespace;
+	private readonly string $appNamespace;
 
 	/**
 	 * @var array<array{line: int, varName: string, tableName: string, entityClass: string, nullable: bool}>

--- a/src/Annotator/ClassAnnotatorTask/TestClassAnnotatorTask.php
+++ b/src/Annotator/ClassAnnotatorTask/TestClassAnnotatorTask.php
@@ -46,11 +46,8 @@ class TestClassAnnotatorTask extends AbstractClassAnnotatorTask implements PathA
 		if (!preg_match('#^namespace .+\\\\Test\\\\TestCase\\\\(' . $typeList . ')\b#m', $content)) {
 			return false;
 		}
-		if (!$this->matchesType($content, $types)) {
-			return false;
-		}
 
-		return true;
+		return $this->matchesType($content, $types);
 	}
 
 	/**
@@ -59,7 +56,7 @@ class TestClassAnnotatorTask extends AbstractClassAnnotatorTask implements PathA
 	 * @return bool
 	 */
 	protected function matchesType(string $content, array $types): bool {
-		foreach ($types as $type => $pattern) {
+		foreach ($types as $pattern) {
 			if (preg_match($pattern, $content)) {
 				return true;
 			}

--- a/src/Annotator/CommandAnnotator.php
+++ b/src/Annotator/CommandAnnotator.php
@@ -45,9 +45,7 @@ class CommandAnnotator extends AbstractAnnotator {
 			return null;
 		}
 
-		$modelName = $matches[1];
-
-		return $modelName;
+		return $matches[1];
 	}
 
 }

--- a/src/Annotator/ControllerAnnotator.php
+++ b/src/Annotator/ControllerAnnotator.php
@@ -188,9 +188,8 @@ class ControllerAnnotator extends AbstractAnnotator {
 		}
 
 		$appControllerComponents = $this->getUsedComponents('AppController', $path);
-		$components = array_diff_key($components, $appControllerComponents);
 
-		return $components;
+		return array_diff_key($components, $appControllerComponents);
 	}
 
 	/**
@@ -212,9 +211,7 @@ class ControllerAnnotator extends AbstractAnnotator {
 			$settingsType = 'array<string, mixed>';
 		}
 
-		$annotations = [AnnotationFactory::createOrFail(MethodAnnotation::TAG, $resultSetInterfaceCollection, 'paginate(\Cake\Datasource\RepositoryInterface|\Cake\Datasource\QueryInterface|string|null $object = null, ' . $settingsType . ' $settings = [])')];
-
-		return $annotations;
+		return [AnnotationFactory::createOrFail(MethodAnnotation::TAG, $resultSetInterfaceCollection, 'paginate(\Cake\Datasource\RepositoryInterface|\Cake\Datasource\QueryInterface|string|null $object = null, ' . $settingsType . ' $settings = [])')];
 	}
 
 	/**
@@ -268,7 +265,7 @@ class ControllerAnnotator extends AbstractAnnotator {
 		try {
 			$table = TableRegistry::getTableLocator()->get($modelName);
 			$entityClassName = $table->getEntityClass();
-		} catch (Throwable $exception) {
+		} catch (Throwable) {
 			$plugin = null;
 			if (str_contains($modelName, '.')) {
 				[$plugin, $modelName] = explode('.', $modelName, 2);

--- a/src/Annotator/EntityAnnotator.php
+++ b/src/Annotator/EntityAnnotator.php
@@ -129,7 +129,7 @@ class EntityAnnotator extends AbstractAnnotator {
 					if ($plugin !== null) {
 						$namespace = $plugin;
 					}
-					$namespace = str_replace('/', '\\', trim($namespace, '\\'));
+					$namespace = str_replace('/', '\\', trim((string)$namespace, '\\'));
 
 					$entityClass = $this->entityName($association->getTarget()->getAlias());
 					$entityClass = '\\' . $namespace . '\Model\Entity\\' . $entityClass;
@@ -158,7 +158,7 @@ class EntityAnnotator extends AbstractAnnotator {
 
 				try {
 					$className = $table->getEntityClass();
-				} catch (Throwable $e) {
+				} catch (Throwable) {
 					$className = Entity::class;
 				}
 
@@ -295,11 +295,7 @@ class EntityAnnotator extends AbstractAnnotator {
 			static::$typeMap = (array)Configure::read('IdeHelper.typeMap') + static::$typeMapDefaults;
 		}
 
-		if (isset(static::$typeMap[$type])) {
-			return static::$typeMap[$type];
-		}
-
-		return null;
+		return static::$typeMap[$type] ?? null;
 	}
 
 	/**
@@ -345,7 +341,7 @@ class EntityAnnotator extends AbstractAnnotator {
 
 			$startIndex = $methodNameIndex + 1;
 
-			if (!preg_match('#^_get([A-Z][a-zA-Z0-9]+)$#', $methodName, $matches)) {
+			if (!preg_match('#^_get([A-Z][a-zA-Z0-9]+)$#', (string)$methodName, $matches)) {
 				continue;
 			}
 
@@ -487,7 +483,7 @@ class EntityAnnotator extends AbstractAnnotator {
 
 				continue;
 			}
-			if ($bracketDepth === 0 && ($char === ' ' || $char === "\t" || $char === '*' || $char === "\n" || $char === "\r")) {
+			if ($bracketDepth === 0 && (in_array($char, [' ', "\t", '*', "\n", "\r"], true))) {
 				$end = $i;
 
 				break;
@@ -518,7 +514,7 @@ class EntityAnnotator extends AbstractAnnotator {
 			return $name;
 		}
 
-		return strpos($name, '\\') === 0 ? $name : '\\' . $name;
+		return str_starts_with($name, '\\') ? $name : '\\' . $name;
 	}
 
 	/**
@@ -602,7 +598,7 @@ class EntityAnnotator extends AbstractAnnotator {
 			// Spaces inside <> brackets should not be treated as type boundaries
 			$bracketDepth = 0;
 			$typeEnd = null;
-			$length = strlen($content);
+			$length = strlen((string)$content);
 			for ($j = 0; $j < $length; $j++) {
 				$char = $content[$j];
 				if ($char === '<') {
@@ -617,7 +613,7 @@ class EntityAnnotator extends AbstractAnnotator {
 			}
 
 			if ($typeEnd !== null) {
-				$content = substr($content, 0, $typeEnd);
+				$content = substr((string)$content, 0, $typeEnd);
 			}
 
 			return $content;
@@ -675,7 +671,7 @@ class EntityAnnotator extends AbstractAnnotator {
 		try {
 			/** @var \Cake\Datasource\EntityInterface $entity */
 			$entity = new $className();
-		} catch (Throwable $exception) {
+		} catch (Throwable) {
 			return [];
 		}
 

--- a/src/Annotator/ModelAnnotator.php
+++ b/src/Annotator/ModelAnnotator.php
@@ -282,9 +282,6 @@ class ModelAnnotator extends AbstractAnnotator {
 			if (!$entityTemplateEmitted || $detailed) {
 				$annotations[] = "@method {$fullClassName} newEntity({$dataType} \$data, {$optionsType} \$options = [])";
 				$annotations[] = "@method {$fullClassNameCollection} newEntities({$dataListType} \$data, {$optionsType} \$options = [])";
-			}
-
-			if (!$entityTemplateEmitted || $detailed) {
 				$annotations[] = "@method {$fullClassName} get(mixed \$primaryKey, {$finderType} \$finder = 'all', \Psr\SimpleCache\CacheInterface|string|null \$cache = null, \Closure|string|null \$cacheKey = null, mixed ...\$args)";
 			}
 			if (Configure::read('IdeHelper.tableEntityQuery') && !$entityTemplateFindFamily) {
@@ -333,9 +330,8 @@ class ModelAnnotator extends AbstractAnnotator {
 		}
 
 		$result = $this->addBehaviorMixins($result, $behaviors);
-		$result = $this->addBehaviorExtends($result, $behaviors, $parentClass, $entityClass);
 
-		return $result;
+		return $this->addBehaviorExtends($result, $behaviors, $parentClass, $entityClass);
 	}
 
 	/**

--- a/src/Annotator/ModelAnnotator.php
+++ b/src/Annotator/ModelAnnotator.php
@@ -293,8 +293,6 @@ class ModelAnnotator extends AbstractAnnotator {
 
 			if (!$entityTemplateEmitted || $detailed || $concrete) {
 				$annotations[] = "@method {$fullClassName} patchEntity({$entityInterface} \$entity, {$dataType} \$data, {$optionsType} \$options = [])";
-			}
-			if (!$entityTemplateEmitted || $detailed || $concrete) {
 				$annotations[] = "@method {$fullClassNameCollection} patchEntities({$iterable} \$entities, {$dataListType} \$data, {$optionsType} \$options = [])";
 			}
 

--- a/src/Annotator/Template/VariableExtractor.php
+++ b/src/Annotator/Template/VariableExtractor.php
@@ -79,7 +79,7 @@ class VariableExtractor {
 		}
 
 		foreach ($tokens as $i => $token) {
-			if ($token['code'] !== T_STRING || strtolower($token['content']) !== 'compact') {
+			if ($token['code'] !== T_STRING || strtolower((string)$token['content']) !== 'compact') {
 				continue;
 			}
 
@@ -105,7 +105,7 @@ class VariableExtractor {
 	 * @return array<string, mixed>
 	 */
 	protected function getVar(File $file, array $token, int $index): array {
-		$variable = substr($token['content'], 1);
+		$variable = substr((string)$token['content'], 1);
 
 		$result = [
 			'name' => $variable,
@@ -142,10 +142,8 @@ class VariableExtractor {
 		}
 
 		$prevIndex = $file->findPrevious(Tokens::$emptyTokens, $result['index'] - 1, $result['index'] - 3, true, null, true);
-		if ($prevIndex && in_array($tokens[$prevIndex]['code'], [T_ECHO, T_OPEN_TAG_WITH_ECHO, T_STRING_CONCAT], true)) {
-			if ($nextIndex && in_array($tokens[$nextIndex]['code'], [T_SEMICOLON, T_STRING_CONCAT, T_CLOSE_TAG], true)) {
-				return 'string';
-			}
+		if ($prevIndex && in_array($tokens[$prevIndex]['code'], [T_ECHO, T_OPEN_TAG_WITH_ECHO, T_STRING_CONCAT], true) && ($nextIndex && in_array($tokens[$nextIndex]['code'], [T_SEMICOLON, T_STRING_CONCAT, T_CLOSE_TAG], true))) {
+			return 'string';
 		}
 
 		return null;
@@ -187,11 +185,7 @@ class VariableExtractor {
 			return true;
 		}
 
-		if ($prevIndex && $tokens[$prevIndex]['code'] === T_DOUBLE_ARROW && $this->isInLoop($file, $result, $prevIndex)) {
-			return true;
-		}
-
-		return false;
+		return $prevIndex && $tokens[$prevIndex]['code'] === T_DOUBLE_ARROW && $this->isInLoop($file, $result, $prevIndex);
 	}
 
 	/**
@@ -322,7 +316,7 @@ class VariableExtractor {
 	 * @return array<array<string, mixed>>
 	 */
 	protected function getVarsFromString(File $file, array $token, int $i): array {
-		preg_match_all('/\$(\{)?([a-zA-Z_][a-zA-Z0-9_]*)\}?/', $token['content'], $matches);
+		preg_match_all('/\$(\{)?([a-zA-Z_]\w*)\}?/', (string)$token['content'], $matches);
 		if (empty($matches[2])) {
 			return [];
 		}
@@ -389,7 +383,7 @@ class VariableExtractor {
 			}
 
 			// Strip quotes from the string
-			$variable = trim($tokens[$i]['content'], '\'"');
+			$variable = trim((string)$tokens[$i]['content'], '\'"');
 			if ($variable === '' || $variable === 'this') {
 				continue;
 			}

--- a/src/Annotator/TemplateAnnotator.php
+++ b/src/Annotator/TemplateAnnotator.php
@@ -180,7 +180,7 @@ class TemplateAnnotator extends AbstractAnnotator {
 			// PHPCS v3 does not have this requirement
 			$fixer->addContent($phpOpenTagIndex, PHP_EOL . $annotationString);
 		} else {
-				$fixer->addContent($phpOpenTagIndex, $docBlock);
+			$fixer->addContent($phpOpenTagIndex, $docBlock);
 		}
 
 		$this->_counter[static::COUNT_ADDED] = count($annotations);

--- a/src/Annotator/TemplateAnnotator.php
+++ b/src/Annotator/TemplateAnnotator.php
@@ -60,11 +60,7 @@ class TemplateAnnotator extends AbstractAnnotator {
 		$phpOpenTagIndexAdjusted = $this->checkForDeclareStatement($file, $phpOpenTagIndex);
 
 		$docBlockCloseTagIndex = null;
-		if ($needsPhpTag) {
-			$phpOpenTagIndexForSearch = null;
-		} else {
-			$phpOpenTagIndexForSearch = $phpOpenTagIndexAdjusted;
-		}
+		$phpOpenTagIndexForSearch = $needsPhpTag ? null : $phpOpenTagIndexAdjusted;
 		if ($phpOpenTagIndexForSearch !== null) {
 			$docBlockCloseTagIndex = $this->findExistingDocBlock($file, $phpOpenTagIndexForSearch);
 		}
@@ -179,14 +175,12 @@ class TemplateAnnotator extends AbstractAnnotator {
 		$fixer = $this->getFixer($file);
 		if ($phpOpenTagIndex === null) {
 			$fixer->addContentBefore(0, $docBlock);
-		} else {
+		} elseif ($this->isV4()) {
 			// PHPCS v4 requires a blank line after <?php tag for PSR12 compliance
 			// PHPCS v3 does not have this requirement
-			if ($this->isV4()) {
-				$fixer->addContent($phpOpenTagIndex, PHP_EOL . $annotationString);
-			} else {
+			$fixer->addContent($phpOpenTagIndex, PHP_EOL . $annotationString);
+		} else {
 				$fixer->addContent($phpOpenTagIndex, $docBlock);
-			}
 		}
 
 		$this->_counter[static::COUNT_ADDED] = count($annotations);
@@ -247,11 +241,7 @@ class TemplateAnnotator extends AbstractAnnotator {
 			return true;
 		}
 
-		if (preg_match('/<\?/', $content)) {
-			return true;
-		}
-
-		return false;
+		return (bool)preg_match('/<\?/', $content);
 	}
 
 	/**
@@ -320,7 +310,7 @@ class TemplateAnnotator extends AbstractAnnotator {
 			if ($tokens[$i]['type'] !== T_INLINE_HTML) {
 				return false;
 			}
-			if (trim($tokens[$i]['content']) !== '') {
+			if (trim((string)$tokens[$i]['content']) !== '') {
 				return false;
 			}
 		}
@@ -341,7 +331,7 @@ class TemplateAnnotator extends AbstractAnnotator {
 
 		$entityAnnotations = $loopEntityAnnotations + $formEntityAnnotations + $entityAnnotations;
 
-		foreach ($entityAnnotations as $name => $entityAnnotation) {
+		foreach (array_keys($entityAnnotations) as $name) {
 			if (!empty($variables[$name]) && $variables[$name]['excludeReason']) {
 				unset($entityAnnotations[$name]);
 			}

--- a/src/Annotator/Traits/DocBlockTrait.php
+++ b/src/Annotator/Traits/DocBlockTrait.php
@@ -144,16 +144,12 @@ trait DocBlockTrait {
 				continue;
 			}
 			$content = $tokens[$i]['content'];
-			$pos = stripos($content, $alias);
+			$pos = stripos((string)$content, $alias);
 			if ($pos === false) {
 				continue;
 			}
 
-			if ($pos && str_starts_with($alias, '@') && substr($content, $pos - 1, $pos) === '{') {
-				return false;
-			}
-
-			return true;
+			return !($pos && str_starts_with($alias, '@') && substr((string)$content, $pos - 1, $pos) === '{');
 		}
 
 		return false;

--- a/src/Annotator/Traits/UseStatementsTrait.php
+++ b/src/Annotator/Traits/UseStatementsTrait.php
@@ -86,11 +86,7 @@ trait UseStatementsTrait {
 	 * @return bool
 	 */
 	protected function isMultipleUseStatement(string $statementContent): bool {
-		if (str_contains($statementContent, ',')) {
-			return true;
-		}
-
-		return false;
+		return str_contains($statementContent, ',');
 	}
 
 }

--- a/src/Annotator/ViewAnnotator.php
+++ b/src/Annotator/ViewAnnotator.php
@@ -45,9 +45,8 @@ class ViewAnnotator extends AbstractAnnotator {
 		$helperArray = $this->parseViewClass();
 
 		$helperArray = $this->addAppHelpers($helperArray);
-		$helperArray = $this->addExtractedHelpers($helperArray);
 
-		return $helperArray;
+		return $this->addExtractedHelpers($helperArray);
 	}
 
 	/**
@@ -112,9 +111,7 @@ class ViewAnnotator extends AbstractAnnotator {
 			return [];
 		}
 
-		$helpers = array_unique($matches[1]);
-
-		return $helpers;
+		return array_unique($matches[1]);
 	}
 
 	/**

--- a/src/CodeCompletion/CodeCompletionGenerator.php
+++ b/src/CodeCompletion/CodeCompletionGenerator.php
@@ -38,10 +38,8 @@ CODE;
 			$path = $this->path();
 			$filename = $path . 'CodeCompletion' . $this->type($namespace) . '.php';
 
-			if (!file_exists($filename) || md5_file($filename) !== md5($template)) {
-				if (file_put_contents($filename, $template) === false) {
-					throw new RuntimeException(sprintf('Failed to write file `%s`.', $filename));
-				}
+			if ((!file_exists($filename) || md5_file($filename) !== md5($template)) && file_put_contents($filename, $template) === false) {
+				throw new RuntimeException(sprintf('Failed to write file `%s`.', $filename));
 			}
 		}
 

--- a/src/CodeCompletion/Task/BehaviorTask.php
+++ b/src/CodeCompletion/Task/BehaviorTask.php
@@ -32,7 +32,7 @@ class BehaviorTask implements TaskInterface {
 
 		$content = $this->build($behaviors);
 
-		$content = <<<CODE
+		return <<<CODE
 abstract class BehaviorRegistry extends \Cake\Core\ObjectRegistry {
 
 $content
@@ -40,8 +40,6 @@ $content
 }
 
 CODE;
-
-		return $content;
 	}
 
 	/**

--- a/src/CodeCompletion/Task/ControllerEventsTask.php
+++ b/src/CodeCompletion/Task/ControllerEventsTask.php
@@ -56,7 +56,7 @@ CODE;
 		$type = null;
 		$docBlock = null;
 		if ($returnType) {
-			$type = ': ' . 'void';
+			$type = ': void';
 		} else {
 			$docBlock = <<<TXT
 		/**
@@ -78,7 +78,7 @@ TXT;
 TXT;
 		$docBlockRedirect = trim($docBlockRedirect) . PHP_EOL . str_repeat("\t", 2);
 
-		$events = <<<TXT
+		return <<<TXT
 		{$docBlock}public function startup(EventInterface \$event)$type {
 		}
 
@@ -97,8 +97,6 @@ TXT;
 		{$docBlockRedirect}public function beforeRedirect(EventInterface \$event, UriInterface|array|string \$url, Response \$response)$type {
 		}
 TXT;
-
-		return $events;
 	}
 
 }

--- a/src/Command/Annotate/TemplatesCommand.php
+++ b/src/Command/Annotate/TemplatesCommand.php
@@ -58,7 +58,7 @@ class TemplatesCommand extends AnnotateCommand {
 			if (is_dir($path)) {
 				foreach ($this->_config['skipTemplatePaths'] as $skip) {
 					$subFolder = pathinfo($path, PATHINFO_BASENAME);
-					if (!str_contains($subFolder, $skip)) {
+					if (!str_contains($subFolder, (string)$skip)) {
 						continue;
 					}
 

--- a/src/Command/AnnotateCommand.php
+++ b/src/Command/AnnotateCommand.php
@@ -207,7 +207,7 @@ abstract class AnnotateCommand extends Command {
 	 * @return bool
 	 */
 	protected function _annotatorMadeChanges(): bool {
-		return AbstractAnnotator::$output !== false || AbstractAnnotator::$stale;
+		return AbstractAnnotator::$output || AbstractAnnotator::$stale;
 	}
 
 }

--- a/src/Command/Command.php
+++ b/src/Command/Command.php
@@ -61,12 +61,10 @@ abstract class Command extends CoreCommand {
 		foreach ($plugins as $plugin) {
 			if (!$type) {
 				$pluginPaths = [Plugin::path($plugin)];
+			} elseif ($type === 'classes') {
+				$pluginPaths = [PluginPath::classPath($plugin)];
 			} else {
-				if ($type === 'classes') {
-					$pluginPaths = [PluginPath::classPath($plugin)];
-				} else {
 					$pluginPaths = $type === 'templates' ? App::path('templates', $plugin) : AppPath::get($type, $plugin);
-				}
 			}
 
 			$paths[$plugin] = $pluginPaths;

--- a/src/Filesystem/Folder.php
+++ b/src/Filesystem/Folder.php
@@ -19,6 +19,7 @@ namespace IdeHelper\Filesystem;
 
 use DirectoryIterator;
 use Exception;
+use FilesystemIterator;
 use InvalidArgumentException;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
@@ -124,7 +125,7 @@ class Folder {
 			$this->mode = $mode;
 		}
 
-		if (!file_exists($path) && $create === true) {
+		if (!file_exists($path) && $create) {
 			$this->create($path, $this->mode);
 		}
 		if (!static::isAbsolute($path)) {
@@ -182,7 +183,7 @@ class Folder {
 
 		try {
 			$iterator = new DirectoryIterator((string)$this->path);
-		} catch (Exception $e) {
+		} catch (Exception) {
 			return [$dirs, $files];
 		}
 
@@ -431,7 +432,7 @@ class Folder {
 
 			foreach ($paths as $type) {
 				foreach ($type as $fullpath) {
-					$check = explode(DIRECTORY_SEPARATOR, $fullpath);
+					$check = explode(DIRECTORY_SEPARATOR, (string)$fullpath);
 					$count = count($check);
 
 					if (in_array($check[$count - 1], $exceptions, true)) {
@@ -471,7 +472,7 @@ class Folder {
 
 		try {
 			$iterator = new DirectoryIterator($path);
-		} catch (Exception $e) {
+		} catch (Exception) {
 			return [];
 		}
 
@@ -517,10 +518,10 @@ class Folder {
 		try {
 			$directory = new RecursiveDirectoryIterator(
 				$path,
-				RecursiveDirectoryIterator::KEY_AS_PATHNAME | RecursiveDirectoryIterator::CURRENT_AS_SELF,
+				RecursiveDirectoryIterator::KEY_AS_PATHNAME | RecursiveDirectoryIterator::CURRENT_AS_SELF | FilesystemIterator::SKIP_DOTS,
 			);
 			$iterator = new RecursiveIteratorIterator($directory, RecursiveIteratorIterator::SELF_FIRST);
-		} catch (Exception $e) {
+		} catch (Exception) {
 			unset($directory, $iterator);
 
 			if ($type === null) {
@@ -607,20 +608,18 @@ class Folder {
 		$pathname = rtrim($pathname, DIRECTORY_SEPARATOR);
 		$nextPathname = substr($pathname, 0, (int)strrpos($pathname, DIRECTORY_SEPARATOR));
 
-		if ($this->create($nextPathname, $mode)) {
-			if (!file_exists($pathname)) {
-				$old = umask(0);
-				if (mkdir($pathname, $mode, true)) {
+		if ($this->create($nextPathname, $mode) && !file_exists($pathname)) {
+			$old = umask(0);
+			if (mkdir($pathname, $mode, true)) {
 					$this->_messages[] = sprintf('%s created', $pathname);
 					umask($old);
 
 					return true;
-				}
-				$this->_errors[] = sprintf('%s NOT created', $pathname);
-				umask($old);
-
-				return false;
 			}
+			$this->_errors[] = sprintf('%s NOT created', $pathname);
+			umask($old);
+
+			return false;
 		}
 
 		return false;
@@ -679,9 +678,9 @@ class Folder {
 		if (is_dir($path)) {
 			$directory = $iterator = null;
 			try {
-				$directory = new RecursiveDirectoryIterator($path, RecursiveDirectoryIterator::CURRENT_AS_SELF);
+				$directory = new RecursiveDirectoryIterator($path, RecursiveDirectoryIterator::CURRENT_AS_SELF | FilesystemIterator::SKIP_DOTS);
 				$iterator = new RecursiveIteratorIterator($directory, RecursiveIteratorIterator::CHILD_FIRST);
-			} catch (Exception $e) {
+			} catch (Exception) {
 				unset($directory, $iterator);
 
 				return false;

--- a/src/Generator/Directive/BaseDirective.php
+++ b/src/Generator/Directive/BaseDirective.php
@@ -34,11 +34,7 @@ abstract class BaseDirective {
 	protected function buildList(array $array, int $indentation = 2): string {
 		$result = [];
 		foreach ($array as $value) {
-			if ($value instanceof ValueObjectInterface) {
-				$element = (string)$value;
-			} else {
-				$element = $value;
-			}
+			$element = $value instanceof ValueObjectInterface ? (string)$value : $value;
 			$result[] = str_repeat("\t", $indentation) . $element;
 		}
 

--- a/src/Generator/Directive/ExitPoint.php
+++ b/src/Generator/Directive/ExitPoint.php
@@ -53,11 +53,9 @@ class ExitPoint extends BaseDirective {
 	public function build() {
 		$method = $this->method;
 
-		$result = <<<TXT
+		return <<<TXT
 	exitPoint($method);
 TXT;
-
-		return $result;
 	}
 
 }

--- a/src/Generator/Directive/ExpectedArguments.php
+++ b/src/Generator/Directive/ExpectedArguments.php
@@ -81,15 +81,14 @@ class ExpectedArguments extends BaseDirective {
 		$position = $this->position;
 
 		$list = $this->buildList($this->list);
-		$result = <<<TXT
+
+		return <<<TXT
 	expectedArguments(
 		$method,
 		$position,
 $list
 	);
 TXT;
-
-		return $result;
 	}
 
 }

--- a/src/Generator/Directive/ExpectedReturnValues.php
+++ b/src/Generator/Directive/ExpectedReturnValues.php
@@ -71,14 +71,12 @@ class ExpectedReturnValues extends BaseDirective {
 		$method = $this->method;
 		$list = $this->buildList($this->list);
 
-		$result = <<<TXT
+		return <<<TXT
 	expectedReturnValues(
 		$method,
 $list
 	);
 TXT;
-
-		return $result;
 	}
 
 }

--- a/src/Generator/Directive/Override.php
+++ b/src/Generator/Directive/Override.php
@@ -66,7 +66,7 @@ class Override extends BaseDirective {
 		$method = $this->method;
 		$mapDefinitions = $this->buildKeyValueMap($this->map);
 
-		$result = <<<TXT
+		return <<<TXT
 	override(
 		$method,
 		map([
@@ -74,8 +74,6 @@ $mapDefinitions
 		]),
 	);
 TXT;
-
-		return $result;
 	}
 
 }

--- a/src/Generator/Directive/RegisterArgumentsSet.php
+++ b/src/Generator/Directive/RegisterArgumentsSet.php
@@ -2,6 +2,8 @@
 
 namespace IdeHelper\Generator\Directive;
 
+use Stringable;
+
 /**
  * Helps to register an argument set to be used in other directives for DRY code.
  *
@@ -17,7 +19,7 @@ namespace IdeHelper\Generator\Directive;
  *
  * @see https://www.jetbrains.com/help/phpstorm/ide-advanced-metadata.html#arguments-set
  */
-class RegisterArgumentsSet extends BaseDirective {
+class RegisterArgumentsSet extends BaseDirective implements Stringable {
 
 	/**
 	 * @var string
@@ -66,20 +68,18 @@ class RegisterArgumentsSet extends BaseDirective {
 		$set = "'" . $this->set . "'";
 		$list = $this->buildList($this->list);
 
-		$result = <<<TXT
+		return <<<TXT
 	registerArgumentsSet(
 		$set,
 $list
 	);
 TXT;
-
-		return $result;
 	}
 
 	/**
 	 * @return string
 	 */
-	public function __toString() {
+	public function __toString(): string {
 		return 'argumentsSet(\'' . $this->set . '\')';
 	}
 

--- a/src/Generator/PhpstormGenerator.php
+++ b/src/Generator/PhpstormGenerator.php
@@ -43,7 +43,7 @@ class PhpstormGenerator implements GeneratorInterface {
 		}
 		$overrides = implode(PHP_EOL . PHP_EOL, $overrides);
 
-		$template = <<<TXT
+		return <<<TXT
 <?php
 // @link https://confluence.jetbrains.com/display/PhpStorm/PhpStorm+Advanced+Metadata
 namespace PHPSTORM_META {
@@ -53,8 +53,6 @@ $overrides
 }
 
 TXT;
-
-		return $template;
 	}
 
 	/**

--- a/src/Generator/Task/BehaviorTask.php
+++ b/src/Generator/Task/BehaviorTask.php
@@ -52,7 +52,7 @@ class BehaviorTask implements TaskInterface {
 		$behaviors = $this->collectBehaviors();
 		foreach ($behaviors as $name => $className) {
 			$prefixedList[$name] = StringName::create($name);
-			if (str_contains($name, '.')) {
+			if (str_contains((string)$name, '.')) {
 				[, $name] = pluginSplit($name);
 			}
 			$nonPrefixedList[$name] = StringName::create($name);
@@ -77,7 +77,7 @@ class BehaviorTask implements TaskInterface {
 		foreach ($this->getAliases as $alias) {
 			$map = [];
 			foreach ($behaviors as $name => $className) {
-				if (str_contains($name, '.')) {
+				if (str_contains((string)$name, '.')) {
 					[, $name] = pluginSplit($name);
 				}
 				$map[$name] = ClassName::create($className);

--- a/src/Generator/Task/ComponentTask.php
+++ b/src/Generator/Task/ComponentTask.php
@@ -42,7 +42,7 @@ class ComponentTask implements TaskInterface {
 		$components = $this->collectComponents();
 		foreach ($components as $name => $className) {
 			$addMap[$name] = ClassName::create($className);
-			if (str_contains($name, '.')) {
+			if (str_contains((string)$name, '.')) {
 				[, $name] = pluginSplit($name);
 			}
 			$removeList[$name] = StringName::create($name);

--- a/src/Generator/Task/ConsoleHelperTask.php
+++ b/src/Generator/Task/ConsoleHelperTask.php
@@ -30,7 +30,7 @@ class ConsoleHelperTask implements TaskInterface {
 		$components = $this->collectHelpers();
 		foreach ($components as $name => $className) {
 			$addMap[$name] = ClassName::create($className);
-			if (str_contains($name, '.')) {
+			if (str_contains((string)$name, '.')) {
 				[, $name] = pluginSplit($name);
 			}
 		}

--- a/src/Generator/Task/DatabaseTableTask.php
+++ b/src/Generator/Task/DatabaseTableTask.php
@@ -72,7 +72,7 @@ class DatabaseTableTask implements TaskInterface {
 				/** @var array<string>|null $ignore */
 				$ignore = Configure::read('IdeHelper.ignoreDatabaseTables');
 				$tables = (new TableScanner($db, $ignore))->listUnskipped();
-			} catch (Throwable $exception) {
+			} catch (Throwable) {
 				$tables = [];
 			}
 			static::$tables = $tables;

--- a/src/Generator/Task/DatabaseTypeTask.php
+++ b/src/Generator/Task/DatabaseTypeTask.php
@@ -35,7 +35,7 @@ class DatabaseTypeTask implements TaskInterface {
 		$result[$directive->key()] = $directive;
 
 		$list = [];
-		foreach ($types as $type => $className) {
+		foreach (array_keys($types) as $type) {
 			$list[$type] = StringName::create($type);
 		}
 		ksort($list);
@@ -55,12 +55,12 @@ class DatabaseTypeTask implements TaskInterface {
 
 		try {
 			$allTypes = TypeFactory::buildAll();
-		} catch (Throwable $exception) {
+		} catch (Throwable) {
 			return $types;
 		}
 
 		foreach ($allTypes as $key => $type) {
-			if (str_starts_with($key, 'enum-')) {
+			if (str_starts_with((string)$key, 'enum-')) {
 				continue;
 			}
 

--- a/src/Generator/Task/EntityTask.php
+++ b/src/Generator/Task/EntityTask.php
@@ -67,7 +67,7 @@ class EntityTask extends ModelTask {
 				$tableObject = new $className();
 				$fields = $tableObject->getSchema()->columns();
 
-			} catch (Throwable $exception) {
+			} catch (Throwable) {
 				// Do nothing
 			}
 

--- a/src/Generator/Task/EntityTask.php
+++ b/src/Generator/Task/EntityTask.php
@@ -59,7 +59,7 @@ class EntityTask extends ModelTask {
 		$modelFields = [];
 
 		$models = $this->collectModels();
-		foreach ($models as $model => $className) {
+		foreach ($models as $className) {
 			$fields = [];
 			$tableObject = null;
 			try {
@@ -76,7 +76,7 @@ class EntityTask extends ModelTask {
 					$fieldsFromRelations = $this->addFromRelations($tableObject);
 					$fields = array_merge($fields, $fieldsFromRelations);
 					$fields = array_unique($fields);
-				} catch (Throwable $exception) {
+				} catch (Throwable) {
 					// Do nothing
 				}
 			}
@@ -89,7 +89,7 @@ class EntityTask extends ModelTask {
 				$virtualFields = $entityObject->getVirtual();
 				$fields = array_merge($fields, $virtualFields, $visibleFields);
 				$fields = array_unique($fields);
-			} catch (Throwable $exception) {
+			} catch (Throwable) {
 				// Do nothing
 			}
 

--- a/src/Generator/Task/EnvTask.php
+++ b/src/Generator/Task/EnvTask.php
@@ -10,7 +10,7 @@ class EnvTask implements TaskInterface {
 	/**
 	 * @var string
 	 */
-	protected const METHOD_ENV = '\\' . 'env()';
+	protected const METHOD_ENV = '\env()';
 
 	/**
 	 * Keys from Web based request, will be merged with CLI ones.
@@ -77,7 +77,7 @@ class EnvTask implements TaskInterface {
 		$list = [];
 
 		foreach ($keys as $key) {
-			if (str_starts_with($key, '_')) {
+			if (str_starts_with((string)$key, '_')) {
 				continue;
 			}
 

--- a/src/Generator/Task/FormHelperTask.php
+++ b/src/Generator/Task/FormHelperTask.php
@@ -38,7 +38,7 @@ class FormHelperTask extends ModelTask {
 		$models = $this->collectModels();
 
 		$allFields = [];
-		foreach ($models as $model => $className) {
+		foreach (array_keys($models) as $model) {
 			/** @phpstan-var class-string<object>|null $tableClass */
 			$tableClass = App::className($model, 'Model/Table', 'Table');
 			if (!$tableClass) {
@@ -54,7 +54,7 @@ class FormHelperTask extends ModelTask {
 				$modelObject = TableRegistry::getTableLocator()->get($model);
 				$fields = $modelObject->getSchema()->columns();
 
-			} catch (Throwable $exception) {
+			} catch (Throwable) {
 				continue;
 			}
 

--- a/src/Generator/Task/HelperTask.php
+++ b/src/Generator/Task/HelperTask.php
@@ -50,7 +50,7 @@ class HelperTask implements TaskInterface {
 		}
 
 		$list = [];
-		foreach ($helpers as $name => $className) {
+		foreach (array_keys($helpers) as $name) {
 			$list[$name] = "'$name'";
 		}
 		ksort($list);

--- a/src/Generator/Task/ModelTask.php
+++ b/src/Generator/Task/ModelTask.php
@@ -30,7 +30,7 @@ class ModelTask implements TaskInterface {
 	protected static ?array $models = null;
 
 	public function __construct() {
-		$this->clearBuffer();
+		static::clearBuffer();
 	}
 
 	/**

--- a/src/Generator/Task/TableAssociationTask.php
+++ b/src/Generator/Task/TableAssociationTask.php
@@ -33,7 +33,7 @@ class TableAssociationTask extends ModelTask {
 		$result = [];
 		foreach ($this->aliases as $alias => $className) {
 			$map = [];
-			foreach ($models as $model => $modelClassName) {
+			foreach (array_keys($models) as $model) {
 				$map[$model] = ClassName::create($className);
 			}
 

--- a/src/Generator/Task/TableFinderTask.php
+++ b/src/Generator/Task/TableFinderTask.php
@@ -126,7 +126,7 @@ class TableFinderTask extends ModelTask {
 						$customFinders = array_merge($customFinders, array_keys($behavior->implementedFinders()));
 					}
 				}
-			} catch (Throwable $exception) {
+			} catch (Throwable) {
 			}
 
 			$allFinders = array_merge($allFinders, $customFinders);
@@ -195,7 +195,7 @@ class TableFinderTask extends ModelTask {
 
 		try {
 			$methodReflection = new ReflectionMethod($className, $method);
-		} catch (ReflectionException $e) {
+		} catch (ReflectionException) {
 			return $result;
 		}
 

--- a/src/Generator/Task/TranslationKeyTask.php
+++ b/src/Generator/Task/TranslationKeyTask.php
@@ -127,7 +127,7 @@ class TranslationKeyTask implements TaskInterface {
 
 					$domainKeys = $this->translationParser->parse($file);
 
-					$domain = pathinfo($file, PATHINFO_FILENAME);
+					$domain = pathinfo((string)$file, PATHINFO_FILENAME);
 					if (!isset($keys[$domain])) {
 						$keys[$domain] = [];
 					}
@@ -155,7 +155,7 @@ class TranslationKeyTask implements TaskInterface {
 
 						$domainKeys = $this->translationParser->parse($file);
 
-						$domain = pathinfo($file, PATHINFO_FILENAME);
+						$domain = pathinfo((string)$file, PATHINFO_FILENAME);
 						if (!isset($keys[$domain])) {
 							$keys[$domain] = [];
 						}

--- a/src/Illuminator/Illuminator.php
+++ b/src/Illuminator/Illuminator.php
@@ -60,9 +60,8 @@ class Illuminator {
 	 */
 	protected function getFiles($path) {
 		$folder = new Folder($path);
-		$result = $folder->findRecursive('.*\.php', true);
 
-		return $result;
+		return $folder->findRecursive('.*\.php', true);
 	}
 
 }

--- a/src/Illuminator/Task/ControllerDefaultTableTask.php
+++ b/src/Illuminator/Task/ControllerDefaultTableTask.php
@@ -36,11 +36,7 @@ class ControllerDefaultTableTask extends AbstractTask {
 			return false;
 		}
 
-		if (!preg_match('#[\\\/]Controller[\\\/]#', $path)) {
-			return false;
-		}
-
-		return true;
+		return (bool)preg_match('#[\\\/]Controller[\\\/]#', $path);
 	}
 
 	/**
@@ -86,11 +82,7 @@ class ControllerDefaultTableTask extends AbstractTask {
 	protected function hasDefaultTableProperty(File $file, int $classIndex, string $content): bool {
 		// Fast regex check for performance (optional, can be enabled via config)
 		if ($this->getConfig('fastPropertyCheck')) {
-			if (preg_match('/\bprotected \?string \$defaultTable\b/', $content)) {
-				return true;
-			}
-
-			return false;
+			return (bool)preg_match('/\bprotected \?string \$defaultTable\b/', $content);
 		}
 
 		// Robust token-based check within class scope

--- a/src/Illuminator/Task/EntityFieldTask.php
+++ b/src/Illuminator/Task/EntityFieldTask.php
@@ -106,7 +106,7 @@ class EntityFieldTask extends AbstractTask {
 			$returnTypes = $this->valueNodeParts($valueNode);
 			$typeString = $this->renderUnionTypes($returnTypes);
 
-			$varAndComment = substr($tokens[$i + 2]['content'], strlen($typeString) + 1);
+			$varAndComment = substr((string)$tokens[$i + 2]['content'], strlen($typeString) + 1);
 			$varName = mb_substr($varAndComment, 1);
 			$pieces = explode(' ', $varName);
 			$field = $pieces[0];
@@ -225,13 +225,13 @@ class EntityFieldTask extends AbstractTask {
 
 			$constant = $tokens[$index]['content'];
 
-			$pos = strpos($constant, '_') ?: 0;
-			$prefix = substr($constant, 0, $pos) ?: '';
+			$pos = strpos((string)$constant, '_') ?: 0;
+			$prefix = substr((string)$constant, 0, $pos) ?: '';
 			if ($prefix . '_' !== static::PREFIX) {
 				continue;
 			}
 
-			$field = substr($constant, $pos + 1);
+			$field = substr((string)$constant, $pos + 1);
 			$field = strtolower($field);
 
 			$constants[$field] = [

--- a/src/Illuminator/Task/TableValidationLinkTask.php
+++ b/src/Illuminator/Task/TableValidationLinkTask.php
@@ -3,6 +3,7 @@
 namespace IdeHelper\Illuminator\Task;
 
 use PhpParser\Node;
+use PhpParser\Node\Expr;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitorAbstract;
 use PhpParser\ParserFactory;
@@ -52,7 +53,7 @@ class TableValidationLinkTask extends AbstractTask {
 
 		try {
 			$ast = $parser->parse($content);
-		} catch (Throwable $e) {
+		} catch (Throwable) {
 			return [];
 		}
 
@@ -112,7 +113,7 @@ class TableValidationLinkTask extends AbstractTask {
 				$ruleLine = null;
 
 				foreach ($options->items as $item) {
-					if (!$item instanceof Node\Expr\ArrayItem || $item->key === null) {
+					if (!$item instanceof Node\Expr\ArrayItem || !$item->key instanceof Expr) {
 						continue;
 					}
 

--- a/src/Illuminator/TaskCollection.php
+++ b/src/Illuminator/TaskCollection.php
@@ -131,7 +131,7 @@ class TaskCollection {
 		}
 
 		$keys = array_keys($tasks);
-		$keyMap = array_combine($keys, $keys);
+		$keyMap = array_combine($keys, $keys) ?: [];
 		foreach ($keyMap as $k => $v) {
 			preg_match('#\bTask\\\\([A-Za-z0-9]+)Task$#', (string)$v, $matches);
 			if (!$matches) {

--- a/src/Illuminator/TaskCollection.php
+++ b/src/Illuminator/TaskCollection.php
@@ -131,9 +131,9 @@ class TaskCollection {
 		}
 
 		$keys = array_keys($tasks);
-		$keyMap = array_combine($keys, $keys) ?: [];
+		$keyMap = array_combine($keys, $keys);
 		foreach ($keyMap as $k => $v) {
-			preg_match('#\bTask\\\\([A-Za-z0-9]+)Task$#', $v, $matches);
+			preg_match('#\bTask\\\\([A-Za-z0-9]+)Task$#', (string)$v, $matches);
 			if (!$matches) {
 				throw new RuntimeException('Invalid task name: ' . $v);
 			}
@@ -213,14 +213,14 @@ class TaskCollection {
 			$row = $array[$i];
 
 			$char = ' ';
-			$output = trim($row[0], "\n\r\0\x0B");
+			$output = trim((string)$row[0], "\n\r\0\x0B");
 
 			if ($row[1] === 1) {
 				$char = '+';
 				$this->_io->info('   | ' . $char . $output, 1, ConsoleIo::VERBOSE);
 			} elseif ($row[1] === 2) {
 				$char = '-';
-				$this->_io->out('<warning>' . '   | ' . $char . $output . '</warning>', 1, ConsoleIo::VERBOSE);
+				$this->_io->out('<warning>   | ' . $char . $output . '</warning>', 1, ConsoleIo::VERBOSE);
 			} else {
 				$this->_io->out('   | ' . $char . $output, 1, ConsoleIo::VERBOSE);
 			}

--- a/src/Utility/App.php
+++ b/src/Utility/App.php
@@ -43,7 +43,7 @@ class App extends CoreApp {
 
 			/** @var class-string */
 			return 'Cake' . $fullName;
-		} catch (Throwable $e) {
+		} catch (Throwable) {
 			// Do nothing
 		}
 

--- a/src/Utility/AppPath.php
+++ b/src/Utility/AppPath.php
@@ -16,7 +16,7 @@ class AppPath {
 	public static function get(string $type, ?string $plugin = null): array {
 		try {
 			return App::classPath($type, $plugin);
-		} catch (MissingPluginException $exception) {
+		} catch (MissingPluginException) {
 		}
 
 		return App::classPath($type, $plugin);

--- a/src/Utility/ControllerActionParser.php
+++ b/src/Utility/ControllerActionParser.php
@@ -27,7 +27,7 @@ class ControllerActionParser {
 			try {
 				$class = new ReflectionClass(AppController::class);
 				$methods = $class->getMethods(ReflectionMethod::IS_PUBLIC);
-			} catch (Throwable $exception) {
+			} catch (Throwable) {
 				return [];
 			}
 

--- a/src/Utility/GenericString.php
+++ b/src/Utility/GenericString.php
@@ -14,11 +14,7 @@ class GenericString {
 	 * @return string
 	 */
 	public static function generate(string $value, ?string $type = null): string {
-		if ($type !== null && str_starts_with($type, '\\')) {
-			$typeCheck = substr($type, 1);
-		} else {
-			$typeCheck = $type;
-		}
+		$typeCheck = $type !== null && str_starts_with($type, '\\') ? substr($type, 1) : $type;
 
 		$detailed = Configure::read('IdeHelper.genericsInParam') === 'detailed';
 		if ($detailed && $typeCheck === ResultSetInterface::class) {

--- a/src/Utility/Plugin.php
+++ b/src/Utility/Plugin.php
@@ -16,8 +16,8 @@ class Plugin extends CorePlugin {
 
 		$pluginMap = (array)Configure::read('IdeHelper.plugins');
 		foreach ($pluginMap as $plugin) {
-			if (str_starts_with($plugin, '-')) {
-				$plugin = substr($plugin, 1);
+			if (str_starts_with((string)$plugin, '-')) {
+				$plugin = substr((string)$plugin, 1);
 				unset($plugins[$plugin]);
 
 				continue;

--- a/src/Utility/PluginPath.php
+++ b/src/Utility/PluginPath.php
@@ -14,7 +14,7 @@ class PluginPath {
 	public static function get(string $plugin): string {
 		try {
 			return Plugin::path($plugin);
-		} catch (MissingPluginException $exception) {
+		} catch (MissingPluginException) {
 		}
 
 		return Plugin::path($plugin);
@@ -28,7 +28,7 @@ class PluginPath {
 	public static function classPath(string $plugin): string {
 		try {
 			return Plugin::classPath($plugin);
-		} catch (MissingPluginException $exception) {
+		} catch (MissingPluginException) {
 		}
 
 		return Plugin::classPath($plugin);

--- a/src/View/Helper/DocBlockHelper.php
+++ b/src/View/Helper/DocBlockHelper.php
@@ -64,9 +64,7 @@ class DocBlockHelper extends BakeDocBlockHelper {
 			return $type;
 		}
 
-		$type .= '|null';
-
-		return $type;
+		return $type . '|null';
 	}
 
 	/**
@@ -206,7 +204,7 @@ class DocBlockHelper extends BakeDocBlockHelper {
 			$annotations[] = "@method {$class}|array<{$class}> loadInto({$class}|array<{$class}> \$entities, array \$contain)";
 		}
 
-		foreach ($behaviors as $behavior => $behaviorData) {
+		foreach (array_keys($behaviors) as $behavior) {
 			$className = App::className($behavior, 'Model/Behavior', 'Behavior');
 			if (!$className) {
 				$className = "Cake\ORM\Behavior\\{$behavior}Behavior";

--- a/tests/TestCase/Annotator/AbstractAnnotatorTest.php
+++ b/tests/TestCase/Annotator/AbstractAnnotatorTest.php
@@ -48,7 +48,6 @@ class AbstractAnnotatorTest extends TestCase {
 		[$annotator, $out] = $this->annotatorWithOutput([]);
 
 		$counter = new ReflectionProperty($annotator, '_counter');
-		$counter->setAccessible(true);
 		$counter->setValue($annotator, [
 			AbstractAnnotator::COUNT_ADDED => 0,
 			AbstractAnnotator::COUNT_UPDATED => 0,
@@ -58,7 +57,6 @@ class AbstractAnnotatorTest extends TestCase {
 		]);
 
 		$report = new ReflectionMethod($annotator, 'report');
-		$report->setAccessible(true);
 		$report->invoke($annotator);
 
 		$this->assertStringContainsString('3 annotations outdated (run with -r to remove)', $out->output());
@@ -71,7 +69,6 @@ class AbstractAnnotatorTest extends TestCase {
 	 */
 	protected function isSuperseded(ModelAnnotator $annotator, string $content): bool {
 		$method = new ReflectionMethod($annotator, 'methodSupersededByParent');
-		$method->setAccessible(true);
 
 		return $method->invoke($annotator, $content);
 	}

--- a/tests/TestCase/Annotator/ClassAnnotatorTask/FormClassAnnotatorTaskTest.php
+++ b/tests/TestCase/Annotator/ClassAnnotatorTask/FormClassAnnotatorTaskTest.php
@@ -67,6 +67,19 @@ class FormClassAnnotatorTaskTest extends TestCase {
 	}
 
 	/**
+	 * A Form class from a different (non-app) namespace must not be detected.
+	 *
+	 * @return void
+	 */
+	public function testShouldRunIgnoresForeignNamespace() {
+		$task = $this->getTask('');
+
+		$content = 'namespace TestApp\\Foo' . PHP_EOL . 'use Vendor\\Form\\WidgetForm' . PHP_EOL . '$widgetForm->execute()';
+		$result = $task->shouldRun('/src/Foo.php', $content);
+		$this->assertFalse($result);
+	}
+
+	/**
 	 * @return void
 	 */
 	public function testAnnotate() {

--- a/tests/TestCase/Annotator/EntityAnnotatorTest.php
+++ b/tests/TestCase/Annotator/EntityAnnotatorTest.php
@@ -408,7 +408,7 @@ class EntityAnnotatorTest extends TestCase {
 		$path = PLUGINS . 'Relations/src/Model/Entity/User.php';
 		$annotator->annotate($path);
 
-		$output = $this->out->output();
+		$output = (string)$this->out->output();
 
 		$this->assertTextContains('   -> 4 annotations added', $output);
 	}
@@ -438,7 +438,7 @@ class EntityAnnotatorTest extends TestCase {
 		$path = PLUGINS . 'Relations/src/Model/Entity/Foo.php';
 		$annotator->annotate($path);
 
-		$output = $this->out->output();
+		$output = (string)$this->out->output();
 
 		$this->assertTextContains('   -> 5 annotations added', $output);
 	}
@@ -468,7 +468,7 @@ class EntityAnnotatorTest extends TestCase {
 		$path = PLUGINS . 'Relations/src/Model/Entity/Bar.php';
 		$annotator->annotate($path);
 
-		$output = $this->out->output();
+		$output = (string)$this->out->output();
 
 		$this->assertTextContains('   -> 4 annotations added', $output);
 	}

--- a/tests/TestCase/Annotator/EntityAnnotatorTest.php
+++ b/tests/TestCase/Annotator/EntityAnnotatorTest.php
@@ -408,7 +408,7 @@ class EntityAnnotatorTest extends TestCase {
 		$path = PLUGINS . 'Relations/src/Model/Entity/User.php';
 		$annotator->annotate($path);
 
-		$output = (string)$this->out->output();
+		$output = $this->out->output();
 
 		$this->assertTextContains('   -> 4 annotations added', $output);
 	}
@@ -438,7 +438,7 @@ class EntityAnnotatorTest extends TestCase {
 		$path = PLUGINS . 'Relations/src/Model/Entity/Foo.php';
 		$annotator->annotate($path);
 
-		$output = (string)$this->out->output();
+		$output = $this->out->output();
 
 		$this->assertTextContains('   -> 5 annotations added', $output);
 	}
@@ -468,7 +468,7 @@ class EntityAnnotatorTest extends TestCase {
 		$path = PLUGINS . 'Relations/src/Model/Entity/Bar.php';
 		$annotator->annotate($path);
 
-		$output = (string)$this->out->output();
+		$output = $this->out->output();
 
 		$this->assertTextContains('   -> 4 annotations added', $output);
 	}

--- a/tests/TestCase/Annotator/TemplateAnnotatorTest.php
+++ b/tests/TestCase/Annotator/TemplateAnnotatorTest.php
@@ -474,6 +474,20 @@ class TemplateAnnotatorTest extends TestCase {
 		Configure::write('IdeHelper.autoCollect', 'mixed');
 		$annotator = $this->_getAnnotatorMock([]);
 
+		$expectedVariables = [
+			'$this',
+			'$participantMoods',
+			'$yourMoodIds',
+			'$items',
+			'$filtered',
+			'$data',
+			'$numbers',
+			'$doubled',
+			'$multiplier',
+			'$values',
+			'$result',
+		];
+
 		// Variables that should NOT get annotations (anonymous function parameters)
 		$excludedVariables = ['$m', '$item', '$a', '$b', '$x', '$n'];
 		// Note: $id is excluded too, but it's a foreach loop variable, not an anonymous function parameter

--- a/tests/TestCase/Annotator/TemplateAnnotatorTest.php
+++ b/tests/TestCase/Annotator/TemplateAnnotatorTest.php
@@ -474,25 +474,11 @@ class TemplateAnnotatorTest extends TestCase {
 		Configure::write('IdeHelper.autoCollect', 'mixed');
 		$annotator = $this->_getAnnotatorMock([]);
 
-		$expectedVariables = [
-			'$this',
-			'$participantMoods',
-			'$yourMoodIds',
-			'$items',
-			'$filtered',
-			'$data',
-			'$numbers',
-			'$doubled',
-			'$multiplier',
-			'$values',
-			'$result',
-		];
-
 		// Variables that should NOT get annotations (anonymous function parameters)
 		$excludedVariables = ['$m', '$item', '$a', '$b', '$x', '$n'];
 		// Note: $id is excluded too, but it's a foreach loop variable, not an anonymous function parameter
 
-		$callback = function($value) use ($expectedVariables, $excludedVariables) {
+		$callback = function($value) use ($excludedVariables) {
 			// Extract just the PHPDoc block
 			if (preg_match('/\/\*\*(.*?)\*\//s', $value, $matches)) {
 				$docBlock = $matches[1];

--- a/tests/TestCase/Command/AnnotateCommandTest.php
+++ b/tests/TestCase/Command/AnnotateCommandTest.php
@@ -217,7 +217,6 @@ class AnnotateCommandTest extends TestCase {
 	public function testCiPredicateFailsOnStaleWithoutRemove(): void {
 		$command = new ModelsCommand();
 		$method = new ReflectionMethod($command, '_annotatorMadeChanges');
-		$method->setAccessible(true);
 
 		AbstractAnnotator::$output = false;
 		AbstractAnnotator::$stale = false;

--- a/tests/TestCase/Generator/Task/DatabaseTableColumnTypeTaskTest.php
+++ b/tests/TestCase/Generator/Task/DatabaseTableColumnTypeTaskTest.php
@@ -67,7 +67,7 @@ class DatabaseTableColumnTypeTaskTest extends TestCase {
 		$this->assertSame('\Migrations\Db\Table::addColumn()', $directive->toArray()['method']);
 
 		$list = array_map(function ($value) {
-			return (string)$value;
+			return $value;
 		}, $list);
 
 		$expectedList = [
@@ -99,7 +99,7 @@ class DatabaseTableColumnTypeTaskTest extends TestCase {
 	 */
 	public function testCollectPluginLoaded() {
 		$driver = ConnectionManager::get('test')->getDriver();
-		$this->skipIf(!($driver instanceof Mysql || $driver instanceof Postgres), 'Only for Postgres/Mysql');
+		$this->skipIf(!$driver instanceof Mysql && !$driver instanceof Postgres, 'Only for Postgres/Mysql');
 
 		$this->assertFalse(Plugin::isLoaded('Migrations'));
 

--- a/tests/TestCase/Generator/Task/DatabaseTableColumnTypeTaskTest.php
+++ b/tests/TestCase/Generator/Task/DatabaseTableColumnTypeTaskTest.php
@@ -67,7 +67,7 @@ class DatabaseTableColumnTypeTaskTest extends TestCase {
 		$this->assertSame('\Migrations\Db\Table::addColumn()', $directive->toArray()['method']);
 
 		$list = array_map(function ($value) {
-			return $value;
+			return (string)$value;
 		}, $list);
 
 		$expectedList = [

--- a/tests/schema.php
+++ b/tests/schema.php
@@ -18,7 +18,7 @@ foreach ($iterator as $file) {
 	$class = 'IdeHelper\\Test\\Fixture\\' . $name . 'Fixture';
 	try {
 		$object = (new ReflectionClass($class))->getProperty('fields');
-	} catch (ReflectionException $e) {
+	} catch (ReflectionException) {
 		continue;
 	}
 

--- a/tests/shim.php
+++ b/tests/shim.php
@@ -21,5 +21,5 @@ if (!defined('T_SEMICOLON')) {
 }
 
 if (!class_exists(TestCase::class)) {
-	require 'TestCase.php';
+	require __DIR__ . '/TestCase.php';
 }


### PR DESCRIPTION
Adds rector to the plugin with a conservative, behavior-neutral ruleset.

- `rector.php`: `deadCode` + `codeQuality` prepared sets on PHP 8.2.
- composer scripts `rector` (dry-run), `rector-fix`, `rector-setup` (backup-dance, matching the existing `stan-setup` pattern).
- Applies the resulting simplifications across `src/` and `tests/` (net -78 lines).

The skip list (documented inline in `rector.php`) excludes rules that:

- conflict with house style (`SafeDeclareStrictTypesRector`, `ExplicitBoolCompareRector`, `DisallowedEmptyRuleFixerRector`),
- are overly opinionated / large churn (constructor promotion, arrow functions, `CompleteDynamicPropertiesRector`, the docblock-stripping rules),
- would rewrite the hand-crafted annotator fixtures (`tests/test_files`, `tests/test_app`),
- are unsafe (`FunctionFirstClassCallableRector` rectorphp/rector#9767; `SimplifyEmptyCheckOnEmptyArrayRector` rectorphp/rector#9768; `StringClassNameToClassConstantRector`; `ClassOnObjectRector`).
