### PR TITLE
Fix PHP-Parser token initialization order

### DIFF
--- a/src/Annotator/AbstractAnnotator.php
+++ b/src/Annotator/AbstractAnnotator.php
@@ -23,11 +23,15 @@ use IdeHelper\Utility\App;
 use PHP_CodeSniffer\Config;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
+use PhpParser\Lexer;
 use PHPStan\PhpDocParser\Ast\PhpDoc\InvalidTagValueNode;
 use ReflectionClass;
 use RuntimeException;
 use SebastianBergmann\Diff\Differ;
 use SebastianBergmann\Diff\Output\DiffOnlyOutputBuilder;
+
+// Initialize PHP-Parser compatibility tokens before PHPCS defines its custom tokens.
+class_exists(Lexer::class);
 
 $composerVendorDir = getcwd() . DS . 'vendor';
 $codesnifferDir = 'squizlabs' . DS . 'php_codesniffer';

--- a/src/Illuminator/Task/AbstractTask.php
+++ b/src/Illuminator/Task/AbstractTask.php
@@ -6,6 +6,10 @@ use Cake\Core\Configure;
 use Cake\Core\InstanceConfigTrait;
 use IdeHelper\Annotator\Traits\FileTrait;
 use PHP_CodeSniffer\Config;
+use PhpParser\Lexer;
+
+// Initialize PHP-Parser compatibility tokens before PHPCS defines its custom tokens.
+class_exists(Lexer::class);
 
 $composerVendorDir = getcwd() . DS . 'vendor';
 $codesnifferDir = 'squizlabs' . DS . 'php_codesniffer';

--- a/tests/TestCase/Illuminator/IlluminatorTest.php
+++ b/tests/TestCase/Illuminator/IlluminatorTest.php
@@ -4,8 +4,10 @@ namespace IdeHelper\Test\TestCase\Illuminator;
 
 use Cake\Console\ConsoleIo;
 use Cake\TestSuite\TestCase;
+use IdeHelper\Annotator\AbstractAnnotator;
 use IdeHelper\Console\Io;
 use IdeHelper\Illuminator\Illuminator;
+use IdeHelper\Illuminator\Task\AbstractTask;
 use IdeHelper\Illuminator\TaskCollection;
 use Shim\TestSuite\ConsoleOutput;
 
@@ -48,6 +50,24 @@ class IlluminatorTest extends TestCase {
 		$out = $this->out->output();
 
 		$this->assertTextContains('public const FIELD_ID = \'id\';', $out);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testPhpParserCompatibilityWithPhpCodeSniffer(): void {
+		$script = TEST_FILES . 'Illuminator/php_parser_compatibility.php';
+		$classes = [
+			AbstractAnnotator::class,
+			AbstractTask::class,
+		];
+
+		foreach ($classes as $class) {
+			$command = escapeshellarg(PHP_BINARY) . ' ' . escapeshellarg($script) . ' ' . escapeshellarg($class);
+			exec($command, $output, $exitCode);
+
+			$this->assertSame(0, $exitCode, implode(PHP_EOL, $output));
+		}
 	}
 
 }

--- a/tests/test_files/Illuminator/php_parser_compatibility.php
+++ b/tests/test_files/Illuminator/php_parser_compatibility.php
@@ -1,0 +1,7 @@
+<?php
+declare(strict_types=1);
+
+require dirname(__DIR__, 3) . '/vendor/autoload.php';
+
+class_exists($argv[1]);
+(new \PhpParser\ParserFactory())->createForNewestSupportedVersion();


### PR DESCRIPTION
### Summary

- initialize PHP-Parser compatibility tokens before PHP_CodeSniffer registers custom PHP 8.5 tokens
- cover both annotator and illuminator load paths
- add regression coverage using isolated PHP processes

### Problem

With PHP_CodeSniffer 4 and PHP-Parser 5 on PHP < 8.5, loading PHPCS first defines future token constants such as `T_VOID_CAST` as strings. PHP-Parser then rejects those constants because native token IDs must be integers. This makes commands such as `bin/cake illuminate code` fail with:

```
Token T_VOID_CAST has ID of type string, should be int
```

### Verification

- PHP 8.4: focused annotator and illuminator tests (10 tests, 28 assertions)
- `composer cs-check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility between PHP parsing and code analysis workflows.
  * Ensured PHP parser components initialize reliably before code analysis begins.

* **Tests**
  * Added compatibility coverage across supported PHP parser versions.
  * Added validation for parser initialization in key analysis components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->