### PR TITLE
Fix property type annotation docblock format

### DIFF
--- a/docs/annotations/classes.md
+++ b/docs/annotations/classes.md
@@ -38,7 +38,7 @@ $notificationMailer->send('notify', [$user, $details]);
 
 ## Declared Property Types
 
-Declared properties can receive configured inline `@var` annotations through
+Declared properties can receive configured `@var` annotations through
 `IdeHelper.propertyTypeMap`. This is useful when a native property type must stay
 broad for backward compatibility, but static analysis needs a more specific
 PHPDoc type.
@@ -57,18 +57,24 @@ PHPDoc type.
 Running `bin/cake annotate classes` can then add:
 
 ```php
-/** @var array<string, mixed> $actsAs */
+/**
+ * @var array<string, mixed>
+ */
 public array $actsAs = [
     'Timestamp' => [],
 ];
 
-/** @var array<int|string, string|array<string, mixed>> $helpers */
+/**
+ * @var array<int|string, string|array<string, mixed>>
+ */
 protected array $helpers = [
     'Html',
     'Form' => ['templates' => 'custom'],
 ];
 
-/** @var array<string, mixed> $paginate */
+/**
+ * @var array<string, mixed>
+ */
 protected array $paginate = [
     'limit' => 50,
 ];

--- a/src/Annotator/ClassAnnotatorTask/PropertyTypeAnnotatorTask.php
+++ b/src/Annotator/ClassAnnotatorTask/PropertyTypeAnnotatorTask.php
@@ -3,8 +3,6 @@
 namespace IdeHelper\Annotator\ClassAnnotatorTask;
 
 use Cake\Core\Configure;
-use IdeHelper\Annotation\AnnotationFactory;
-use IdeHelper\Annotation\VariableAnnotation;
 
 /**
  * Declared properties can be annotated with configured inline `@var` types.
@@ -50,13 +48,78 @@ class PropertyTypeAnnotatorTask extends AbstractClassAnnotatorTask implements Cl
 
 		$changed = false;
 		foreach ($properties as $property => $line) {
-			$annotation = AnnotationFactory::createOrFail(VariableAnnotation::TAG, $propertyTypeMap[$property], '$' . $property);
-			if ($this->annotateInlineContent($path, $this->content, [$annotation], $line)) {
+			if ($this->annotatePropertyContent($path, $propertyTypeMap[$property], $line)) {
 				$changed = true;
 			}
 		}
 
 		return $changed;
+	}
+
+	/**
+	 * @param string $path
+	 * @param string $type
+	 * @param int $line
+	 * @return bool
+	 */
+	protected function annotatePropertyContent(string $path, string $type, int $line): bool {
+		$lines = explode("\n", $this->content);
+		$index = $line - 1;
+		if (!isset($lines[$index])) {
+			return false;
+		}
+
+		if ($this->hasDocBlockBefore($lines, $index)) {
+			$this->reportSkipped($path);
+
+			return false;
+		}
+
+		if (!preg_match('/^(\s*)/', $lines[$index], $matches)) {
+			return false;
+		}
+
+		$indentation = $matches[1];
+		$docBlock = [
+			$indentation . '/**',
+			$indentation . ' * @var ' . $type,
+			$indentation . ' */',
+		];
+
+		array_splice($lines, $index, 0, $docBlock);
+		$newContent = implode("\n", $lines);
+		if ($newContent === $this->content) {
+			$this->reportSkipped($path);
+
+			return false;
+		}
+
+		$this->_counter[static::COUNT_ADDED] = 1;
+		$this->displayDiff($this->content, $newContent);
+		$this->storeFile($path, $newContent);
+		$this->content = $newContent;
+
+		$this->report();
+
+		return true;
+	}
+
+	/**
+	 * @param array<int, string> $lines
+	 * @param int $index
+	 * @return bool
+	 */
+	protected function hasDocBlockBefore(array $lines, int $index): bool {
+		for ($i = $index - 1; $i >= 0; $i--) {
+			$line = trim($lines[$i]);
+			if ($line === '') {
+				continue;
+			}
+
+			return str_ends_with($line, '*/');
+		}
+
+		return false;
 	}
 
 	/**

--- a/tests/TestCase/Annotator/ClassAnnotatorTask/PropertyTypeAnnotatorTaskTest.php
+++ b/tests/TestCase/Annotator/ClassAnnotatorTask/PropertyTypeAnnotatorTaskTest.php
@@ -87,10 +87,33 @@ PHP;
 		$this->assertTrue($result);
 
 		$content = $task->getContent();
-		$this->assertMatchesRegularExpression('#/\*\* @var array<string, mixed> \$actsAs \*/\R\s+public array \$actsAs = \[\];#', $content);
-		$this->assertMatchesRegularExpression('#/\*\* @var array<int\|string, string\|array<string, mixed>> \$helpers \*/\R\s+protected array \$helpers = \[\];#', $content);
-		$this->assertMatchesRegularExpression('#/\*\* @var array<int\|string, string\|array<string, mixed>> \$components \*/\R\s+public array \$components = \[\];#', $content);
-		$this->assertMatchesRegularExpression('#/\*\* @var array<string, mixed> \$paginate \*/\R\s+protected array \$paginate = \[\];#', $content);
+		$expected = <<<'PHP'
+<?php
+namespace TestApp\Model\Table;
+
+class FooTable {
+	/**
+	 * @var array<string, mixed>
+	 */
+	public array $actsAs = [];
+
+	/**
+	 * @var array<int|string, string|array<string, mixed>>
+	 */
+	protected array $helpers = [];
+
+	/**
+	 * @var array<int|string, string|array<string, mixed>>
+	 */
+	public array $components = [];
+
+	/**
+	 * @var array<string, mixed>
+	 */
+	protected array $paginate = [];
+}
+PHP;
+		$this->assertSame($expected, $content);
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- Generate configured property type annotations as regular multiline property PHPDoc blocks
- Preserve the target property's existing indentation, including tabs
- Update docs to show the generated property docblock format

## Tests
- composer test -- --filter PropertyTypeAnnotatorTaskTest
- vendor/bin/phpcs -s src/Annotator/ClassAnnotatorTask/PropertyTypeAnnotatorTask.php tests/TestCase/Annotator/ClassAnnotatorTask/PropertyTypeAnnotatorTaskTest.php
- git diff --check
- ddev exec bin/cake annotate all -r -d --ci (downstream app)
- ddev exec bin/cake annotate all -r -d --ci -p all (downstream app)

Note: composer stan currently fails locally on pre-existing Migrations/Phinx class discovery ignore-pattern issues unrelated to this change.