### PR TITLE
Add support for sebastian/diff 9.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
 		"cakephp/cakephp": "^5.1.5",
 		"nikic/php-parser": "^5.7",
 		"phpstan/phpdoc-parser": "^2.1.0",
-		"sebastian/diff": "^6.0 || ^7.0 || ^8.0",
+		"sebastian/diff": "^6.0 || ^7.0 || ^8.0 || ^9.0",
 		"squizlabs/php_codesniffer": "^3.13 || ^4.0"
 	},
 	"require-dev": {


### PR DESCRIPTION
Adds `^9.0` to the allowed `sebastian/diff` version range.

The code already constructs the differ via `new Differ(new DiffOnlyOutputBuilder())` in both `AbstractAnnotator` and `TaskCollection`. `DiffOnlyOutputBuilder` survives in diff 9, and passing the builder explicitly satisfies the now-mandatory constructor argument, so no API change is required.

sebastian/diff 9 requires PHP 8.4+, which is handled by the OR version range (older PHP keeps resolving to 6/7/8).