### PR TITLE
Fix MissingTableClassException for belongsToMany join data

### DIFF
--- a/src/Annotator/EntityAnnotator.php
+++ b/src/Annotator/EntityAnnotator.php
@@ -164,7 +164,19 @@ class EntityAnnotator extends AbstractAnnotator {
 
 				$entityClass = '\\' . ltrim($className, '\\');
 				$alias = $association->getTarget()->getAlias() . 'Join';
-				$table->addAssociations(['belongsTo' => [$alias]]);
+				// This is a synthetic association that only carries the `_joinData` type info; no such table
+				// class exists. Both `targetTable` and `foreignKey` must be passed explicitly, otherwise
+				// `getForeignKey()` lazily resolves the target through the locator and apps that ran
+				// `allowFallbackClass(false)` (the default in the CakePHP app skeleton) fail with a
+				// MissingTableClassException on the made-up alias.
+				$table->addAssociations([
+					'belongsTo' => [
+						$alias => [
+							'targetTable' => $table,
+							'foreignKey' => $association->getForeignKey(),
+						],
+					],
+				]);
 				$schema['_joinData'] = [
 					'kind' => 'association',
 					'association' => $table->{$alias},

--- a/tests/TestCase/Annotator/EntityAnnotatorTest.php
+++ b/tests/TestCase/Annotator/EntityAnnotatorTest.php
@@ -117,6 +117,15 @@ class EntityAnnotatorTest extends TestCase {
 	/**
 	 * @return void
 	 */
+	protected function tearDown(): void {
+		TableRegistry::getTableLocator()->allowFallbackClass(true);
+
+		parent::tearDown();
+	}
+
+	/**
+	 * @return void
+	 */
 	public function testBuildExtendedEntityPropertyHintTypeMap() {
 		$config = [];
 		$annotator = new EntityAnnotator(new Io(new ConsoleIo()), $config);
@@ -540,6 +549,38 @@ class EntityAnnotatorTest extends TestCase {
 		$output = (string)$this->out->output();
 
 		$this->assertTextContains('   -> 4 annotations added', $output);
+	}
+
+	/**
+	 * The `_joinData` association is synthetic, its `{Alias}Join` table class does not exist.
+	 * Apps that ran `allowFallbackClass(false)` (the CakePHP app skeleton default) must not
+	 * run into a MissingTableClassException for that made-up alias.
+	 *
+	 * @return void
+	 */
+	public function testAnnotateBelongsToManyWithoutFallbackClass() {
+		TableRegistry::getTableLocator()->allowFallbackClass(false);
+
+		/** @var \Relations\Model\Table\UsersTable $Table */
+		$Table = TableRegistry::getTableLocator()->get('Relations.Users');
+		$Table->belongsToMany('Tags', ['className' => 'Relations.Bars']);
+
+		$schema = $Table->getSchema();
+		$associations = $Table->associations();
+		$annotator = $this->_getAnnotatorMock(['schema' => $schema, 'associations' => $associations]);
+
+		$content = null;
+		$callback = function ($value) use (&$content) {
+			$content = $value;
+
+			return true;
+		};
+		$annotator->expects($this->once())->method('storeFile')->with($this->anything(), $this->callback($callback));
+
+		$path = PLUGINS . 'Relations/src/Model/Entity/User.php';
+		$annotator->annotate($path);
+
+		$this->assertTextContains('@property \Cake\ORM\Entity $_joinData', (string)$content);
 	}
 
 	/**


### PR DESCRIPTION
`bin/cake annotate models` aborts on any table with a `belongsToMany` association:

```
error: [Cake\ORM\Exception\MissingTableClassException] Table class for alias `TagsJoin` could not be found.
```

### Cause

`EntityAnnotator::hydrateSchemaFromAssoc()` builds a synthetic `belongsTo` association named `{TargetAlias}Join` to carry the `_joinData` type info. No table class exists for that alias, and neither `targetTable` nor `foreignKey` were passed.

The association stays unresolved there, so nothing throws yet. Later `DocBlockHelper::buildEntityAssociationHintTypeMap()` calls `getForeignKey()` on it, and Cake's `BelongsTo::getForeignKey()` derives the default key via `_modelKey($this->getTarget()->getAlias())`, which hits the table locator for the made-up alias.

With the locator default that silently falls back to a generic `Cake\ORM\Table`, this went unnoticed. Apps that ran `allowFallbackClass(false)`, which the CakePHP application skeleton does, get the exception instead. It escapes the `try`/`catch` in `hydrateSchemaFromAssoc()` because it happens in a later call, so not even verbose mode reports it as a warning.

Reproducible on a plain skeleton app with the CMS tutorial models plus `bake all`.

### Fix

Pass `targetTable` and `foreignKey` explicitly when adding the synthetic association, so the locator is never consulted for the alias. Setting `through` on the association does not help, the alias is classless either way.

Regression test added, it fails with the exact exception above before the fix.
