### PR TITLE
Annotate pure virtual entity fields as read-only (property-read)

### DIFF
--- a/docs/annotations/models.md
+++ b/docs/annotations/models.md
@@ -133,10 +133,11 @@ A `Location` entity could look like this afterward:
  * @property string $details
  * @property \Cake\I18n\DateTime $created
  * @property \Cake\I18n\DateTime $modified
- * @property string|null $virtual_property
  *
  * @property \App\Model\Entity\Image[] $images
  * @property \App\Model\Entity\User $user
+ *
+ * @property-read string|null $virtual_property
  */
 class Location extends Entity {
 }
@@ -179,5 +180,8 @@ the documented type in the doc block's `@return`, otherwise (given PHP 7.0+)
 tries to read it from the return type hint (e.g. `: ?string`). Only if that is
 also not present does it fall back to `mixed`.
 
-Note: You can also use the `@property-read` tag if it is a pure virtual field
-getter.
+Pure virtual fields are annotated with the `@property-read` tag instead of
+`@property`: a field counts as read-only when it has a `_get...()` accessor but
+neither a real DB column / association behind it nor a matching `_set...()`
+mutator. If you do add a `_set...()` mutator (or the name also maps to a real
+column), the field stays writable and keeps the plain `@property` tag.

--- a/src/Annotation/AbstractAnnotation.php
+++ b/src/Annotation/AbstractAnnotation.php
@@ -65,6 +65,15 @@ abstract class AbstractAnnotation implements AnnotationInterface, ReplacableAnno
 	}
 
 	/**
+	 * @param int $index
+	 *
+	 * @return void
+	 */
+	public function setIndex(int $index): void {
+		$this->index = $index;
+	}
+
+	/**
 	 * @param bool $inUse
 	 *
 	 * @return void

--- a/src/Annotator/AbstractAnnotator.php
+++ b/src/Annotator/AbstractAnnotator.php
@@ -358,6 +358,21 @@ abstract class AbstractAnnotator {
 
 		foreach ($replacingAnnotations as $annotation) {
 			$fixer->replaceToken($annotation->getIndex(), $annotation->build());
+
+			// On a `@property` <-> `@property-read` flip the tag itself lives in
+			// a separate token two positions before the value token, so the
+			// in-place value rewrite above would leave the old tag behind.
+			// Rewrite the tag token too when it no longer matches.
+			$tagIndex = $annotation->getIndex() - 2;
+			if (
+				isset($tokens[$tagIndex])
+				&& $tokens[$tagIndex]['type'] === 'T_DOC_COMMENT_TAG'
+				&& $tokens[$tagIndex]['content'] !== $annotation::TAG
+				&& in_array($tokens[$tagIndex]['content'], [PropertyAnnotation::TAG, PropertyReadAnnotation::TAG], true)
+			) {
+				$fixer->replaceToken($tagIndex, $annotation::TAG);
+			}
+
 			$this->_counter[static::COUNT_UPDATED]++;
 		}
 
@@ -464,6 +479,19 @@ abstract class AbstractAnnotator {
 	 */
 	protected function exists(AbstractAnnotation $annotation, array &$existingAnnotations): bool {
 		foreach ($existingAnnotations as $key => $existingAnnotation) {
+			// A `@property` <-> `@property-read` tag flip for the same property
+			// must not be treated as already existing here: build() ignores the
+			// tag, so the two lines would look identical. Skip it so it falls
+			// through to the replacing path where the tag gets rewritten.
+			if (
+				$annotation instanceof PropertyAnnotation
+				&& $existingAnnotation instanceof PropertyAnnotation
+				&& $annotation->getProperty() === $existingAnnotation->getProperty()
+				&& $annotation::TAG !== $existingAnnotation::TAG
+			) {
+				continue;
+			}
+
 			if ($existingAnnotation->build() === $annotation->build()) {
 				unset($existingAnnotations[$key]);
 
@@ -503,6 +531,21 @@ abstract class AbstractAnnotator {
 	protected function needsReplacing(AbstractAnnotation $annotation, array &$existingAnnotations) {
 		foreach ($existingAnnotations as $key => $existingAnnotation) {
 			if ($existingAnnotation->matches($annotation)) {
+				if (
+					$annotation instanceof PropertyAnnotation
+					&& $existingAnnotation instanceof PropertyAnnotation
+					&& $annotation::TAG !== $existingAnnotation::TAG
+				) {
+					// Tag flip: keep the freshly generated annotation (correct
+					// tag and type) but reuse the existing token position so the
+					// docblock line is rewritten in place.
+					$annotation->setIndex($existingAnnotation->getIndex());
+
+					unset($existingAnnotations[$key]);
+
+					return $annotation;
+				}
+
 				$newAnnotation = clone $existingAnnotation;
 				$newAnnotation->replaceWith($annotation);
 

--- a/src/Annotator/EntityAnnotator.php
+++ b/src/Annotator/EntityAnnotator.php
@@ -63,7 +63,7 @@ class EntityAnnotator extends AbstractAnnotator {
 		$helper = new DocBlockHelper(new View());
 		$propertyHintMap = $this->propertyHintMap($content, $helper, $name);
 
-		$virtualFields = $this->virtualFields($name);
+		$virtualFields = $this->readOnlyVirtualFields($name, $content);
 		// For BC reasons we cannot pass it as 3rd param, so we transport it on the helper as setter/getter
 		$helper->setVirtualFields($virtualFields);
 		$annotations = $this->buildAnnotations($propertyHintMap, $helper);
@@ -655,27 +655,122 @@ class EntityAnnotator extends AbstractAnnotator {
 	}
 
 	/**
-	 * Detect actual virtual fields by them being exposed as such.
+	 * Detect read-only virtual fields: computed `_get*` accessors that have
+	 * neither a real DB column / association backing them nor a `_set*`
+	 * mutator. These are pure derived values and therefore get a
+	 * `@property-read` tag instead of `@property`.
 	 *
-	 * @param string $name
+	 * A `_get*` that shadows a real column or association, or that is paired
+	 * with a `_set*` mutator, stays writable and keeps the plain `@property`.
+	 *
+	 * @param string $name Entity short name (filename without extension).
+	 * @param string $content Entity file content.
 	 *
 	 * @return array<string>
 	 */
-	protected function virtualFields(string $name): array {
+	protected function readOnlyVirtualFields(string $name, string $content): array {
+		$computed = $this->buildVirtualPropertyHintTypeMap($content);
+		if ($name !== '') {
+			$computed += $this->buildInheritedVirtualPropertyHintTypeMap($name);
+		}
+		if (!$computed) {
+			return [];
+		}
+
+		$realFields = $this->realFields();
+		$mutators = $this->mutatorFields($content, $name);
+
+		$readOnly = [];
+		foreach (array_keys($computed) as $field) {
+			if (in_array($field, $realFields, true) || in_array($field, $mutators, true)) {
+				continue;
+			}
+
+			$readOnly[] = $field;
+		}
+
+		return $readOnly;
+	}
+
+	/**
+	 * Real (writable) field names: table columns plus association properties.
+	 *
+	 * @return array<string>
+	 */
+	protected function realFields(): array {
+		/** @var \Cake\Database\Schema\TableSchemaInterface $tableSchema */
+		$tableSchema = $this->getConfig('schema');
+		$fields = $tableSchema->columns();
+
+		/** @var \Cake\ORM\AssociationCollection<\Cake\ORM\Association> $associations */
+		$associations = $this->getConfig('associations');
+		foreach ($associations as $association) {
+			$fields[] = $association->getProperty();
+		}
+
+		return $fields;
+	}
+
+	/**
+	 * Property names that have a `_set*` mutator (own file body or inherited
+	 * from a trait / parent). Used to keep computed fields writable.
+	 *
+	 * @param string $content Entity file content.
+	 * @param string $name Entity short name (filename without extension).
+	 *
+	 * @return array<string>
+	 */
+	protected function mutatorFields(string $content, string $name): array {
+		$fields = [];
+		if (preg_match_all('#\bfunction _set([A-Z][a-zA-Z0-9]+)\s*\(#', $content, $matches)) {
+			foreach ($matches[1] as $suffix) {
+				$fields[Inflector::underscore($suffix)] = true;
+			}
+		}
+
+		if ($name !== '') {
+			foreach ($this->inheritedMutatorFields($name) as $field) {
+				$fields[$field] = true;
+			}
+		}
+
+		return array_keys($fields);
+	}
+
+	/**
+	 * Property names with a `_set*` mutator inherited from a trait or parent
+	 * class (i.e. not declared in the entity's own file body — those are
+	 * picked up by the tokenizer scan in mutatorFields()).
+	 *
+	 * @param string $name Entity short name (filename without extension).
+	 *
+	 * @return array<string>
+	 */
+	protected function inheritedMutatorFields(string $name): array {
 		$plugin = $this->getConfig(static::CONFIG_PLUGIN);
 		$className = App::className(($plugin ? $plugin . '.' : '') . $name, 'Model/Entity');
-		if (!$className) {
+		if (!$className || !class_exists($className)) {
 			return [];
 		}
 
-		try {
-			/** @var \Cake\Datasource\EntityInterface $entity */
-			$entity = new $className();
-		} catch (Throwable) {
-			return [];
+		$reflection = new ReflectionClass($className);
+		$entityFile = $reflection->getFileName();
+
+		$fields = [];
+		foreach ($reflection->getMethods(ReflectionMethod::IS_PROTECTED) as $method) {
+			if (!preg_match('#^_set([A-Z][a-zA-Z0-9]+)$#', $method->getName(), $matches)) {
+				continue;
+			}
+
+			$methodFile = $method->getFileName();
+			if ($methodFile === false || $methodFile === $entityFile) {
+				continue;
+			}
+
+			$fields[] = Inflector::underscore($matches[1]);
 		}
 
-		return $entity->getVirtual();
+		return $fields;
 	}
 
 	/**

--- a/tests/TestCase/Annotator/EntityAnnotatorTest.php
+++ b/tests/TestCase/Annotator/EntityAnnotatorTest.php
@@ -313,6 +313,75 @@ class EntityAnnotatorTest extends TestCase {
 	}
 
 	/**
+	 * A computed `_get*` field with no DB column gets `@property-read` only
+	 * when it has no matching `_set*` mutator. A `_get*`/`_set*` pair is
+	 * writable and must keep the plain `@property` tag.
+	 *
+	 * @return void
+	 */
+	public function testAnnotateWithVirtualMutator() {
+		/** @var \TestApp\Model\Table\FoosTable $Table */
+		$Table = TableRegistry::getTableLocator()->get('Foos');
+
+		$schema = $Table->getSchema();
+		$associations = $Table->associations();
+		$annotator = $this->_getAnnotatorMock(['schema' => $schema, 'associations' => $associations]);
+
+		$expectedContent = str_replace(["\r\n", "\r"], "\n", file_get_contents(TEST_FILES . 'Model/Entity/VirtualWithMutator.php'));
+		$callback = function ($value) use ($expectedContent) {
+			$value = str_replace(["\r\n", "\r"], "\n", $value);
+			if ($value !== $expectedContent) {
+				$this->_displayDiff($expectedContent, $value);
+			}
+
+			return $value === $expectedContent;
+		};
+		$annotator->expects($this->once())->method('storeFile')->with($this->anything(), $this->callback($callback));
+
+		$path = APP . 'Model/Entity/VirtualWithMutator.php';
+		$annotator->annotate($path);
+
+		$output = $this->out->output();
+
+		$this->assertTextContains('annotations added', $output);
+	}
+
+	/**
+	 * Migration: a stale tag from an older run is flipped in place. A
+	 * `@property` on a read-only virtual field becomes `@property-read`, and a
+	 * `@property-read` on a field that has gained a `_set*` mutator becomes
+	 * `@property` again, even when the type is unchanged.
+	 *
+	 * @return void
+	 */
+	public function testAnnotateVirtualTagMigration() {
+		/** @var \TestApp\Model\Table\FoosTable $Table */
+		$Table = TableRegistry::getTableLocator()->get('Foos');
+
+		$schema = $Table->getSchema();
+		$associations = $Table->associations();
+		$annotator = $this->_getAnnotatorMock(['schema' => $schema, 'associations' => $associations]);
+
+		$expectedContent = str_replace(["\r\n", "\r"], "\n", file_get_contents(TEST_FILES . 'Model/Entity/VirtualMigration.php'));
+		$callback = function ($value) use ($expectedContent) {
+			$value = str_replace(["\r\n", "\r"], "\n", $value);
+			if ($value !== $expectedContent) {
+				$this->_displayDiff($expectedContent, $value);
+			}
+
+			return $value === $expectedContent;
+		};
+		$annotator->expects($this->once())->method('storeFile')->with($this->anything(), $this->callback($callback));
+
+		$path = APP . 'Model/Entity/VirtualMigration.php';
+		$annotator->annotate($path);
+
+		$output = $this->out->output();
+
+		$this->assertTextContains('annotations', $output);
+	}
+
+	/**
 	 * Regression test for trait-backed virtual properties: the
 	 * tokenizer-based scan only sees `_get*` methods declared in
 	 * the entity's own file body, so trait-imported `_get*` methods

--- a/tests/TestCase/Illuminator/IlluminatorTest.php
+++ b/tests/TestCase/Illuminator/IlluminatorTest.php
@@ -43,7 +43,7 @@ class IlluminatorTest extends TestCase {
 		$path = TEST_FILES;
 		$count = $this->illuminator->illuminate($path, null);
 
-		$this->assertSame(15, $count);
+		$this->assertSame(17, $count);
 
 		$out = $this->out->output();
 

--- a/tests/test_app/src/Model/Entity/VirtualMigration.php
+++ b/tests/test_app/src/Model/Entity/VirtualMigration.php
@@ -1,0 +1,38 @@
+<?php
+namespace TestApp\Model\Entity;
+
+use Cake\ORM\Entity;
+
+/**
+ * @property string $read_only_field
+ * @property-read string $writable_field
+ */
+class VirtualMigration extends Entity {
+
+	/**
+	 * Read-only: no mutator, so the stale `@property` flips to `@property-read`.
+	 *
+	 * @return string
+	 */
+	protected function _getReadOnlyField(): string {
+		return 'ro';
+	}
+
+	/**
+	 * Writable: has a mutator, so the stale `@property-read` flips to `@property`.
+	 *
+	 * @return string
+	 */
+	protected function _getWritableField(): string {
+		return 'rw';
+	}
+
+	/**
+	 * @param string $value
+	 * @return string
+	 */
+	protected function _setWritableField(string $value): string {
+		return $value;
+	}
+
+}

--- a/tests/test_app/src/Model/Entity/VirtualWithMutator.php
+++ b/tests/test_app/src/Model/Entity/VirtualWithMutator.php
@@ -1,0 +1,34 @@
+<?php
+namespace TestApp\Model\Entity;
+
+use Cake\ORM\Entity;
+
+class VirtualWithMutator extends Entity {
+
+	/**
+	 * Computed value without a mutator: pure read-only virtual field.
+	 *
+	 * @return string
+	 */
+	protected function _getLabel(): string {
+		return 'label';
+	}
+
+	/**
+	 * Computed value paired with a mutator below, so it stays writable.
+	 *
+	 * @return string
+	 */
+	protected function _getSlug(): string {
+		return 'slug';
+	}
+
+	/**
+	 * @param string $slug
+	 * @return string
+	 */
+	protected function _setSlug(string $slug): string {
+		return $slug;
+	}
+
+}

--- a/tests/test_files/Model/Entity/PHP7/Virtual.php
+++ b/tests/test_files/Model/Entity/PHP7/Virtual.php
@@ -11,11 +11,11 @@ use Cake\ORM\Entity;
  * @property \Cake\I18n\Date $offer_date
  * @property \Cake\I18n\DateTime $created
  * @property \Cake\I18n\DateTime|null $modified
- * @property string $virtual_two
- * @property array<int, array<string>> $nested_generic
  * @property \TestApp\Model\Entity\Wheel[] $wheels
  *
  * @property-read string|null $virtual_one
+ * @property-read string $virtual_two
+ * @property-read array<int, array<string>> $nested_generic
  */
 class Virtual extends Entity {
 

--- a/tests/test_files/Model/Entity/Virtual.php
+++ b/tests/test_files/Model/Entity/Virtual.php
@@ -12,9 +12,9 @@ use Cake\ORM\Entity;
  * @property \Cake\I18n\Date $offer_date
  * @property \Cake\I18n\DateTime $created
  * @property \Cake\I18n\DateTime|null $modified
- * @property mixed $virtual_two
  * @property \TestApp\Model\Entity\Wheel[] $wheels
  * @property-read string|null $virtual_one
+ * @property-read mixed $virtual_two
  */
 class Virtual extends Entity {
 

--- a/tests/test_files/Model/Entity/VirtualMigration.php
+++ b/tests/test_files/Model/Entity/VirtualMigration.php
@@ -1,0 +1,45 @@
+<?php
+namespace TestApp\Model\Entity;
+
+use Cake\ORM\Entity;
+
+/**
+ * @property-read string $read_only_field
+ * @property string $writable_field
+ * @property array|null $params
+ * @property int $id
+ * @property string $name
+ * @property string $content
+ * @property \Cake\I18n\Date $offer_date
+ * @property \Cake\I18n\DateTime $created
+ * @property \Cake\I18n\DateTime|null $modified
+ */
+class VirtualMigration extends Entity {
+
+	/**
+	 * Read-only: no mutator, so the stale `@property` flips to `@property-read`.
+	 *
+	 * @return string
+	 */
+	protected function _getReadOnlyField(): string {
+		return 'ro';
+	}
+
+	/**
+	 * Writable: has a mutator, so the stale `@property-read` flips to `@property`.
+	 *
+	 * @return string
+	 */
+	protected function _getWritableField(): string {
+		return 'rw';
+	}
+
+	/**
+	 * @param string $value
+	 * @return string
+	 */
+	protected function _setWritableField(string $value): string {
+		return $value;
+	}
+
+}

--- a/tests/test_files/Model/Entity/VirtualWithMutator.php
+++ b/tests/test_files/Model/Entity/VirtualWithMutator.php
@@ -1,0 +1,46 @@
+<?php
+namespace TestApp\Model\Entity;
+
+use Cake\ORM\Entity;
+
+/**
+ * @property array|null $params
+ * @property int $id
+ * @property string $name
+ * @property string $content
+ * @property \Cake\I18n\Date $offer_date
+ * @property \Cake\I18n\DateTime $created
+ * @property \Cake\I18n\DateTime|null $modified
+ * @property string $slug
+ *
+ * @property-read string $label
+ */
+class VirtualWithMutator extends Entity {
+
+	/**
+	 * Computed value without a mutator: pure read-only virtual field.
+	 *
+	 * @return string
+	 */
+	protected function _getLabel(): string {
+		return 'label';
+	}
+
+	/**
+	 * Computed value paired with a mutator below, so it stays writable.
+	 *
+	 * @return string
+	 */
+	protected function _getSlug(): string {
+		return 'slug';
+	}
+
+	/**
+	 * @param string $slug
+	 * @return string
+	 */
+	protected function _setSlug(string $slug): string {
+		return $slug;
+	}
+
+}


### PR DESCRIPTION
Fixes #457.

Entities now distinguish real fields from pure virtual fields in the generated docblock.

## What

A field is annotated as read-only (the property-read tag) when it:

- has a `_get...()` accessor, and
- has no backing DB column or association, and
- has no matching `_set...()` mutator.

Writable fields - real columns, associations, or a get/set pair - keep the plain property tag.

```php
/**
 * @property int $id
 * @property string $name
 *
 * @property-read string|null $full_name
 */
```

Previously the read-only tag was only emitted for fields explicitly registered in the entity's `$_virtual` list, so a computed `_getFullName()` accessor that was not also registered there stayed a plain writable property.

## Migration of existing annotations

Stale tags from earlier runs are rewritten in place, even when the type is unchanged:

- a read-only virtual field still tagged as writable is flipped to the read-only tag
- a field that has since gained a `_set...()` mutator is flipped back to the writable tag

The tag lives in its own docblock token, so the shared annotation replace path now rewrites the tag token, not just the value part.
