### PR TITLE
Fix CI rector step by holding PHPStan below 2.2.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -85,7 +85,7 @@
 		"stan-tests": "phpstan analyze -c tests/phpstan.neon",
 		"rector": "rector process --dry-run",
 		"rector-fix": "rector process",
-		"rector-setup": "cp composer.json composer.backup && composer require --dev rector/rector:~2.4.0 && mv composer.backup composer.json",
+		"rector-setup": "cp composer.json composer.backup && composer require --dev rector/rector:~2.4.0 'phpstan/phpstan:<2.2.6' -W && mv composer.backup composer.json",
 		"test": "phpunit",
 		"test-coverage": "phpunit --log-junit tmp/coverage/unitreport.xml --coverage-html tmp/coverage --coverage-clover tmp/coverage/coverage.xml"
 	}


### PR DESCRIPTION
The "Coding Standard & Static Analysis" job has been red on master since 2026-07-27, without any code change. Run 30231102081 and run 30139597005 are the same sha `85c8644`, one fails and the older one passed.

### Cause

PHPStan 2.2.6 removed the private `$container` property from `PHPStan\Parser\RichParser`. Rector reads it through its `PrivatesAccessor`, so the rector step fatals during container boot, before analyzing any file:

```
PHP Fatal error:  Uncaught Rector\Exception\Reflection\MissingPrivatePropertyException:
Property "$container" was not found in "PHPStan\Parser\RichParser" class
in vendor/rector/rector/src/Util/Reflection/PrivatesAccessor.php:82
```

Bisected locally against rector 2.4.6:

| PHPStan | rector exit |
|---|---|
| 2.2.2 | 0 |
| 2.2.3 | 0 |
| 2.2.4 | 0 |
| 2.2.5 | 0 |
| 2.2.6 | 255 |

Pinning rector lower is not a fix, 2.4.5 fatals identically. Rector 2.5.8 does boot against 2.2.6, but it also reports 30 files with changes from new rules, so that bump belongs in its own PR.

### Fix

Hold PHPStan below 2.2.6 in `rector-setup`, so the constraint applies to the rector step only. The phpstan step runs earlier in the job off `stan-setup` and keeps resolving the latest release.

Verified locally with a fresh install: `rector-setup` resolves rector 2.4.6 plus PHPStan 2.2.5, and `composer rector` returns `[OK] Rector is done!`.

Can be reverted once rector stops reaching into that private property.
