### PR TITLE
Fix ResultSetInterface return type ignoring objectAsGenerics / genericsInParam

### DIFF
--- a/src/Utility/GenericString.php
+++ b/src/Utility/GenericString.php
@@ -19,7 +19,15 @@ class GenericString {
 		// ResultSetInterface declares two template params (TKey, TValue); always emit both so PHPStan's
 		// missingType.generics stays clean. Keys are int for a result set. PHPStorm handles the object generic.
 		if ($typeCheck === ResultSetInterface::class) {
-			if (Configure::read('IdeHelper.genericsInParam') === 'detailed' || Configure::read('IdeHelper.concreteEntitiesInParam')) {
+			// Emit the generic form whenever generics are enabled for objects (`objectAsGenerics`,
+			// mirroring the object handling below) or for params (`genericsInParam` true|'detailed'),
+			// or when concrete entities are requested. Only the all-disabled legacy case keeps the
+			// `Foo[]|...` union fallback.
+			if (
+				Configure::read('IdeHelper.objectAsGenerics')
+				|| Configure::read('IdeHelper.genericsInParam')
+				|| Configure::read('IdeHelper.concreteEntitiesInParam')
+			) {
 				return sprintf($type . '<int, %s>', $value);
 			}
 

--- a/tests/TestCase/Utility/GenericStringTest.php
+++ b/tests/TestCase/Utility/GenericStringTest.php
@@ -3,6 +3,7 @@
 namespace IdeHelper\Test\TestCase\Utility;
 
 use Cake\Core\Configure;
+use Cake\Datasource\ResultSetInterface;
 use Cake\TestSuite\TestCase;
 use IdeHelper\Utility\GenericString;
 
@@ -38,6 +39,37 @@ class GenericStringTest extends TestCase {
 		Configure::delete('IdeHelper.objectAsGenerics');
 
 		$this->assertSame('\Bar<\Foo>', $result);
+	}
+
+	/**
+	 * A ResultSetInterface always emits both template params (TKey, TValue). The generic form
+	 * must be produced whenever generics are enabled for objects (`objectAsGenerics`) or params
+	 * (`genericsInParam` true|'detailed'), or when concrete entities are requested - not only for
+	 * 'detailed'. Otherwise the documented `ResultSetInterface<int, TEntity>` return type silently
+	 * regressed to the `Foo[]|...` union despite generics being on.
+	 *
+	 * @return void
+	 */
+	public function testClassNameResultSetInterface() {
+		$type = '\\' . ResultSetInterface::class;
+
+		// Legacy fallback (no generics enabled): union, but still both template params.
+		$result = GenericString::generate('\Foo', $type);
+		$this->assertSame('\Foo[]|' . $type . '<int, \Foo>', $result);
+
+		$enablingConfigs = [
+			['objectAsGenerics', true],
+			['genericsInParam', true],
+			['genericsInParam', 'detailed'],
+			['concreteEntitiesInParam', true],
+		];
+		foreach ($enablingConfigs as [$key, $value]) {
+			Configure::write('IdeHelper.' . $key, $value);
+			$result = GenericString::generate('\Foo', $type);
+			Configure::delete('IdeHelper.' . $key);
+
+			$this->assertSame($type . '<int, \Foo>', $result, "Failed for IdeHelper.$key=" . var_export($value, true));
+		}
 	}
 
 }


### PR DESCRIPTION
## Problem

`GenericString::generate()` special-cases `ResultSetInterface` to always emit both template params (good). But it only produced the clean generic form when:

```php
Configure::read('IdeHelper.genericsInParam') === 'detailed' || Configure::read('IdeHelper.concreteEntitiesInParam')
```

So with `objectAsGenerics => true`, or `genericsInParam => true` (the documented "basic generics" mode), it fell through to the union fallback:

```
Foo[]|\Cake\Datasource\ResultSetInterface<int, Foo>
```

This contradicts:

- **The docs** - `docs/annotations/models.md` lists `ResultSetInterface<int, TEntity>` as the collection return type for the `genericsInParam => true` mode (and the `false` description says collection returns still carry `ResultSetInterface<int, TEntity>`).
- **This same function** - the general object branch a few lines down honours `objectAsGenerics` and emits `Type<X>`, but the `ResultSetInterface` special-case ignored `objectAsGenerics` entirely.

Net effect: an inversion where `'detailed'` (the richer mode) produced the clean `ResultSetInterface<int, Foo>`, while `true` (the lighter mode) produced the more verbose `Foo[]|ResultSetInterface<int, Foo>` - and `objectAsGenerics` had no effect at all on `saveMany`/`saveManyOrFail`/`deleteMany`/`deleteManyOrFail` return types.

## Fix

Emit the generic `ResultSetInterface<int, TEntity>` whenever generics are enabled for objects (`objectAsGenerics`), params (`genericsInParam` truthy - `true` or `'detailed'`), or concrete entities (`concreteEntitiesInParam`). The `Foo[]|...` union is kept only for the fully-disabled legacy case.

## Tests

Added `GenericStringTest::testClassNameResultSetInterface` covering the legacy fallback plus each enabling flag (`objectAsGenerics`, `genericsInParam => true`, `genericsInParam => 'detailed'`, `concreteEntitiesInParam`). Verified it fails on the old code (`objectAsGenerics=true` case) and passes with the fix. Full suite: 305 tests green; phpcs + phpstan clean.
