### PR TITLE
Emit extends annotation for helpers (PHPStan generics)

### DIFF
--- a/src/Annotator/HelperAnnotator.php
+++ b/src/Annotator/HelperAnnotator.php
@@ -4,9 +4,11 @@ namespace IdeHelper\Annotator;
 
 use Cake\View\View;
 use IdeHelper\Annotation\AnnotationFactory;
+use IdeHelper\Annotation\ExtendsAnnotation;
 use IdeHelper\Annotation\PropertyAnnotation;
 use IdeHelper\Annotator\Traits\HelperTrait;
 use IdeHelper\Utility\App;
+use ReflectionClass;
 use RuntimeException;
 use Throwable;
 
@@ -56,8 +58,58 @@ class HelperAnnotator extends AbstractAnnotator {
 		}
 
 		$annotations = $this->getHelperAnnotations($helperMap);
+		$annotations = $this->addHelperExtends($annotations, $className);
 
 		return $this->annotateContent($path, $content, $annotations);
+	}
+
+	/**
+	 * Emits `@extends \Cake\View\Helper<\Cake\View\View>` so PHPStan's
+	 * `missingType.generics` stays clean on `Cake\View\Helper` (generic via
+	 * `@template TView` since CakePHP 5.3). Gated by a runtime check on the
+	 * parent's doc-block rather than a version constant, so it self-disables on
+	 * older cores and never emits a bare/over-specified generic on a
+	 * non-generic parent (which would trigger `generics.notGeneric`).
+	 *
+	 * @param array<\IdeHelper\Annotation\AbstractAnnotation> $annotations
+	 * @param class-string<object> $className
+	 * @return array<\IdeHelper\Annotation\AbstractAnnotation>
+	 */
+	protected function addHelperExtends(array $annotations, string $className): array {
+		$parentClass = get_parent_class($className);
+		if ($parentClass === false || !$this->parentSupportsGenerics($parentClass)) {
+			return $annotations;
+		}
+
+		// Prepend so `@extends` sits at the top of the class doc-block, matching the
+		// tag order enforced by php-collective/code-sniffer DocBlockTagOrderSniff.
+		array_unshift(
+			$annotations,
+			AnnotationFactory::createOrFail(ExtendsAnnotation::TAG, '\\' . ltrim($parentClass, '\\') . '<\\' . View::class . '>'),
+		);
+
+		return $annotations;
+	}
+
+	/**
+	 * Whether the parent helper declares template parameters and can therefore
+	 * be parameterized via `@extends`.
+	 *
+	 * @param string $parentClass
+	 * @return bool
+	 */
+	protected function parentSupportsGenerics(string $parentClass): bool {
+		$fqcn = ltrim($parentClass, '\\');
+		if (!class_exists($fqcn)) {
+			return false;
+		}
+
+		$doc = (new ReflectionClass($fqcn))->getDocComment();
+		if ($doc === false) {
+			return false;
+		}
+
+		return preg_match('/^\s*\*\s*@template\s/m', $doc) === 1;
 	}
 
 	/**

--- a/tests/TestCase/Annotator/HelperAnnotatorTest.php
+++ b/tests/TestCase/Annotator/HelperAnnotatorTest.php
@@ -4,9 +4,11 @@ namespace IdeHelper\Test\TestCase\Annotator;
 
 use Cake\Console\ConsoleIo;
 use Cake\TestSuite\TestCase;
+use Cake\View\Helper;
 use IdeHelper\Annotator\AbstractAnnotator;
 use IdeHelper\Annotator\HelperAnnotator;
 use IdeHelper\Console\Io;
+use ReflectionClass;
 use Shim\TestSuite\ConsoleOutput;
 
 class HelperAnnotatorTest extends TestCase {
@@ -38,6 +40,11 @@ class HelperAnnotatorTest extends TestCase {
 		$annotator = $this->_getAnnotatorMock([]);
 
 		$expectedContent = str_replace("\r\n", "\n", file_get_contents(TEST_FILES . 'View/Helper/MyHelper.php'));
+		$expectedCount = 4;
+		if (!$this->helperBaseSupportsGenerics()) {
+			$expectedContent = str_replace(" * @extends \\Cake\\View\\Helper<\\Cake\\View\\View>\n *\n", '', $expectedContent);
+			$expectedCount = 3;
+		}
 		$callback = function($value) use ($expectedContent) {
 			$value = str_replace(["\r\n", "\r"], "\n", $value);
 			if ($value !== $expectedContent) {
@@ -53,7 +60,7 @@ class HelperAnnotatorTest extends TestCase {
 
 		$output = $this->out->output();
 
-		$this->assertTextContains('   -> 4 annotations added', $output);
+		$this->assertTextContains('   -> ' . $expectedCount . ' annotations added', $output);
 	}
 
 	/**
@@ -63,6 +70,11 @@ class HelperAnnotatorTest extends TestCase {
 		$annotator = $this->_getAnnotatorMock([]);
 
 		$expectedContent = str_replace("\r\n", "\n", file_get_contents(TEST_FILES . 'View/Helper/MyMethodHelper.php'));
+		$expectedCount = 3;
+		if (!$this->helperBaseSupportsGenerics()) {
+			$expectedContent = str_replace(" * @extends \\Cake\\View\\Helper<\\Cake\\View\\View>\n", '', $expectedContent);
+			$expectedCount = 2;
+		}
 		$callback = function($value) use ($expectedContent) {
 			$value = str_replace(["\r\n", "\r"], "\n", $value);
 			if ($value !== $expectedContent) {
@@ -78,7 +90,19 @@ class HelperAnnotatorTest extends TestCase {
 
 		$output = $this->out->output();
 
-		$this->assertTextContains('   -> 3 annotations added', $output);
+		$this->assertTextContains('   -> ' . $expectedCount . ' annotations added', $output);
+	}
+
+	/**
+	 * Whether the base helper declares a template parameter (CakePHP 5.3+) and
+	 * therefore receives an `@extends` annotation.
+	 *
+	 * @return bool
+	 */
+	protected function helperBaseSupportsGenerics(): bool {
+		$doc = (new ReflectionClass(Helper::class))->getDocComment();
+
+		return $doc !== false && preg_match('/^\s*\*\s*@template\s/m', $doc) === 1;
 	}
 
 	/**

--- a/tests/TestCase/Annotator/HelperAnnotatorTest.php
+++ b/tests/TestCase/Annotator/HelperAnnotatorTest.php
@@ -53,7 +53,7 @@ class HelperAnnotatorTest extends TestCase {
 
 		$output = $this->out->output();
 
-		$this->assertTextContains('   -> 3 annotations added', $output);
+		$this->assertTextContains('   -> 4 annotations added', $output);
 	}
 
 	/**
@@ -78,7 +78,7 @@ class HelperAnnotatorTest extends TestCase {
 
 		$output = $this->out->output();
 
-		$this->assertTextContains('   -> 2 annotations added', $output);
+		$this->assertTextContains('   -> 3 annotations added', $output);
 	}
 
 	/**

--- a/tests/test_files/View/Helper/MyHelper.php
+++ b/tests/test_files/View/Helper/MyHelper.php
@@ -4,6 +4,8 @@ namespace TestApp\View\Helper;
 use Cake\View\Helper;
 
 /**
+ * @extends \Cake\View\Helper<\Cake\View\View>
+ *
  * @property \TestApp\View\Helper\HtmlHelper $Html
  * @property \Cake\View\Helper\FormHelper $Form
  * @property \Shim\View\Helper\ConfigureHelper $Configure

--- a/tests/test_files/View/Helper/MyMethodHelper.php
+++ b/tests/test_files/View/Helper/MyMethodHelper.php
@@ -7,6 +7,7 @@ use Cake\View\Helper;
  * @property \Cake\View\Helper\FormHelper $Form
  * @method bool isAdmin()
  * @method bool isStaff()
+ * @extends \Cake\View\Helper<\Cake\View\View>
  * @property \TestApp\View\Helper\HtmlHelper $Html
  * @property \Shim\View\Helper\ConfigureHelper $Configure
  */


### PR DESCRIPTION
## Problem

App and plugin helpers extending the Cake view helper base trip PHPStan's missingType.generics:

> Class App\View\Helper\AppHelper extends generic class Cake\View\Helper but does not specify its types: TView

The base helper has been generic since CakePHP 5.3:

```php
/**
 * @template TView of \Cake\View\View
 */
class Helper { /* ... */ }
```

but HelperAnnotator never emitted an extends tag.

## Change

HelperAnnotator now prepends:

```php
/**
 * @extends \Cake\View\Helper<\Cake\View\View>
 */
```

Emission is gated by a runtime reflection check for a template declaration on the parent doc-block (mirroring `ModelAnnotator::parentSupportsGenerics()`), so it:

- self-disables on cores where the base helper is not generic,
- never emits an over-specified generic on a non-generic parent (which would raise generics.notGeneric).

Final tag ordering is left to the DocBlockTagOrderSniff, same as the existing extends handling in ModelAnnotator. HelperAnnotatorTest fixtures and annotation counts updated accordingly.
