### PR TITLE
Add configurable property type annotator

### DIFF
--- a/config/app.example.php
+++ b/config/app.example.php
@@ -37,6 +37,8 @@ return [
 		'preferLinkOverUsesInTests' => true, // Prefer `@link` annotations over `@uses` in test files, prevents PHPUnit/Rector to replace them with attributes.
 		// Additional test class type => regex patterns for TestClassAnnotatorTask, merged onto the built-in Controller/Command patterns. Default [].
 		'testClassPatterns' => [],
+		// Inline `@var` annotations for declared properties by property name. Default [].
+		'propertyTypeMap' => [],
 		// Custom Entity field type mapping
 		'typeMap' => [],
 		// Per-type override map for nullable column annotations: set `'someType' => false` to suppress the `|null` suffix. Default [].

--- a/docs/annotations/classes.md
+++ b/docs/annotations/classes.md
@@ -36,6 +36,44 @@ $notificationMailer = $this->getMailer('Notification');
 $notificationMailer->send('notify', [$user, $details]);
 ```
 
+## Declared Property Types
+
+Declared properties can receive configured inline `@var` annotations through
+`IdeHelper.propertyTypeMap`. This is useful when a native property type must stay
+broad for backward compatibility, but static analysis needs a more specific
+PHPDoc type.
+
+```php
+'IdeHelper' => [
+    'propertyTypeMap' => [
+        'actsAs' => 'array<string, mixed>',
+        'helpers' => 'array<int|string, string|array<string, mixed>>',
+        'components' => 'array<int|string, string|array<string, mixed>>',
+        'paginate' => 'array<string, mixed>',
+    ],
+],
+```
+
+Running `bin/cake annotate classes` can then add:
+
+```php
+/** @var array<string, mixed> $actsAs */
+public array $actsAs = [
+    'Timestamp' => [],
+];
+
+/** @var array<int|string, string|array<string, mixed>> $helpers */
+protected array $helpers = [
+    'Html',
+    'Form' => ['templates' => 'custom'],
+];
+
+/** @var array<string, mixed> $paginate */
+protected array $paginate = [
+    'limit' => 50,
+];
+```
+
 ## Test
 
 Test classes of specific types can be annotated with the corresponding class

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -30,9 +30,37 @@ the full set, defaults, and the most up-to-date options, see
 | `preemptive` | `bool` | Preemptive annotations (e.g. always add `@var \App\View\AppView $this` to templates). |
 | `viewClass` | `string` | Custom AppView FQCN. |
 | `preferLinkOverUsesInTests` | `bool` | Use `@link` (default) vs. `@uses` in test class annotations. |
+| `propertyTypeMap` | `array` | Map declared property names → inline `@var` types for class annotations. |
 | `annotators` | `array` | Replace or disable native annotators. |
 | `classAnnotatorTasks` | `array` | Register or replace class-annotator tasks. |
 | `CallbackAnnotatorTasks` | `array` | Register or replace callback-annotator tasks. |
+
+## Recommended Static Analysis Defaults
+
+For projects that use PHPStan or Psalm, prefer detailed generic annotations so
+generated docblocks do not leave bare `array` types behind:
+
+```php
+'IdeHelper' => [
+    'arrayAsGenerics' => true,
+    'objectAsGenerics' => true,
+    'genericsInParam' => 'detailed',
+    'tableBehaviors' => true,
+    'propertyTypeMap' => [
+        'actsAs' => 'array<string, mixed>',
+        'helpers' => 'array<int|string, string|array<string, mixed>>',
+        'components' => 'array<int|string, string|array<string, mixed>>',
+        'paginate' => 'array<string, mixed>',
+    ],
+],
+```
+
+The `actsAs` property is commonly used by legacy CakePHP apps and plugins to
+declare behaviors. Helper and component declarations can use shorthand strings
+or named config arrays before CakePHP normalizes them. Controller `$paginate`
+settings are associative configuration arrays. Mapping these properties through
+`propertyTypeMap` lets `bin/cake annotate classes` add the missing iterable
+value type without changing the native property type.
 
 ### Generator
 

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -2,6 +2,9 @@
 <ruleset name="plugin">
 	<arg name="cache" value=".phpcs.cache"/>
 	<rule ref="PSR2R"/>
+	<rule ref="SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly.ReferenceViaFullyQualifiedName">
+		<exclude-pattern>*/tests/TestCase/*</exclude-pattern>
+	</rule>
 
     <arg value="nps"/>
 

--- a/src/Annotator/ClassAnnotatorTask/MailerClassAnnotatorTask.php
+++ b/src/Annotator/ClassAnnotatorTask/MailerClassAnnotatorTask.php
@@ -28,6 +28,7 @@ class MailerClassAnnotatorTask extends AbstractClassAnnotatorTask implements Cla
 		}
 
 		preg_match('#\buse (\w+)\\\\Mailer\\\\(\w+)Mailer\b#', $content, $useMatches);
+		$callMatches = [];
 		preg_match('#\$\w+\s*=\s*\$this-\>getMailer\(\'([\w\.]+)\'\)#', $content, $callMatches);
 		$singleLine = false;
 		if (!$callMatches) {
@@ -60,6 +61,7 @@ class MailerClassAnnotatorTask extends AbstractClassAnnotatorTask implements Cla
 	public function annotate(string $path): bool {
 		preg_match('#\buse (\w+)\\\\Mailer\\\\(\w+)Mailer\b#', $this->content, $useMatches);
 
+		$callMatches = [];
 		$singleCall = false;
 		$singleCallAction = null;
 		if (!$useMatches) {
@@ -101,6 +103,9 @@ class MailerClassAnnotatorTask extends AbstractClassAnnotatorTask implements Cla
 			}
 		} else {
 			assert($singleCallAction !== null);
+			if (!isset($callMatches[0], $callMatches[1])) {
+				return false;
+			}
 			$rows = explode(PHP_EOL, $this->content);
 			$rowToAnnotate = null;
 			$rowMatches = null;

--- a/src/Annotator/ClassAnnotatorTask/PropertyTypeAnnotatorTask.php
+++ b/src/Annotator/ClassAnnotatorTask/PropertyTypeAnnotatorTask.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace IdeHelper\Annotator\ClassAnnotatorTask;
+
+use Cake\Core\Configure;
+use IdeHelper\Annotation\AnnotationFactory;
+use IdeHelper\Annotation\VariableAnnotation;
+
+/**
+ * Declared properties can be annotated with configured inline `@var` types.
+ */
+class PropertyTypeAnnotatorTask extends AbstractClassAnnotatorTask implements ClassAnnotatorTaskInterface {
+
+	/**
+	 * Deprecated: $content, use $this->content instead.
+	 *
+	 * @param string $path
+	 * @param string $content
+	 * @return bool
+	 */
+	public function shouldRun(string $path, string $content): bool {
+		if (!str_contains($path, DS . 'src' . DS)) {
+			return false;
+		}
+
+		$propertyTypeMap = $this->propertyTypeMap();
+		if (!$propertyTypeMap) {
+			return false;
+		}
+
+		foreach (array_keys($propertyTypeMap) as $property) {
+			if (preg_match('#\$\s*' . preg_quote((string)$property, '#') . '\b#', $content)) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * @param string $path
+	 * @return bool
+	 */
+	public function annotate(string $path): bool {
+		$propertyTypeMap = $this->propertyTypeMap();
+		$properties = $this->findProperties($this->content, $propertyTypeMap);
+		if (!$properties) {
+			return false;
+		}
+
+		$changed = false;
+		foreach ($properties as $property => $line) {
+			$annotation = AnnotationFactory::createOrFail(VariableAnnotation::TAG, $propertyTypeMap[$property], '$' . $property);
+			if ($this->annotateInlineContent($path, $this->content, [$annotation], $line)) {
+				$changed = true;
+			}
+		}
+
+		return $changed;
+	}
+
+	/**
+	 * @param string $content
+	 * @param array<string, string> $propertyTypeMap
+	 * @return array<string, int>
+	 */
+	protected function findProperties(string $content, array $propertyTypeMap): array {
+		$properties = [];
+		$lines = explode("\n", $content);
+		foreach ($lines as $index => $line) {
+			foreach (array_keys($propertyTypeMap) as $property) {
+				if (!preg_match('#^\s*(?:public|protected|private)\s+(?:static\s+)?(?:readonly\s+)?(?:[^$;=]+\s+)?\$' . preg_quote((string)$property, '#') . '\b#', $line)) {
+					continue;
+				}
+
+				$properties[(string)$property] = $index + 1;
+			}
+		}
+
+		return array_reverse($properties);
+	}
+
+	/**
+	 * @return array<string, string>
+	 */
+	protected function propertyTypeMap(): array {
+		/** @var array<string, string> $propertyTypeMap */
+		$propertyTypeMap = (array)Configure::read('IdeHelper.propertyTypeMap');
+
+		return array_filter($propertyTypeMap);
+	}
+
+}

--- a/src/Annotator/ClassAnnotatorTask/TableFindNodeVisitor.php
+++ b/src/Annotator/ClassAnnotatorTask/TableFindNodeVisitor.php
@@ -4,6 +4,7 @@ namespace IdeHelper\Annotator\ClassAnnotatorTask;
 
 use Cake\Utility\Inflector;
 use PhpParser\Node;
+use PhpParser\Node\Expr as NodeExpr;
 use PhpParser\Node\Expr\Assign;
 use PhpParser\NodeVisitorAbstract;
 
@@ -87,7 +88,7 @@ class TableFindNodeVisitor extends NodeVisitorAbstract {
 	 * @param \PhpParser\Node\Expr $expr
 	 * @return string|null
 	 */
-	private function extractTableName(Node\Expr $expr): ?string {
+	private function extractTableName(NodeExpr $expr): ?string {
 		// Walk back through the method chain
 		while ($expr instanceof Node\Expr\MethodCall) {
 			$expr = $expr->var;

--- a/src/Annotator/ClassAnnotatorTaskCollection.php
+++ b/src/Annotator/ClassAnnotatorTaskCollection.php
@@ -6,6 +6,7 @@ use Cake\Core\Configure;
 use IdeHelper\Annotator\ClassAnnotatorTask\FormClassAnnotatorTask;
 use IdeHelper\Annotator\ClassAnnotatorTask\MailerClassAnnotatorTask;
 use IdeHelper\Annotator\ClassAnnotatorTask\ModelAwareClassAnnotatorTask;
+use IdeHelper\Annotator\ClassAnnotatorTask\PropertyTypeAnnotatorTask;
 use IdeHelper\Annotator\ClassAnnotatorTask\TestClassAnnotatorTask;
 use IdeHelper\Console\Io;
 
@@ -18,6 +19,7 @@ class ClassAnnotatorTaskCollection {
 		ModelAwareClassAnnotatorTask::class => ModelAwareClassAnnotatorTask::class,
 		FormClassAnnotatorTask::class => FormClassAnnotatorTask::class,
 		MailerClassAnnotatorTask::class => MailerClassAnnotatorTask::class,
+		PropertyTypeAnnotatorTask::class => PropertyTypeAnnotatorTask::class,
 		TestClassAnnotatorTask::class => TestClassAnnotatorTask::class,
 	];
 

--- a/src/Illuminator/Task/TableValidationLinkTask.php
+++ b/src/Illuminator/Task/TableValidationLinkTask.php
@@ -4,6 +4,8 @@ namespace IdeHelper\Illuminator\Task;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr;
+use PhpParser\Node\Expr as NodeExpr;
+use PhpParser\Node\Expr\Array_ as NodeArray;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitorAbstract;
 use PhpParser\ParserFactory;
@@ -107,7 +109,7 @@ class TableValidationLinkTask extends AbstractTask {
 			 * @param \PhpParser\Node\Expr\Array_ $options
 			 * @return array{ruleLine: int, methodName: string}|null
 			 */
-			protected function extractTableProviderMethod(Node\Expr\Array_ $options): ?array {
+			protected function extractTableProviderMethod(NodeArray $options): ?array {
 				$hasTableProvider = false;
 				$methodName = null;
 				$ruleLine = null;
@@ -146,7 +148,7 @@ class TableValidationLinkTask extends AbstractTask {
 			 * @param \PhpParser\Node\Expr $value
 			 * @return string|null
 			 */
-			protected function extractMethodFromRule(Node\Expr $value): ?string {
+			protected function extractMethodFromRule(NodeExpr $value): ?string {
 				// 'rule' => 'methodName'
 				$stringValue = $this->getStringValue($value);
 				if ($stringValue !== null) {
@@ -168,7 +170,7 @@ class TableValidationLinkTask extends AbstractTask {
 			 * @param \PhpParser\Node\Expr $expr
 			 * @return string|null
 			 */
-			protected function getStringValue(Node\Expr $expr): ?string {
+			protected function getStringValue(NodeExpr $expr): ?string {
 				if ($expr instanceof Node\Scalar\String_) {
 					return $expr->value;
 				}

--- a/tests/TestCase/Annotator/ClassAnnotatorTask/PropertyTypeAnnotatorTaskTest.php
+++ b/tests/TestCase/Annotator/ClassAnnotatorTask/PropertyTypeAnnotatorTaskTest.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace IdeHelper\Test\TestCase\Annotator\ClassAnnotatorTask;
+
+use Cake\Console\ConsoleIo;
+use Cake\Core\Configure;
+use IdeHelper\Annotator\AbstractAnnotator;
+use IdeHelper\Annotator\ClassAnnotatorTask\PropertyTypeAnnotatorTask;
+use IdeHelper\Console\Io;
+use Shim\TestSuite\ConsoleOutput;
+use Shim\TestSuite\TestCase;
+
+class PropertyTypeAnnotatorTaskTest extends TestCase {
+
+	protected ConsoleOutput $out;
+
+	protected ConsoleOutput $err;
+
+	protected Io $io;
+
+	/**
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		Configure::write('IdeHelper.propertyTypeMap', [
+			'actsAs' => 'array<string, mixed>',
+			'helpers' => 'array<int|string, string|array<string, mixed>>',
+			'components' => 'array<int|string, string|array<string, mixed>>',
+			'paginate' => 'array<string, mixed>',
+		]);
+
+		$this->out = new ConsoleOutput();
+		$this->err = new ConsoleOutput();
+		$consoleIo = new ConsoleIo($this->out, $this->err);
+		$this->io = new Io($consoleIo);
+	}
+
+	/**
+	 * @return void
+	 */
+	protected function tearDown(): void {
+		Configure::delete('IdeHelper.propertyTypeMap');
+
+		parent::tearDown();
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testShouldRun(): void {
+		$task = $this->getTask('');
+
+		$result = $task->shouldRun('/src/Foo.php', '');
+		$this->assertFalse($result);
+
+		$result = $task->shouldRun('/tests/Foo.php', 'class Foo { public array $actsAs = []; }');
+		$this->assertFalse($result);
+
+		$result = $task->shouldRun('/src/Foo.php', 'class Foo { public array $actsAs = []; }');
+		$this->assertTrue($result);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testAnnotate(): void {
+		$content = <<<'PHP'
+<?php
+namespace TestApp\Model\Table;
+
+class FooTable {
+	public array $actsAs = [];
+
+	protected array $helpers = [];
+
+	public array $components = [];
+
+	protected array $paginate = [];
+}
+PHP;
+
+		$task = $this->getTask($content);
+
+		$result = $task->annotate('/src/Model/Table/FooTable.php');
+		$this->assertTrue($result);
+
+		$content = $task->getContent();
+		$this->assertMatchesRegularExpression('#/\*\* @var array<string, mixed> \$actsAs \*/\R\s+public array \$actsAs = \[\];#', $content);
+		$this->assertMatchesRegularExpression('#/\*\* @var array<int\|string, string\|array<string, mixed>> \$helpers \*/\R\s+protected array \$helpers = \[\];#', $content);
+		$this->assertMatchesRegularExpression('#/\*\* @var array<int\|string, string\|array<string, mixed>> \$components \*/\R\s+public array \$components = \[\];#', $content);
+		$this->assertMatchesRegularExpression('#/\*\* @var array<string, mixed> \$paginate \*/\R\s+protected array \$paginate = \[\];#', $content);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testAnnotateAlreadyAnnotated(): void {
+		$content = <<<'PHP'
+<?php
+namespace TestApp\Model\Table;
+
+class FooTable {
+	/** @var array<string, mixed> */
+	public array $actsAs = [];
+}
+PHP;
+
+		$task = $this->getTask($content);
+
+		$result = $task->annotate('/src/Model/Table/FooTable.php');
+		$this->assertFalse($result);
+	}
+
+	/**
+	 * @param string $content
+	 * @param array<string, mixed> $params
+	 * @return \IdeHelper\Annotator\ClassAnnotatorTask\PropertyTypeAnnotatorTask
+	 */
+	protected function getTask(string $content, array $params = []): PropertyTypeAnnotatorTask {
+		$params += [
+			AbstractAnnotator::CONFIG_DRY_RUN => true,
+			AbstractAnnotator::CONFIG_VERBOSE => true,
+		];
+
+		return new PropertyTypeAnnotatorTask($this->io, $params, $content);
+	}
+
+}

--- a/tests/TestCase/Command/AnnotateCommandTest.php
+++ b/tests/TestCase/Command/AnnotateCommandTest.php
@@ -8,7 +8,6 @@ use Cake\TestSuite\TestCase;
 use IdeHelper\Annotator\AbstractAnnotator;
 use IdeHelper\Command\Annotate\ModelsCommand;
 use IdeHelper\Command\AnnotateCommand;
-use PHPUnit\Framework\Attributes\DataProvider;
 use ReflectionMethod;
 
 class AnnotateCommandTest extends TestCase {
@@ -185,7 +184,7 @@ class AnnotateCommandTest extends TestCase {
 	 * @param string $subcommand The subcommand to be tested
 	 * @return void
 	 */
-	#[DataProvider('provideSubcommandsForCiModeTest')]
+	#[\PHPUnit\Framework\Attributes\DataProvider('provideSubcommandsForCiModeTest')]
 	public function testIndividualSubcommandCiModeNoChanges(string $subcommand): void {
 		$this->skipIf($subcommand === 'view', 'View does not support the plugin parameter');
 		// See testAllCiModeNoChanges() — the Awesome plugin tables are pre-annotated for the
@@ -201,7 +200,7 @@ class AnnotateCommandTest extends TestCase {
 	 * @param string $subcommand The subcommand to be tested
 	 * @return void
 	 */
-	#[DataProvider('provideSubcommandsForCiModeTest')]
+	#[\PHPUnit\Framework\Attributes\DataProvider('provideSubcommandsForCiModeTest')]
 	public function testIndividualSubcommandCiModeChanges(string $subcommand): void {
 		$this->exec('annotate ' . $subcommand . ' -d -v --ci');
 

--- a/tests/TestCase/View/Helper/DocBlockHelperTest.php
+++ b/tests/TestCase/View/Helper/DocBlockHelperTest.php
@@ -8,12 +8,11 @@ use Cake\Http\Response;
 use Cake\Http\ServerRequest as Request;
 use Cake\TestSuite\TestCase;
 use IdeHelper\View\Helper\DocBlockHelper;
-use PHPUnit\Framework\Attributes\CoversClass;
 
 /**
  * DocBlockHelper Test
  */
-#[CoversClass(DocBlockHelper::class)]
+#[\PHPUnit\Framework\Attributes\CoversClass(DocBlockHelper::class)]
 class DocBlockHelperTest extends TestCase {
 
 	/**


### PR DESCRIPTION
### Summary
- add an opt-in `IdeHelper.propertyTypeMap` config for declared properties
- add `PropertyTypeAnnotatorTask` to insert inline `@var` annotations before matching property declarations
- document the config key and cover the task with PHPUnit tests

This helps projects keep PHPStan-friendly value types for declared array properties without hand-editing every class. For example, apps can configure `actsAs => array<string, mixed>` and run `bin/cake annotate classes`.

### Examples

Declared properties can receive configured inline `@var` annotations through
`IdeHelper.propertyTypeMap`. This is useful when a native property type must stay
broad for backward compatibility, but static analysis needs a more specific
PHPDoc type.

```php
'IdeHelper' => [
    'propertyTypeMap' => [
        'actsAs' => 'array<string, mixed>',
        'helpers' => 'array<int|string, string|array<string, mixed>>',
        'components' => 'array<int|string, string|array<string, mixed>>',
        'paginate' => 'array<string, mixed>',
    ],
],
```