### PR TITLE
Fix duplicate annotations on CRLF (Windows) source files

### DIFF
--- a/src/Annotator/AbstractAnnotator.php
+++ b/src/Annotator/AbstractAnnotator.php
@@ -377,9 +377,10 @@ abstract class AbstractAnnotator {
 		}
 
 		if (count($addingAnnotations)) {
-			$annotationString = $needsNewline ? ' *' . "\n" : '';
+			$eol = $file->eolChar;
+			$annotationString = $needsNewline ? ' *' . $eol : '';
 			foreach ($addingAnnotations as $annotation) {
-				$annotationString .= ' * ' . $annotation . "\n";
+				$annotationString .= ' * ' . $annotation . $eol;
 				$this->_counter[static::COUNT_ADDED]++;
 			}
 
@@ -873,13 +874,14 @@ abstract class AbstractAnnotator {
 
 		$helper = new DocBlockHelper(new View());
 		$annotationString = $helper->classDescription('', '', $annotations);
-		if (PHP_EOL !== "\n") {
-			$annotationString = str_replace("\n", PHP_EOL, $annotationString);
+		$eol = $file->eolChar;
+		if ($eol !== "\n") {
+			$annotationString = str_replace("\n", $eol, $annotationString);
 		}
 
 		$fixer = $this->getFixer($file);
 
-		$docBlock = $annotationString . PHP_EOL;
+		$docBlock = $annotationString . $eol;
 		$fixer->replaceToken($index, $docBlock . $tokens[$index]['content']);
 
 		$contents = $fixer->getContents();

--- a/src/Annotator/CallbackAnnotatorTask/VirtualFieldCallbackAnnotatorTask.php
+++ b/src/Annotator/CallbackAnnotatorTask/VirtualFieldCallbackAnnotatorTask.php
@@ -91,7 +91,7 @@ class VirtualFieldCallbackAnnotatorTask extends AbstractCallbackAnnotatorTask im
 				$endIndex = $method['docBlockEnd'];
 
 				$indentation = $this->indentation($file, $endIndex);
-				$fixer->addContentBefore($endIndex, '* @see ' . $addingAnnotation->build() . PHP_EOL . $indentation);
+				$fixer->addContentBefore($endIndex, '* @see ' . $addingAnnotation->build() . $file->eolChar . $indentation);
 			}
 		}
 

--- a/src/Annotator/ClassAnnotatorTask/AbstractClassAnnotatorTask.php
+++ b/src/Annotator/ClassAnnotatorTask/AbstractClassAnnotatorTask.php
@@ -157,14 +157,15 @@ abstract class AbstractClassAnnotatorTask extends AbstractAnnotator {
 
 		$annotation = reset($annotations);
 		$annotationString = '/** ' . $annotation . ' */';
-		if (PHP_EOL !== "\n") {
-			$annotationString = str_replace("\n", PHP_EOL, $annotationString);
+		$eol = $file->eolChar;
+		if ($eol !== "\n") {
+			$annotationString = str_replace("\n", $eol, $annotationString);
 		}
 		$indentation = $this->detectIndentation($file, $index);
 
 		$fixer = $this->getFixer($file);
 
-		$docBlock = $indentation . $annotationString . PHP_EOL;
+		$docBlock = $indentation . $annotationString . $eol;
 		$fixer->replaceToken($index, $docBlock . $tokens[$index]['content']);
 
 		$contents = $fixer->getContents();

--- a/src/Annotator/TemplateAnnotator.php
+++ b/src/Annotator/TemplateAnnotator.php
@@ -157,15 +157,16 @@ class TemplateAnnotator extends AbstractAnnotator {
 		}
 
 		$annotationString = $helper->classDescription('', '', $annotationStrings);
-		if (PHP_EOL !== "\n") {
-			$annotationString = str_replace("\n", PHP_EOL, $annotationString);
+		$eol = $file->eolChar;
+		if ($eol !== "\n") {
+			$annotationString = str_replace("\n", $eol, $annotationString);
 		}
 
 		if ($phpOpenTagIndex === null) {
-			$annotationString = '<?php' . PHP_EOL . $annotationString . PHP_EOL . '?>';
+			$annotationString = '<?php' . $eol . $annotationString . $eol . '?>';
 		}
 
-		$docBlock = $annotationString . PHP_EOL;
+		$docBlock = $annotationString . $eol;
 		if (!$file->getTokens()) {
 			$this->_counter[static::COUNT_ADDED] = count($annotations);
 
@@ -178,7 +179,7 @@ class TemplateAnnotator extends AbstractAnnotator {
 		} elseif ($this->isV4()) {
 			// PHPCS v4 requires a blank line after <?php tag for PSR12 compliance
 			// PHPCS v3 does not have this requirement
-			$fixer->addContent($phpOpenTagIndex, PHP_EOL . $annotationString);
+			$fixer->addContent($phpOpenTagIndex, $eol . $annotationString);
 		} else {
 			$fixer->addContent($phpOpenTagIndex, $docBlock);
 		}

--- a/tests/TestCase/Annotator/HelperAnnotatorTest.php
+++ b/tests/TestCase/Annotator/HelperAnnotatorTest.php
@@ -118,4 +118,44 @@ class HelperAnnotatorTest extends TestCase {
 		return $this->getMockBuilder(HelperAnnotator::class)->onlyMethods(['storeFile'])->setConstructorArgs([$this->io, $params])->getMock();
 	}
 
+	/**
+	 * A CRLF (Windows) source file must annotate idempotently. Repeated runs may
+	 * not stack duplicate doc-blocks or duplicate tags, and the emitted lines must
+	 * keep the file's CRLF endings so no LF/CRLF mix is introduced (the mix is what
+	 * made re-runs fail to recognize existing annotations and re-add them).
+	 *
+	 * @return void
+	 */
+	public function testAnnotateCrlfFileIsIdempotent() {
+		$source = str_replace(["\r\n", "\r"], "\n", (string)file_get_contents(APP . 'View/Helper/MyHelper.php'));
+		$crlf = str_replace("\n", "\r\n", $source);
+
+		$dir = TMP . 'crlf_helper';
+		if (!is_dir($dir)) {
+			mkdir($dir, 0770, true);
+		}
+		$path = $dir . DS . 'MyHelper.php';
+		file_put_contents($path, $crlf);
+
+		$annotator = new HelperAnnotator($this->io, [AbstractAnnotator::CONFIG_REMOVE => true]);
+
+		$annotator->annotate($path);
+		$afterFirst = (string)file_get_contents($path);
+
+		$annotator->annotate($path);
+		$afterSecond = (string)file_get_contents($path);
+
+		unlink($path);
+
+		// Second run must be a no-op - no re-added / stacked annotations.
+		$this->assertSame($afterFirst, $afterSecond);
+
+		// No duplicated tags or doc-blocks.
+		$this->assertSame(1, substr_count($afterSecond, '@property \\TestApp\\View\\Helper\\HtmlHelper $Html'));
+		$this->assertLessThanOrEqual(1, substr_count($afterSecond, '@extends'));
+
+		// Uniform CRLF: every LF belongs to a CRLF pair, no bare LF was introduced.
+		$this->assertSame(substr_count($afterSecond, "\n"), substr_count($afterSecond, "\r\n"));
+	}
+
 }


### PR DESCRIPTION
## Problem

Fixes #466. Repeated `annotate` runs stack duplicate doc-block annotations on **CRLF (Windows) source files** - duplicated extends, property and method tags, and even whole duplicated doc-blocks, growing by one copy per run.

## Root cause

The annotators emitted new doc-block lines with **LF** regardless of the source file's actual line endings:

- `AbstractAnnotator::appendToExistingDocBlock()` used a hardcoded `"\n"`.
- `AbstractAnnotator::addNewDocBlock()`, `AbstractClassAnnotatorTask::addNewInlineDocBlock()`, `TemplateAnnotator`, and the virtual-field see-tag writer used the platform `PHP_EOL`.

On a CRLF file this produces **mixed line endings**. PHP_CodeSniffer then mis-tokenizes the doc-block on the next run, so `parseExistingAnnotations()` no longer recognizes the annotations it just wrote. `exists()` treats them as missing and re-adds them - stacking a duplicate on every run.

This is not specific to the extends tag; it hits every tag type and every annotator (helpers, controllers, components, templates), which matches the follow-up examples in the issue.

The hardcoded-LF append path reproduces even on native Windows PHP (where `PHP_EOL` is already CRLF), so the platform constant alone never fully guarded it.

## Fix

Use the file's detected line ending (`$file->eolChar`, populated by PHP_CodeSniffer - CRLF for Windows files, LF otherwise) everywhere a doc-block line is emitted. Output keeps uniform line endings and repeated runs are idempotent.

## Test

Added `HelperAnnotatorTest::testAnnotateCrlfFileIsIdempotent`: writes a CRLF helper, annotates twice, and asserts the second run is a no-op, no duplicated tags, and no bare-LF/CRLF mix is introduced. It fails on the current code and passes with the fix.