### PR TITLE
Do not register the synthetic _joinData association on the junction table

### DIFF
--- a/src/Annotator/EntityAnnotator.php
+++ b/src/Annotator/EntityAnnotator.php
@@ -4,6 +4,7 @@ namespace IdeHelper\Annotator;
 
 use Cake\Core\Configure;
 use Cake\ORM\Association;
+use Cake\ORM\Association\BelongsTo;
 use Cake\ORM\Association\BelongsToMany;
 use Cake\ORM\Entity;
 use Cake\ORM\Table;
@@ -165,21 +166,21 @@ class EntityAnnotator extends AbstractAnnotator {
 				$entityClass = '\\' . ltrim($className, '\\');
 				$alias = $association->getTarget()->getAlias() . 'Join';
 				// This is a synthetic association that only carries the `_joinData` type info; no such table
-				// class exists. Both `targetTable` and `foreignKey` must be passed explicitly, otherwise
+				// class exists. It must not be registered on the junction table, which is the locator's
+				// shared instance - the extra association would survive into the ModelAnnotator run and
+				// end up as a bogus `@property` in that table's docblock.
+				// Both `targetTable` and `foreignKey` must be passed explicitly, otherwise
 				// `getForeignKey()` lazily resolves the target through the locator and apps that ran
 				// `allowFallbackClass(false)` (the default in the CakePHP app skeleton) fail with a
 				// MissingTableClassException on the made-up alias.
-				$table->addAssociations([
-					'belongsTo' => [
-						$alias => [
-							'targetTable' => $table,
-							'foreignKey' => $association->getForeignKey(),
-						],
-					],
+				$joinAssociation = new BelongsTo($alias, [
+					'sourceTable' => $table,
+					'targetTable' => $table,
+					'foreignKey' => $association->getForeignKey(),
 				]);
 				$schema['_joinData'] = [
 					'kind' => 'association',
-					'association' => $table->{$alias},
+					'association' => $joinAssociation,
 					'type' => $entityClass,
 					'null' => false,
 				];

--- a/src/Annotator/ModelAnnotator.php
+++ b/src/Annotator/ModelAnnotator.php
@@ -403,7 +403,9 @@ class ModelAnnotator extends AbstractAnnotator {
 			}
 			$type = get_class($association);
 
-			[, $name] = pluginSplit($association->getAlias());
+			// Not `getAlias()`, which Association::__call() proxies to the target table. That returns the
+			// target's alias, which differs from the association's own alias whenever one was given.
+			[, $name] = pluginSplit($key);
 			$table = $association->getClassName() ?: $association->getAlias();
 			$className = App::className($table, 'Model/Table', 'Table') ?: static::CLASS_TABLE;
 

--- a/tests/TestCase/Annotator/EntityAnnotatorTest.php
+++ b/tests/TestCase/Annotator/EntityAnnotatorTest.php
@@ -584,6 +584,41 @@ class EntityAnnotatorTest extends TestCase {
 	}
 
 	/**
+	 * The junction table comes from the locator and is shared. Registering the synthetic
+	 * `{Alias}Join` association on it would survive this run, and the ModelAnnotator would
+	 * later emit it as a `@property` on a table that never declared it.
+	 *
+	 * @return void
+	 */
+	public function testAnnotateBelongsToManyLeavesThroughTableUntouched() {
+		/** @var \Relations\Model\Table\BarsTable $through */
+		$through = TableRegistry::getTableLocator()->get('Relations.Bars');
+		$associationsBefore = $through->associations()->keys();
+
+		/** @var \Relations\Model\Table\UsersTable $Table */
+		$Table = TableRegistry::getTableLocator()->get('Relations.Users');
+		$Table->belongsToMany('Tags', ['className' => 'Relations.Foos', 'through' => 'Relations.Bars']);
+
+		$schema = $Table->getSchema();
+		$associations = $Table->associations();
+		$annotator = $this->_getAnnotatorMock(['schema' => $schema, 'associations' => $associations]);
+
+		$content = null;
+		$callback = function ($value) use (&$content) {
+			$content = $value;
+
+			return true;
+		};
+		$annotator->expects($this->once())->method('storeFile')->with($this->anything(), $this->callback($callback));
+
+		$path = PLUGINS . 'Relations/src/Model/Entity/User.php';
+		$annotator->annotate($path);
+
+		$this->assertTextContains('$_joinData', (string)$content);
+		$this->assertSame($associationsBefore, $through->associations()->keys());
+	}
+
+	/**
 	 * @return void
 	 */
 	public function testAnnotateWithGenericUsage() {

--- a/tests/TestCase/Annotator/ModelAnnotatorTest.php
+++ b/tests/TestCase/Annotator/ModelAnnotatorTest.php
@@ -5,17 +5,20 @@ namespace IdeHelper\Test\TestCase\Annotator;
 use Cake\Console\ConsoleIo;
 use Cake\Core\Configure;
 use Cake\Database\Schema\TableSchema;
+use Cake\ORM\Association\BelongsTo;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 use IdeHelper\Annotator\AbstractAnnotator;
 use IdeHelper\Annotator\ModelAnnotator;
 use IdeHelper\Console\Io;
 use Shim\TestSuite\ConsoleOutput;
+use Shim\TestSuite\TestTrait;
 use TestApp\Model\Table\FoosTable;
 
 class ModelAnnotatorTest extends TestCase {
 
 	use DiffHelperTrait;
+	use TestTrait;
 
 	/**
 	 * @var array<string>
@@ -829,6 +832,27 @@ class ModelAnnotatorTest extends TestCase {
 		$annotator->annotate(APP . 'Model/Table/BarBarsAbstractTable.php');
 
 		$this->assertStringContainsString('loadInto(', $capture);
+	}
+
+	/**
+	 * The property name has to come from the association's own alias. `getAlias()` cannot
+	 * provide it: Association::__call() proxies it to the target table, so an association
+	 * registered under a custom alias would be annotated under the target table's name.
+	 *
+	 * @return void
+	 */
+	public function testGetAssociationsUsesAssociationAliasNotTargetAlias() {
+		$target = TableRegistry::getTableLocator()->get('Relations.Bars');
+		$table = TableRegistry::getTableLocator()->get('Relations.Users');
+		// An explicit target table is what makes the two aliases diverge, and it is what the
+		// EntityAnnotator passes for the synthetic `_joinData` association.
+		$table->belongsTo('Author', ['targetTable' => $target, 'foreignKey' => 'author_id']);
+
+		$annotator = new ModelAnnotator($this->io, [AbstractAnnotator::CONFIG_DRY_RUN => true]);
+		$result = $this->invokeMethod($annotator, 'getAssociations', [$table->associations()]);
+
+		$this->assertArrayHasKey(BelongsTo::class, $result);
+		$this->assertArrayHasKey('Author', $result[BelongsTo::class]);
 	}
 
 }


### PR DESCRIPTION
Follow-up to #471.

## Problem

`EntityAnnotator::hydrateSchemaFromAssoc()` builds a synthetic `belongsTo` named `{TargetAlias}Join` to carry the `_joinData` type info for a `belongsToMany`, and registers it on the through table:

```php
$table = $this->getThrough($association);
$table->addAssociations([
    'belongsTo' => [
        $alias => ['targetTable' => $table, 'foreignKey' => $association->getForeignKey()],
    ],
]);
```

`getThrough()` returns the table locator's shared instance, so that association stays on it for the rest of the process. Within a single `bin/cake annotate all` run the `ModelAnnotator` later reaches that same junction table, reads `$table->associations()`, and emits a `@property` the class never declared.

Real case, an app with:

```php
$this->belongsToMany('Shootings', [
    'className' => 'Productions.Shootings',
    'through' => 'Productions.ShootingParties',
    'foreignKey' => 'foreign_id',
]);
```

`ShootingPartiesTable` declares exactly two associations, `Shootings` and `ShootingModels`, and gets a third one written into its docblock:

```php
 * @property \Cake\ORM\Association\BelongsTo<\Cake\ORM\Table> $ShootingParties
```

It only reproduces when the owning table is annotated before the junction table in the same process, so `bin/cake annotate models -p Productions` looks clean while `-p all` does not. Nothing removes it either, since the annotator regenerates it every run.

A second defect makes the emitted name wrong even as an artifact. `Cake\ORM\Association` has no `getAlias()`; `Association::__call()` proxies unknown methods to the target table. Because the synthetic association is constructed with `'targetTable' => $table` (the junction table itself), `getAlias()` returns the junction table's alias rather than the registered key:

```
key=ShootingsJoin | getAlias()=ShootingParties | className='ShootingsJoin'
```

That is why the generated property name changed from `$ShootingsJoin` to `$ShootingParties` after #471 added the explicit `targetTable`.

## Fix

`EntityAnnotator`: construct the association standalone rather than registering it anywhere. Only `type()` and `getForeignKey()` are consumed downstream (`DocBlockHelper::buildEntityAssociationHintTypeMap()`), so nothing needs it on a table. `targetTable` and `foreignKey` are still passed explicitly, so the `allowFallbackClass(false)` behavior #471 fixed is preserved and its test still covers it.

Cloning the through table would not have worked: `Cake\ORM\Table` declares no `__clone`, so a shallow copy shares the same `AssociationCollection` and would mutate the original anyway.

`ModelAnnotator::getAssociations()`: take the property name from the collection key instead of `getAlias()`. `AssociationCollection::add()` stores under the given alias verbatim, so `keys()` yields the real aliases.

## Tests

Two added, both verified to fail on master and pass with the change:

- `EntityAnnotatorTest::testAnnotateBelongsToManyLeavesThroughTableUntouched` snapshots the through table's association keys around `annotate()`. On master the assertion reports the leaked `TagsJoin` entry. It also still asserts `_joinData` is generated, so the pollution check cannot pass by breaking the feature.
- `ModelAnnotatorTest::testGetAssociationsUsesAssociationAliasNotTargetAlias` registers an association under an alias that differs from its target table's alias and asserts the annotated property uses the association alias.

## Side effects observed on the app that surfaced this

Beyond dropping the bogus table property, the fix also removes a stale `@property ... $shootings_join` from the junction entity and adds a previously missing `@property \Tags\Model\Entity\Tagged $_joinData` on two entities using `Tags`. Both trace back to the same shared-instance mutation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved explicitly configured association aliases when generating model annotations.
  * Prevented annotation processing from modifying existing associations on explicit through tables.
  * Continued generating `_joinData` property annotations for many-to-many relationships.

* **Tests**
  * Added regression coverage for association aliases and through-table behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->