### PR TITLE
Fix paginate() annotation to use PaginatedInterface

### DIFF
--- a/docs/annotations/controllers.md
+++ b/docs/annotations/controllers.md
@@ -61,6 +61,39 @@ class ApplesController extends AppController {
 }
 ```
 
+## Pagination
+
+When a controller action paginates, a `paginate()` return type annotation is added
+so both the IDE and PHPStan know which entity comes back:
+
+```php
+<?php
+namespace App\Controller;
+
+/**
+ * @property \App\Model\Table\ApplesTable $Apples
+ *
+ * @method \Cake\Datasource\Paging\PaginatedInterface<int, \App\Model\Entity\Apple> paginate(\Cake\Datasource\RepositoryInterface|\Cake\Datasource\QueryInterface|string|null $object = null, array $settings = [])
+ */
+class ApplesController extends AppController {
+
+    public function index() {
+        $apples = $this->paginate();
+    }
+
+}
+```
+
+`\Cake\Datasource\Paging\PaginatedInterface` is what `Controller::paginate()` actually
+returns, so the paging API (`currentPage()`, `pageCount()`, `totalCount()`, `items()`, ...)
+resolves as well as the entity type when iterating.
+
+::: warning Re-run the annotator after upgrading
+Older versions annotated `\Cake\Datasource\ResultSetInterface` here, which made PHPStan
+report the paging methods as undefined. Run `bin/cake annotate controllers` once to
+refresh existing annotations.
+:::
+
 ## Custom Prefixes
 
 By default, the annotator supports any prefix for your controllers (as a

--- a/src/Annotator/ControllerAnnotator.php
+++ b/src/Annotator/ControllerAnnotator.php
@@ -3,7 +3,7 @@
 namespace IdeHelper\Annotator;
 
 use Cake\Core\Configure;
-use Cake\Datasource\ResultSetInterface;
+use Cake\Datasource\Paging\PaginatedInterface;
 use Cake\Http\ServerRequest;
 use Cake\ORM\Entity;
 use Cake\ORM\TableRegistry;
@@ -204,14 +204,16 @@ class ControllerAnnotator extends AbstractAnnotator {
 			return [];
 		}
 
-		$resultSetInterfaceCollection = GenericString::generate(implode('|', $entities), '\\' . ResultSetInterface::class);
+		// Controller::paginate() returns a PaginatedInterface, not a ResultSetInterface. Annotating the latter
+		// makes PHPStan reject the paging API (currentPage(), pageCount(), items(), ...) as undefined methods.
+		$paginatedInterfaceCollection = GenericString::generate(implode('|', $entities), '\\' . PaginatedInterface::class);
 
 		$settingsType = 'array';
 		if (Configure::read('IdeHelper.genericsInParam')) {
 			$settingsType = 'array<string, mixed>';
 		}
 
-		return [AnnotationFactory::createOrFail(MethodAnnotation::TAG, $resultSetInterfaceCollection, 'paginate(\Cake\Datasource\RepositoryInterface|\Cake\Datasource\QueryInterface|string|null $object = null, ' . $settingsType . ' $settings = [])')];
+		return [AnnotationFactory::createOrFail(MethodAnnotation::TAG, $paginatedInterfaceCollection, 'paginate(\Cake\Datasource\RepositoryInterface|\Cake\Datasource\QueryInterface|string|null $object = null, ' . $settingsType . ' $settings = [])')];
 	}
 
 	/**

--- a/src/Utility/GenericString.php
+++ b/src/Utility/GenericString.php
@@ -3,9 +3,20 @@
 namespace IdeHelper\Utility;
 
 use Cake\Core\Configure;
+use Cake\Datasource\Paging\PaginatedInterface;
 use Cake\Datasource\ResultSetInterface;
 
 class GenericString {
+
+	/**
+	 * Collection types that declare two template params (TKey, TValue).
+	 *
+	 * @var array<string>
+	 */
+	protected const KEY_VALUE_COLLECTIONS = [
+		ResultSetInterface::class,
+		PaginatedInterface::class,
+	];
 
 	/**
 	 * @param string $value
@@ -16,9 +27,10 @@ class GenericString {
 	public static function generate(string $value, ?string $type = null): string {
 		$typeCheck = $type !== null && str_starts_with($type, '\\') ? substr($type, 1) : $type;
 
-		// ResultSetInterface declares two template params (TKey, TValue); always emit both so PHPStan's
-		// missingType.generics stays clean. Keys are int for a result set. PHPStorm handles the object generic.
-		if ($typeCheck === ResultSetInterface::class) {
+		// ResultSetInterface and PaginatedInterface declare two template params (TKey, TValue); always emit
+		// both so PHPStan's missingType.generics stays clean. Keys are int here. PHPStorm handles the object
+		// generic.
+		if (in_array($typeCheck, static::KEY_VALUE_COLLECTIONS, true)) {
 			// Emit the generic form whenever generics are enabled for objects (`objectAsGenerics`,
 			// mirroring the object handling below) or for params (`genericsInParam` true|'detailed'),
 			// or when concrete entities are requested. Only the all-disabled legacy case keeps the

--- a/tests/TestCase/Utility/GenericStringTest.php
+++ b/tests/TestCase/Utility/GenericStringTest.php
@@ -3,6 +3,7 @@
 namespace IdeHelper\Test\TestCase\Utility;
 
 use Cake\Core\Configure;
+use Cake\Datasource\Paging\PaginatedInterface;
 use Cake\Datasource\ResultSetInterface;
 use Cake\TestSuite\TestCase;
 use IdeHelper\Utility\GenericString;
@@ -52,6 +53,34 @@ class GenericStringTest extends TestCase {
 	 */
 	public function testClassNameResultSetInterface() {
 		$type = '\\' . ResultSetInterface::class;
+
+		// Legacy fallback (no generics enabled): union, but still both template params.
+		$result = GenericString::generate('\Foo', $type);
+		$this->assertSame('\Foo[]|' . $type . '<int, \Foo>', $result);
+
+		$enablingConfigs = [
+			['objectAsGenerics', true],
+			['genericsInParam', true],
+			['genericsInParam', 'detailed'],
+			['concreteEntitiesInParam', true],
+		];
+		foreach ($enablingConfigs as [$key, $value]) {
+			Configure::write('IdeHelper.' . $key, $value);
+			$result = GenericString::generate('\Foo', $type);
+			Configure::delete('IdeHelper.' . $key);
+
+			$this->assertSame($type . '<int, \Foo>', $result, "Failed for IdeHelper.$key=" . var_export($value, true));
+		}
+	}
+
+	/**
+	 * PaginatedInterface is the return type of Controller::paginate() and declares the same two template
+	 * params (TKey, TValue) as ResultSetInterface, so it must be emitted the same way.
+	 *
+	 * @return void
+	 */
+	public function testClassNamePaginatedInterface() {
+		$type = '\\' . PaginatedInterface::class;
 
 		// Legacy fallback (no generics enabled): union, but still both template params.
 		$result = GenericString::generate('\Foo', $type);

--- a/tests/test_files/Controller/BarController.php
+++ b/tests/test_files/Controller/BarController.php
@@ -7,7 +7,7 @@ use TestApp\Model\Table\WheelsTable;
  * @property \TestApp\Model\Table\BarBarsTable $BarBars
  * @property \MyNamespace\MyPlugin\Controller\Component\MyComponent $My
  *
- * @method \TestApp\Model\Entity\BarBar[]|\Cake\Datasource\ResultSetInterface<int, \TestApp\Model\Entity\BarBar> paginate(\Cake\Datasource\RepositoryInterface|\Cake\Datasource\QueryInterface|string|null $object = null, array $settings = [])
+ * @method \TestApp\Model\Entity\BarBar[]|\Cake\Datasource\Paging\PaginatedInterface<int, \TestApp\Model\Entity\BarBar> paginate(\Cake\Datasource\RepositoryInterface|\Cake\Datasource\QueryInterface|string|null $object = null, array $settings = [])
  */
 class BarController extends AppController {
 


### PR DESCRIPTION
Fixes the annotation reported in issue [469](https://github.com/dereuromark/cakephp-ide-helper/issues/469).

`Controller::paginate()` returns `\Cake\Datasource\Paging\PaginatedInterface`, but the ControllerAnnotator annotated `\Cake\Datasource\ResultSetInterface`. That type has none of the paging API, so PHPStan rejects perfectly valid code:

```
Call to an undefined method Cake\Datasource\ResultSetInterface<int, App\Model\Entity\Example>::currentPage().
🪪  method.notFound
```

Same for `pageCount()`, `totalCount()`, `hasNextPage()`, `items()` and the rest.

### Changes

- `ControllerAnnotator::getPaginationAnnotations()` now emits `PaginatedInterface`.
- `GenericString` treats `PaginatedInterface` like `ResultSetInterface`: both declare two template params (`TKey`, `TValue`), so the full `<int, TEntity>` form is kept in every generics mode, and the legacy `Foo[]|...` union fallback stays intact for the all-generics-disabled config.
- Docs: new "Pagination" section in `docs/annotations/controllers.md`, including the note that existing annotations need one `bin/cake annotate controllers` run to refresh.

Before:

```php
/**
 * @method \Cake\Datasource\ResultSetInterface<int, \App\Model\Entity\Apple> paginate(...)
 */
```

After:

```php
/**
 * @method \Cake\Datasource\Paging\PaginatedInterface<int, \App\Model\Entity\Apple> paginate(...)
 */
```

### Notes

- Only the pagination annotation changes. The other `ResultSetInterface` usages (ModelAnnotator's `saveMany()`/`deleteMany()`, DocBlockHelper, SelectQueryTask) are correct and untouched.
- Output-only change, no config or API break, but every annotated controller will show a one-line diff on the next annotator run.
